### PR TITLE
Use `derive` for new columns

### DIFF
--- a/examples/functions-1.md
+++ b/examples/functions-1.md
@@ -12,10 +12,12 @@ func excess x = (x - interest_rate) / 252
 func if_valid x = is_valid_price ? x : null
 
 from prices
-let return_total      = prices_adj   | ret | if_valid  # `|` can be used rather than newlines.
-let return_usd        = prices_usd   | ret | if_valid
-let return_excess     = return_total | excess
-let return_usd_excess = return_usd   | excess
+derive [
+  return_total:      prices_adj   | ret | if_valid  # `|` can be used rather than newlines.
+  return_usd:        prices_usd   | ret | if_valid
+  return_excess:     return_total | excess
+  return_usd_excess: return_usd   | excess
+]
 select [
   date,
   sec_id,

--- a/examples/list-equivalence.md
+++ b/examples/list-equivalence.md
@@ -1,0 +1,40 @@
+```elm
+from employees
+select salary
+```
+
+```sql
+SELECT salary FROM employees
+```
+
+```elm
+from employees
+select [salary]
+```
+
+```sql
+SELECT salary FROM employees
+```
+
+```elm
+from employees
+derive [
+  gross_salary: salary + payroll_tax,
+  gross_cost:   gross_salary + benefits_cost
+]
+```
+
+```sql
+SELECT TOP 20
+    title,
+    country,
+    salary + payroll_tax AS gross_salary,
+    salary + payroll_tax + benefits_cost AS gross_cost
+FROM employees
+```
+
+```elm
+from employees
+derive gross_salary salary + payroll_tax
+derive gross_cost gross_salary + benefits_cost
+```

--- a/examples/variables-1.md
+++ b/examples/variables-1.md
@@ -1,16 +1,18 @@
 ```elm
 from employees
 filter country = "USA"                           # Each line transforms the previous result.
-let gross_salary = salary + payroll_tax          # This _adds_ a column / variable.
-let gross_cost   = gross_salary + benefits_cost  # Variables can use other variables.
+derive [                                         # This adds columns / variables.
+  gross_salary: salary + payroll_tax,
+  gross_cost:   gross_salary + benefits_cost     # Variables can use other variables.
+]           
 filter gross_cost > 0
 aggregate by:[title, country] [                  # `by` are the columns to group by.
-    average salary,                              # These are the calcs to run on the groups.
+    average salary,                              # These are aggregation calcs run on each group.
     sum     salary,
     average gross_salary,
     sum     gross_salary,
     average gross_cost,
-    let sum_gross_cost = sum gross_cost,
+    sum_gross_cost: sum gross_cost,
     count,
 ]
 sort sum_gross_cost


### PR DESCRIPTION
Based on discussions in https://github.com/max-sixty/prql/issues/6 & https://github.com/max-sixty/prql/issues/5, with thanks to @rchowell, @hadley, @qorrect , justinpombrio, @ajakaja, @SilverEzhik .

I don't think this is perfect:
- I was partial to the concept of discriminating between insert vs overwrite
- The current syntax can either lead with a new column name or a calc (because columns can be unnamed), so it can require "lookforwards" when someone is reading it. 

But I think it's a good tradeoff and solves one of the blocking questions