### PR TITLE
Parse basic `aggregate` clauses (#26)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -205,6 +205,11 @@ pub fn parse_aggregate(input: &str) -> IResult<&str, Transformation> {
 #[test]
 fn test_parse_aggregate() {
     assert_eq!(
+        // TODO: The current implementation of parse_list can only handle lists of
+        // single words, so that's what the test case has although it is not
+        // syntactically valid PRQL.
+        // TODO: allow for `by` as an optional arg, in either position (either specifically in `aggregate` or a
+        // more general parsing function)
         parse_aggregate("aggregate by:[title, country] [average, sum]"),
         Ok((
             "",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -184,3 +184,34 @@ fn test_parse_filter() {
 //         _ =>
 //     }
 // }
+
+pub fn parse_aggregate(input: &str) -> IResult<&str, Transformation> {
+    let (remainder, _) = ws(tag("aggregate"))(input)?;
+    let (remainder, _) = ws(tag("by"))(remainder)?;
+    let (remainder, _) = ws(tag(":"))(remainder)?;
+
+    let (remainder, by) = parse_list(remainder)?;
+    let (remainder, calcs) = parse_list(remainder)?;
+
+    Ok((
+        remainder,
+        Transformation::Aggregate(Aggregate {
+            by: by,
+            calcs: calcs,
+        }),
+    ))
+}
+
+#[test]
+fn test_parse_aggregate() {
+    assert_eq!(
+        parse_aggregate("aggregate by:[title, country] [average, sum]"),
+        Ok((
+            "",
+            Transformation::Aggregate(Aggregate {
+                by: vec!["title", "country"],
+                calcs: vec!["average", "sum"]
+            })
+        )),
+    )
+}


### PR DESCRIPTION
The current implementation of `parse_list` can only handle lists of
single words, so that's what the test case has although it is not
syntactically valid PRQL.