### PR TITLE
Handle Strings (slightly) better

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -163,7 +163,7 @@ mod test {
         ---
         - Ident: country
         - Raw: "="
-        - String: "\"USA\""
+        - String: USA
         "###);
         assert_yaml_snapshot!(parse(
             parse_to_pest_tree("aggregate by:[title] [sum salary]", Rule::transformation).unwrap()
@@ -391,16 +391,16 @@ take 20
                 Pair {
                     rule: string,
                     span: Span {
-                        str: "\"USA\"",
-                        start: 10,
-                        end: 15,
+                        str: "USA",
+                        start: 11,
+                        end: 14,
                     },
                     inner: [],
                 },
             ],
         )
         "###);
-        assert_debug_snapshot!(parse_to_pest_tree(r#""USA""#, Rule::string));
+        assert_debug_snapshot!(parse_to_pest_tree(r#"USA"#, Rule::string));
         assert_debug_snapshot!(parse_to_pest_tree("select [a, b, c]", Rule::transformation));
         assert_debug_snapshot!(parse_to_pest_tree(
             "aggregate by:[title, country] [sum salary]",

--- a/src/prql.pest
+++ b/src/prql.pest
@@ -29,7 +29,7 @@ expr = _{ ( single_expr )+ }
 single_expr = _{ ( parenthesized_expr | list | named_arg | assign | term | inline_pipeline ) }
 // We could just put these all into `single_expr`, though possibly we want to retain a
 // notion of a valid block (i.e. `+` is not a valid expression).
-term = _{ ( ident | operator | number | string ) }
+term = _{ ( ident | operator | number | quoted_string ) }
 // A non-silent version of `expr`, so we can break up a list or parentheses. A
 // more general version of this would be to make `expr` non-silent, but it would
 // mean basically everything would be in an `expr`, which would be verbose to
@@ -49,10 +49,8 @@ parenthesized_expr = _{ "(" ~ items ~ ")" }
 
 // TODO: escapes
 // https://pest.rs/book/examples/rust/literals.html
-string = { "\"" ~ (ASCII_ALPHANUMERIC)* ~ "\"" }
-// string = { "\"" ~ (raw_string | escape)* ~ "\"" }
-// raw_string = { (!("\\" | "\"") ~ ASCII_ALPHANUMERIC)+ }
-// quoted_string = { "\"" ~ (ASCII_ALPHANUMERIC | " " | "." | "_" | "-" | "\\"  )* ~ "\"" }
+string = { (ASCII_ALPHANUMERIC | " " | "." | "_" | "-" | "\\"  )* }
+quoted_string = _{ "\"" ~ string ~ "\"" }
 number = @{ ( ASCII_DIGIT | "." )+ }
 operator = @{ "==" | "!=" | "=" | ">" | "<" | ">=" | "<=" | "+" | "-" | "*" | "/" | "%" }
 

--- a/src/snapshots/prql__compiler__test__replace_variables-2.snap
+++ b/src/snapshots/prql__compiler__test__replace_variables-2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/compiler.rs
-assertion_line: 256
+assertion_line: 285
 expression: "ast.replace_variables(&mut HashMap::new())"
 
 ---
@@ -10,7 +10,7 @@ Pipeline:
   - Filter:
       - Ident: country
       - Raw: "="
-      - String: "\"USA\""
+      - String: USA
   - Derive:
       - lvalue: gross_salary
         rvalue:

--- a/src/snapshots/prql__parser__test__parse_pipeline.snap
+++ b/src/snapshots/prql__parser__test__parse_pipeline.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser.rs
-assertion_line: 233
+assertion_line: 236
 expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"USA\"                           # Each line transforms the previous result.\nderive [                                         # This adds columns / variables.\n  gross_salary: salary + payroll_tax,\n  gross_cost:   gross_salary + benefits_cost     # Variables can use other variables.\n]\nfilter gross_cost > 0\naggregate by:[title, country] [                  # `by` are the columns to group by.\n    average salary,                              # These are aggregation calcs run on each group.\n    sum     salary,\n    average gross_salary,\n    sum     gross_salary,\n    average gross_cost,\n    sum_gross_cost: sum gross_cost,\n    count: count,\n]\nsort sum_gross_cost\nfilter count > 200\ntake 20\n    \"#.trim(),\n                         Rule::pipeline).unwrap()).unwrap()"
 
 ---
@@ -10,7 +10,7 @@ expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"U
     - Filter:
         - Ident: country
         - Raw: "="
-        - String: "\"USA\""
+        - String: USA
     - Derive:
         - lvalue: gross_salary
           rvalue:

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree-2.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree-2.snap
@@ -1,7 +1,7 @@
 ---
 source: src/parser.rs
-assertion_line: 393
-expression: "parse_to_pest_tree(r#\"\"USA\"\"#, Rule::string)"
+assertion_line: 403
+expression: "parse_to_pest_tree(r#\"USA\"#, Rule::string)"
 
 ---
 Ok(
@@ -9,9 +9,9 @@ Ok(
         Pair {
             rule: string,
             span: Span {
-                str: "\"USA\"",
+                str: "USA",
                 start: 0,
-                end: 5,
+                end: 3,
             },
             inner: [],
         },

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree-5.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree-5.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser.rs
-assertion_line: 399
+assertion_line: 409
 expression: "parse_to_pest_tree(r#\"    filter country = \"USA\"\"#, Rule::transformation)"
 
 ---
@@ -44,9 +44,9 @@ Ok(
                 Pair {
                     rule: string,
                     span: Span {
-                        str: "\"USA\"",
-                        start: 21,
-                        end: 26,
+                        str: "USA",
+                        start: 22,
+                        end: 25,
                     },
                     inner: [],
                 },

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-2.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser.rs
-assertion_line: 430
+assertion_line: 484
 expression: "parse_to_pest_tree(r#\"\n    from employees\n    filter country = \"USA\"\n    \"#.trim(),\n                   Rule::pipeline)"
 
 ---
@@ -80,9 +80,9 @@ Ok(
                         Pair {
                             rule: string,
                             span: Span {
-                                str: "\"USA\"",
-                                start: 36,
-                                end: 41,
+                                str: "USA",
+                                start: 37,
+                                end: 40,
                             },
                             inner: [],
                         },

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-3.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-3.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser.rs
-assertion_line: 489
+assertion_line: 492
 expression: "parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"USA\"                           # Each line transforms the previous result.\nderive [                                         # This adds columns / variables.\n  gross_salary: salary + payroll_tax,\n  gross_cost:   gross_salary + benefits_cost     # Variables can use other variables.\n]\nfilter gross_cost > 0\naggregate by:[title, country] [                  # `by` are the columns to group by.\n    average salary,                              # These are aggregation calcs run on each group.\n    sum     salary,\n    average gross_salary,\n    sum     gross_salary,\n    average gross_cost,\n    sum_gross_cost: sum gross_cost,\n    count: count,\n]\nsort sum_gross_cost\nfilter count > 200\ntake 20\n    \"#.trim(),\n                   Rule::pipeline)"
 
 ---
@@ -80,9 +80,9 @@ Ok(
                         Pair {
                             rule: string,
                             span: Span {
-                                str: "\"USA\"",
-                                start: 32,
-                                end: 37,
+                                str: "USA",
+                                start: 33,
+                                end: 36,
                             },
                             inner: [],
                         },

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -295,7 +295,7 @@ impl TryFrom<Item> for sqlparser::ast::Expr {
                 ),
             )),
             Item::String(ident) => Ok(sqlparser::ast::Expr::Value(
-                sqlparser::ast::Value::DoubleQuotedString(ident),
+                sqlparser::ast::Value::SingleQuotedString(ident),
             )),
             _ => Err(anyhow!("Can't convert to Expr at the moment; {:?}", item)),
         }
@@ -424,7 +424,7 @@ mod test {
 - Filter:
     - Ident: country
     - Raw: "="
-    - String: "\"USA\""
+    - String: USA
 - Aggregate:
     by:
       - List:
@@ -443,6 +443,8 @@ mod test {
         let pipeline: Pipeline = from_str(yaml).unwrap();
         let cte = to_select(&pipeline).unwrap();
         // TODO: totally wrong but compiles, and we're on our way to fixing it.
-        assert_display_snapshot!(cte, @r###"SELECT TOP (20) average salary FROM employees WHERE country = ""USA"" GROUP BY title country SORT BY title"###);
+        assert_display_snapshot!(cte,
+            @"SELECT TOP (20) average salary FROM employees WHERE country = 'USA' GROUP BY title country SORT BY title"
+        );
     }
 }


### PR DESCRIPTION
Still no escapes etc.

And we should decide whether we want to do single vs. double quoted.
When I originally wrote the proposal I defaulted to double, but I
realize that some SQL engines use double quotes for some specific
things, so possibly we need to retain those for that? Or force people to
escape them.
