### PR TITLE
Change NamedArg rvalue to a Box<Item>

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -86,14 +86,12 @@ pub struct Table {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct NamedArg {
     pub lvalue: Ident,
-    // TODO: I think this should just be a single Item, which requires boxing it.
-    pub rvalue: Items,
+    pub rvalue: Box<Item>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Assign {
     pub lvalue: Ident,
-    // TODO: I think this should just be a single Item, which requires boxing it.
     pub rvalue: Items,
 }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -86,11 +86,7 @@ impl ContainsVariables for NamedArg {
     fn replace_variables(&self, variables: &mut HashMap<Ident, Item>) -> Self {
         NamedArg {
             lvalue: self.lvalue.to_owned(),
-            rvalue: self
-                .rvalue
-                .iter()
-                .map(|item| item.replace_variables(variables))
-                .collect(),
+            rvalue: Box::new(self.rvalue.replace_variables(variables)),
         }
     }
 }


### PR DESCRIPTION
Which simplifies its deconstruction, as well as representing the underlying data structure better

This also improves errors slightly
