### PR TITLE
Parse into Function Calls

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -31,8 +31,11 @@ pub enum Item {
     TODO(String),
 }
 
+/// Transformation is currently used for a) each transformation in a pipeline
+/// and b) a normal function call.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-// Need to implement some of these as Structs rather than just `Items`
+// We probably want to implement some of these as Structs rather than just
+// `Items`
 pub enum Transformation {
     From(Items),
     Select(Items),
@@ -40,7 +43,8 @@ pub enum Transformation {
     Derive(Vec<Assign>),
     Aggregate {
         by: Items,
-        calcs: Items,
+        calcs: Vec<Transformation>,
+        assigns: Vec<Assign>,
     },
     // TODO: add ordering
     Sort(Items),
@@ -85,14 +89,14 @@ pub struct Table {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct NamedArg {
-    pub lvalue: Ident,
-    pub rvalue: Box<Item>,
+    pub name: Ident,
+    pub arg: Box<Item>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Assign {
     pub lvalue: Ident,
-    pub rvalue: Items,
+    pub rvalue: Box<Item>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -50,7 +50,7 @@ pub enum Transformation {
     Sort(Items),
     Take(i64),
     Join(Items),
-    Custom {
+    Func {
         name: String,
         args: Items,
         named_args: Vec<NamedArg>,
@@ -69,7 +69,7 @@ impl Transformation {
             Transformation::Sort(_) => "sort",
             Transformation::Take(_) => "take",
             Transformation::Join(_) => "join",
-            Transformation::Custom { name, .. } => name,
+            Transformation::Func { name, .. } => name,
         }
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -170,11 +170,11 @@ impl ContainsVariables for Transformation {
                     .collect(),
             },
             // For everything else, just visit each object and replace the variables.
-            Transformation::Custom {
+            Transformation::Func {
                 name,
                 args,
                 named_args,
-            } => Transformation::Custom {
+            } => Transformation::Func {
                 name: name.to_owned(),
                 args: args
                     .iter()

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -28,7 +28,7 @@ fn extract_variables(assign: &Assign) -> HashMap<Ident, Item> {
     let mut variables = HashMap::new();
     // Not sure we're choosing the correct Item / Items in the types, this is a
     // bit of a smell.
-    variables.insert(assign.lvalue.clone(), Item::Items(assign.rvalue.clone()));
+    variables.insert(assign.lvalue.clone(), *(assign.rvalue).clone());
     variables
 }
 
@@ -73,11 +73,7 @@ impl ContainsVariables for Assign {
     fn replace_variables(&self, variables: &mut HashMap<Ident, Item>) -> Self {
         Assign {
             lvalue: self.lvalue.to_owned(),
-            rvalue: self
-                .rvalue
-                .iter()
-                .map(|item| item.replace_variables(variables))
-                .collect(),
+            rvalue: Box::new(self.rvalue.replace_variables(variables)),
         }
     }
 }
@@ -85,8 +81,8 @@ impl ContainsVariables for Assign {
 impl ContainsVariables for NamedArg {
     fn replace_variables(&self, variables: &mut HashMap<Ident, Item>) -> Self {
         NamedArg {
-            lvalue: self.lvalue.to_owned(),
-            rvalue: Box::new(self.rvalue.replace_variables(variables)),
+            name: self.name.to_owned(),
+            arg: Box::new(self.arg.replace_variables(variables)),
         }
     }
 }
@@ -163,9 +159,15 @@ impl ContainsVariables for Transformation {
             Transformation::Select(ref items) => {
                 Transformation::Select(items.replace_variables(variables))
             }
-            Transformation::Aggregate { by, calcs } => Transformation::Aggregate {
+            Transformation::Aggregate { by, calcs, assigns } => Transformation::Aggregate {
                 by: by.replace_variables(variables),
+                // TODO: this is currently matching against the impl on Pipeline
+                // because it's a Vec of Transformation — is that OK?
                 calcs: calcs.replace_variables(variables),
+                assigns: assigns
+                    .iter()
+                    .map(|assign| assign.replace_variables(variables))
+                    .collect(),
             },
             // For everything else, just visit each object and replace the variables.
             Transformation::Custom {
@@ -237,17 +239,17 @@ mod test {
             &to_string(&ast.replace_variables(&mut HashMap::new())).unwrap()
         ).unified_diff(),
         @r###"
-        @@ -10,6 +10,9 @@
-                   - Ident: payroll_tax
+        @@ -12,6 +12,9 @@
                - lvalue: gross_cost
                  rvalue:
-        -          - Ident: gross_salary
-        +          - Items:
-        +              - Ident: salary
-        +              - Raw: +
-        +              - Ident: payroll_tax
-                   - Raw: +
-                   - Ident: benefits_cost
+                   Items:
+        -            - Ident: gross_salary
+        +            - Items:
+        +                - Ident: salary
+        +                - Raw: +
+        +                - Ident: payroll_tax
+                     - Raw: +
+                     - Ident: benefits_cost
         "###);
 
         let ast = &parse(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -113,6 +113,10 @@ pub fn parse_to_pest_tree(source: &str, rule: Rule) -> Result<Pairs<Rule>, Error
 
 // We put this outside the main parse function because we also use it to parse
 // function calls.
+// (I'm not sure whether we should be using it for both — on the one hand,
+// they're fairly similar `sum salary` is a standard function call. But on the
+// other, we were planning to allow `salary | sum`, which doesn't work. We would
+// need to parse the whole of `sum salary` as a pipeline, which _might_ then work.)
 impl TryFrom<Vec<Item>> for Transformation {
     type Error = anyhow::Error;
     fn try_from(items: Vec<Item>) -> Result<Self> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -149,7 +149,7 @@ impl TryFrom<Vec<Item>> for Transformation {
             }
             "aggregate" => {
                 // This is more compicated rust than I was expecting, and we may
-                // generalize these checks to custom functions anyway.
+                // generalize these checks to Func functions anyway.
                 if args.len() != 1 {
                     return Err(anyhow!(
                         "Expected exactly one unnamed argument for aggregate"
@@ -222,7 +222,7 @@ impl TryFrom<Vec<Item>> for Transformation {
                 }
             }
             "join" => Ok(Transformation::Join(args)),
-            _ => Ok(Transformation::Custom {
+            _ => Ok(Transformation::Func {
                 name: name.to_owned(),
                 args,
                 named_args,
@@ -263,7 +263,7 @@ mod test {
               by:
                 - Ident: title
               calcs:
-                - Custom:
+                - Func:
                     name: sum
                     args:
                       - Ident: salary

--- a/src/prql.pest
+++ b/src/prql.pest
@@ -10,7 +10,8 @@
 //   is valid, but so is `1 1`. Or `foo bar` is not parsed at this stage as
 //   `foo` being a function and `bar` its argument — it's just parsed into a
 //   list of idents. We could instead parse these explicitly, and then disallow
-//   `1 1`.
+//   `1 1`. We do need more structure, then; e.g. we need to allow `x or y` but
+//   not `x orr y`.
 
 WHITESPACE = _{ " " }
 // Need to exclude # in strings (and maybe confirm whether this the syntax we want)

--- a/src/prql.pest
+++ b/src/prql.pest
@@ -10,8 +10,8 @@
 //   is valid, but so is `1 1`. Or `foo bar` is not parsed at this stage as
 //   `foo` being a function and `bar` its argument — it's just parsed into a
 //   list of idents. We could instead parse these explicitly, and then disallow
-//   `1 1`. We do need more structure, then; e.g. we need to allow `x or y` but
-//   not `x orr y`.
+//   `1 1`. We would need more structure though; e.g. we'd need to encode terms
+//   like `or` to allow `x or y` but not `x orr y`.
 
 WHITESPACE = _{ " " }
 // Need to exclude # in strings (and maybe confirm whether this the syntax we want)

--- a/src/snapshots/prql__compiler__test__replace_variables-2.snap
+++ b/src/snapshots/prql__compiler__test__replace_variables-2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/compiler.rs
-assertion_line: 285
+assertion_line: 283
 expression: "ast.replace_variables(&mut HashMap::new())"
 
 ---
@@ -14,17 +14,19 @@ Pipeline:
   - Derive:
       - lvalue: gross_salary
         rvalue:
-          - Ident: salary
-          - Raw: +
-          - Ident: payroll_tax
+          Items:
+            - Ident: salary
+            - Raw: +
+            - Ident: payroll_tax
       - lvalue: gross_cost
         rvalue:
-          - Items:
-              - Ident: salary
-              - Raw: +
-              - Ident: payroll_tax
-          - Raw: +
-          - Ident: benefits_cost
+          Items:
+            - Items:
+                - Ident: salary
+                - Raw: +
+                - Ident: payroll_tax
+            - Raw: +
+            - Ident: benefits_cost
   - Filter:
       - Items:
           - Items:
@@ -40,37 +42,35 @@ Pipeline:
         - Ident: title
         - Ident: country
       calcs:
-        - Items:
-            - Ident: average
-            - Ident: salary
-        - Items:
-            - Ident: sum
-            - Ident: salary
-        - Items:
-            - Ident: average
-            - Items:
-                - Ident: salary
-                - Raw: +
-                - Ident: payroll_tax
-        - Items:
-            - Ident: sum
-            - Items:
-                - Ident: salary
-                - Raw: +
-                - Ident: payroll_tax
-        - Items:
-            - Ident: average
-            - Items:
-                - Items:
-                    - Ident: salary
-                    - Raw: +
-                    - Ident: payroll_tax
-                - Raw: +
-                - Ident: benefits_cost
-        - Assign:
-            lvalue: sum_gross_cost
-            rvalue:
-              - Ident: sum
+        - Custom:
+            name: average
+            args:
+              - Ident: salary
+            named_args: []
+        - Custom:
+            name: sum
+            args:
+              - Ident: salary
+            named_args: []
+        - Custom:
+            name: average
+            args:
+              - Items:
+                  - Ident: salary
+                  - Raw: +
+                  - Ident: payroll_tax
+            named_args: []
+        - Custom:
+            name: sum
+            args:
+              - Items:
+                  - Ident: salary
+                  - Raw: +
+                  - Ident: payroll_tax
+            named_args: []
+        - Custom:
+            name: average
+            args:
               - Items:
                   - Items:
                       - Ident: salary
@@ -78,10 +78,29 @@ Pipeline:
                       - Ident: payroll_tax
                   - Raw: +
                   - Ident: benefits_cost
-        - Assign:
-            lvalue: count
-            rvalue:
-              - Ident: count
+            named_args: []
+      assigns:
+        - lvalue: sum_gross_cost
+          rvalue:
+            Transformation:
+              Custom:
+                name: sum
+                args:
+                  - Items:
+                      - Items:
+                          - Ident: salary
+                          - Raw: +
+                          - Ident: payroll_tax
+                      - Raw: +
+                      - Ident: benefits_cost
+                named_args: []
+        - lvalue: count
+          rvalue:
+            Transformation:
+              Custom:
+                name: count
+                args: []
+                named_args: []
   - Sort:
       - Ident: sum_gross_cost
   - Filter:

--- a/src/snapshots/prql__compiler__test__replace_variables-2.snap
+++ b/src/snapshots/prql__compiler__test__replace_variables-2.snap
@@ -42,17 +42,17 @@ Pipeline:
         - Ident: title
         - Ident: country
       calcs:
-        - Custom:
+        - Func:
             name: average
             args:
               - Ident: salary
             named_args: []
-        - Custom:
+        - Func:
             name: sum
             args:
               - Ident: salary
             named_args: []
-        - Custom:
+        - Func:
             name: average
             args:
               - Items:
@@ -60,7 +60,7 @@ Pipeline:
                   - Raw: +
                   - Ident: payroll_tax
             named_args: []
-        - Custom:
+        - Func:
             name: sum
             args:
               - Items:
@@ -68,7 +68,7 @@ Pipeline:
                   - Raw: +
                   - Ident: payroll_tax
             named_args: []
-        - Custom:
+        - Func:
             name: average
             args:
               - Items:
@@ -83,7 +83,7 @@ Pipeline:
         - lvalue: sum_gross_cost
           rvalue:
             Transformation:
-              Custom:
+              Func:
                 name: sum
                 args:
                   - Items:
@@ -97,7 +97,7 @@ Pipeline:
         - lvalue: count
           rvalue:
             Transformation:
-              Custom:
+              Func:
                 name: count
                 args: []
                 named_args: []

--- a/src/snapshots/prql__parser__test__parse_pipeline.snap
+++ b/src/snapshots/prql__parser__test__parse_pipeline.snap
@@ -33,27 +33,27 @@ expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"U
           - Ident: title
           - Ident: country
         calcs:
-          - Custom:
+          - Func:
               name: average
               args:
                 - Ident: salary
               named_args: []
-          - Custom:
+          - Func:
               name: sum
               args:
                 - Ident: salary
               named_args: []
-          - Custom:
+          - Func:
               name: average
               args:
                 - Ident: gross_salary
               named_args: []
-          - Custom:
+          - Func:
               name: sum
               args:
                 - Ident: gross_salary
               named_args: []
-          - Custom:
+          - Func:
               name: average
               args:
                 - Ident: gross_cost
@@ -62,7 +62,7 @@ expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"U
           - lvalue: sum_gross_cost
             rvalue:
               Transformation:
-                Custom:
+                Func:
                   name: sum
                   args:
                     - Ident: gross_cost
@@ -70,7 +70,7 @@ expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"U
           - lvalue: count
             rvalue:
               Transformation:
-                Custom:
+                Func:
                   name: count
                   args: []
                   named_args: []

--- a/src/snapshots/prql__parser__test__parse_pipeline.snap
+++ b/src/snapshots/prql__parser__test__parse_pipeline.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser.rs
-assertion_line: 241
+assertion_line: 324
 expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"USA\"                           # Each line transforms the previous result.\nderive [                                         # This adds columns / variables.\n  gross_salary: salary + payroll_tax,\n  gross_cost:   gross_salary + benefits_cost     # Variables can use other variables.\n]\nfilter gross_cost > 0\naggregate by:[title, country] [                  # `by` are the columns to group by.\n    average salary,                              # These are aggregation calcs run on each group.\n    sum     salary,\n    average gross_salary,\n    sum     gross_salary,\n    average gross_cost,\n    sum_gross_cost: sum gross_cost,\n    count: count,\n]\nsort sum_gross_cost\nfilter count > 200\ntake 20\n    \"#.trim(),\n                Rule::pipeline).unwrap()).unwrap()"
 
 ---
@@ -14,14 +14,16 @@ expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"U
     - Derive:
         - lvalue: gross_salary
           rvalue:
-            - Ident: salary
-            - Raw: +
-            - Ident: payroll_tax
+            Items:
+              - Ident: salary
+              - Raw: +
+              - Ident: payroll_tax
         - lvalue: gross_cost
           rvalue:
-            - Ident: gross_salary
-            - Raw: +
-            - Ident: benefits_cost
+            Items:
+              - Ident: gross_salary
+              - Raw: +
+              - Ident: benefits_cost
     - Filter:
         - Ident: gross_cost
         - Raw: ">"
@@ -31,30 +33,47 @@ expression: "parse(parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"U
           - Ident: title
           - Ident: country
         calcs:
-          - Items:
-              - Ident: average
-              - Ident: salary
-          - Items:
-              - Ident: sum
-              - Ident: salary
-          - Items:
-              - Ident: average
-              - Ident: gross_salary
-          - Items:
-              - Ident: sum
-              - Ident: gross_salary
-          - Items:
-              - Ident: average
-              - Ident: gross_cost
-          - Assign:
-              lvalue: sum_gross_cost
-              rvalue:
-                - Ident: sum
+          - Custom:
+              name: average
+              args:
+                - Ident: salary
+              named_args: []
+          - Custom:
+              name: sum
+              args:
+                - Ident: salary
+              named_args: []
+          - Custom:
+              name: average
+              args:
+                - Ident: gross_salary
+              named_args: []
+          - Custom:
+              name: sum
+              args:
+                - Ident: gross_salary
+              named_args: []
+          - Custom:
+              name: average
+              args:
                 - Ident: gross_cost
-          - Assign:
-              lvalue: count
-              rvalue:
-                - Ident: count
+              named_args: []
+        assigns:
+          - lvalue: sum_gross_cost
+            rvalue:
+              Transformation:
+                Custom:
+                  name: sum
+                  args:
+                    - Ident: gross_cost
+                  named_args: []
+          - lvalue: count
+            rvalue:
+              Transformation:
+                Custom:
+                  name: count
+                  args: []
+                  named_args: []
     - Sort:
         - Ident: sum_gross_cost
     - Filter:

--- a/src/snapshots/prql__writer__test__to_select.snap
+++ b/src/snapshots/prql__writer__test__to_select.snap
@@ -1,6 +1,6 @@
 ---
 source: src/writer.rs
-assertion_line: 461
+assertion_line: 477
 expression: select
 
 ---
@@ -24,7 +24,7 @@ Select {
         UnnamedExpr(
             Identifier(
                 Ident {
-                    value: "average salary",
+                    value: "TODO: Custom { name: \"average\", args: [Ident(\"salary\")], named_args: [] }",
                     quote_style: None,
                 },
             ),

--- a/src/snapshots/prql__writer__test__to_select.snap
+++ b/src/snapshots/prql__writer__test__to_select.snap
@@ -24,7 +24,7 @@ Select {
         UnnamedExpr(
             Identifier(
                 Ident {
-                    value: "TODO: Custom { name: \"average\", args: [Ident(\"salary\")], named_args: [] }",
+                    value: "TODO: Func { name: \"average\", args: [Ident(\"salary\")], named_args: [] }",
                     quote_style: None,
                 },
             ),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -372,7 +372,7 @@ mod test {
       - Ident: title
       - Ident: country
     calcs:
-      - Custom:
+      - Func:
           name: average
           args:
             - Ident: salary
@@ -401,7 +401,7 @@ mod test {
       - Ident: title
       - Ident: country
     calcs:
-      - Custom:
+      - Func:
           name: average
           args:
             - Ident: salary
@@ -429,7 +429,7 @@ mod test {
       - Ident: title
       - Ident: country
     calcs:
-      - Custom:
+      - Func:
           name: average
           args:
             - Ident: salary
@@ -440,7 +440,7 @@ mod test {
       - Ident: title
       - Ident: country
     calcs:
-      - Custom:
+      - Func:
           name: average
           args:
             - Ident: salary
@@ -470,7 +470,7 @@ mod test {
       - Ident: title
       - Ident: country
     calcs:
-      - Custom:
+      - Func:
           name: average
           args:
             - Ident: salary
@@ -486,7 +486,7 @@ mod test {
         assert_debug_snapshot!(select);
         // TODO: totally wrong but compiles, and we're on our way to fixing it.
         assert_display_snapshot!(select,
-            @r###"SELECT TOP (20) TODO: Custom { name: "average", args: [Ident("salary")], named_args: [] } FROM employees WHERE country = 'USA' GROUP BY title, country SORT BY title"###
+            @r###"SELECT TOP (20) TODO: Func { name: "average", args: [Ident("salary")], named_args: [] } FROM employees WHERE country = 'USA' GROUP BY title, country SORT BY title"###
         );
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -94,10 +94,20 @@ pub fn to_select(pipeline: &Pipeline) -> Result<sqlparser::ast::Select> {
     let aggregate = pipeline
         .iter()
         .find(|t| matches!(t, Transformation::Aggregate { .. }));
-    let (group_bys, select_from_aggregate) = match aggregate {
-        Some(Transformation::Aggregate { by, calcs }) => (
-            (by.clone()),
-            Some(calcs.iter().map(|x| x.clone().try_into()).try_collect()?),
+    let (group_bys, select_from_aggregate): (Vec<Item>, Option<Vec<SelectItem>>) = match aggregate {
+        Some(Transformation::Aggregate { by, calcs, assigns }) => (
+            by.clone(),
+            // This is inscrutable, sorry for the rust.
+            // It's chaining a) the calcs (such as `sum salary`) and b) the assigns
+            // (such as `sum_salary: sum salary`), and converting them into
+            // SelectItems.
+            Some(
+                calcs
+                    .iter()
+                    .map(|x| x.clone().try_into())
+                    .chain(assigns.iter().map(|x| x.clone().try_into()))
+                    .try_collect()?,
+            ),
         ),
         None => (vec![], None),
         _ => unreachable!("Expected an aggregate transformation"),
@@ -111,8 +121,8 @@ pub fn to_select(pipeline: &Pipeline) -> Result<sqlparser::ast::Select> {
             _ => None,
         })
         .flatten()
-        .map(|assign| assign.into())
-        .collect::<Vec<SelectItem>>();
+        .map(|assign| assign.try_into())
+        .try_collect()?;
 
     // Only the final select matters (assuming we don't have notions of `select
     // *` or `select * except`)
@@ -202,16 +212,16 @@ pub fn queries_of_pipeline(pipeline: &Pipeline) -> Vec<Pipeline> {
     queries
 }
 
-// TODO: change to TryInto.
-impl From<Assign> for SelectItem {
-    fn from(assign: Assign) -> Self {
-        SelectItem::ExprWithAlias {
+impl TryFrom<Assign> for SelectItem {
+    type Error = anyhow::Error;
+    fn try_from(assign: Assign) -> Result<Self> {
+        Ok(SelectItem::ExprWithAlias {
             alias: sqlparser::ast::Ident {
                 value: assign.lvalue,
                 quote_style: None,
             },
-            expr: Item::Items(assign.rvalue).try_into().unwrap(),
-        }
+            expr: (*assign.rvalue).try_into()?,
+        })
     }
 }
 
@@ -235,6 +245,17 @@ impl TryFrom<Item> for sqlparser::ast::SelectItem {
                 item
             )),
         }
+    }
+}
+impl TryFrom<Transformation> for sqlparser::ast::SelectItem {
+    type Error = anyhow::Error;
+    fn try_from(transformation: Transformation) -> Result<Self> {
+        Ok(sqlparser::ast::SelectItem::UnnamedExpr(
+            sqlparser::ast::Expr::Identifier(sqlparser::ast::Ident::new(format!(
+                "TODO: {:?}",
+                &transformation
+            ))),
+        ))
     }
 }
 
@@ -348,14 +369,15 @@ mod test {
     - String: USA
 - Aggregate:
     by:
-      - List:
-          - Ident: title
-          - Ident: country
+      - Ident: title
+      - Ident: country
     calcs:
-      - List:
-          - Items:
-              - Ident: average
-              - Ident: salary
+      - Custom:
+          name: average
+          args:
+            - Ident: salary
+          named_args: []
+    assigns: []
 - Sort:
     - Ident: title
 - Take: 20
@@ -376,14 +398,15 @@ mod test {
     - String: USA
 - Aggregate:
     by:
-      - List:
-          - Ident: title
-          - Ident: country
+      - Ident: title
+      - Ident: country
     calcs:
-      - List:
-          - Items:
-              - Ident: average
-              - Ident: salary
+      - Custom:
+          name: average
+          args:
+            - Ident: salary
+          named_args: []
+    assigns: []
 - Sort:
     - Ident: title
         "###;
@@ -403,19 +426,26 @@ mod test {
     - String: USA
 - Aggregate:
     by:
-        - Ident: title
-        - Ident: country
+      - Ident: title
+      - Ident: country
     calcs:
-        - Items:
-            - Ident: average
+      - Custom:
+          name: average
+          args:
             - Ident: salary
+          named_args: []
+    assigns: []
 - Aggregate:
-    by: []
+    by:
+      - Ident: title
+      - Ident: country
     calcs:
-        - Items:
-            - Ident: sum
-            # TODO: this isn't currently defined
-            - Ident: average_salary
+      - Custom:
+          name: average
+          args:
+            - Ident: salary
+          named_args: []
+    assigns: []
 - Sort:
     - Ident: sum_gross_cost
 
@@ -437,12 +467,15 @@ mod test {
     - String: USA
 - Aggregate:
     by:
-        - Ident: title
-        - Ident: country
+      - Ident: title
+      - Ident: country
     calcs:
-        - Items:
-            - Ident: average
+      - Custom:
+          name: average
+          args:
             - Ident: salary
+          named_args: []
+    assigns: []
 - Sort:
     - Ident: title
 - Take: 20
@@ -453,7 +486,7 @@ mod test {
         assert_debug_snapshot!(select);
         // TODO: totally wrong but compiles, and we're on our way to fixing it.
         assert_display_snapshot!(select,
-            @"SELECT TOP (20) average salary FROM employees WHERE country = 'USA' GROUP BY title, country SORT BY title"
+            @r###"SELECT TOP (20) TODO: Custom { name: "average", args: [Ident("salary")], named_args: [] } FROM employees WHERE country = 'USA' GROUP BY title, country SORT BY title"###
         );
     }
 }


### PR DESCRIPTION
This is a sizeable change:
- We used to parse `sum salary` as just `sum salary`
- Now we parse it as a call to the `sum` function with an argument
  `salary`
- Some of the data structure had to be adjusted; it's now more robust

Some of the rust is inscrutable at the moment, but that's been a general
trend over the past few weeks — initial rust has been subpar but become 
nicer over time — I will try to repeat
