### PR TITLE
Fix how spaces inside string literals are handled

### DIFF
--- a/src/prql.pest
+++ b/src/prql.pest
@@ -37,7 +37,7 @@ expr = _{ ( single_expr )+ }
 single_expr = _{ ( parenthesized_expr | list | named_arg | assign | term | inline_pipeline ) }
 // We could just put these all into `single_expr`, though possibly we want to retain a
 // notion of a valid block (i.e. `+` is not a valid expression).
-term = _{ ( ident | operator | number | quoted_string ) }
+term = _{ ( ident | operator | number | string_literal ) }
 // A non-silent version of `expr`, so we can break up a list or parentheses. A
 // more general version of this would be to make `expr` non-silent, but it would
 // mean basically everything would be in an `expr`, which would be verbose to
@@ -57,11 +57,21 @@ parenthesized_expr = _{ "(" ~ items ~ ")" }
 
 // TODO: escapes
 // https://pest.rs/book/examples/rust/literals.html
-string = { (ASCII_ALPHANUMERIC | " " | "." | "_" | "-" | "\\"  )* }
+
+// We need to have a non-silent rule which contains the quotes, because of
+// https://github.com/pest-parser/pest/issues/583, and then when converting to
+// AST, we only keep the `string` and discard the `string_literal` given it
+// contains the quotes.
+//
+// TODO: I'm still a bit unclear how preceeding and trailing spaces are working
+// -- it seems that inner spaces are included without an atomic operator (or
+// with `ANY`), but prceeding & trailing spaces require both `ANY` _and_ an
+// atomic operator. We have some rudimentary tests for these.
+string = { ( !( "\\" | "\"" ) ~ ANY )+ }
 // TODO: allow single quotes.
-quoted_string = _{ "\"" ~ string ~ "\"" }
-number = @{ ( ASCII_DIGIT | "." )+ }
-operator = @{ "==" | "!=" | "=" | ">" | "<" | ">=" | "<=" | "+" | "-" | "*" | "/" | "%" }
+string_literal = ${ "\"" ~ string ~ "\"" }
+number = ${ ( ASCII_DIGIT | "." )+ }
+operator = ${ "==" | "!=" | "=" | ">" | "<" | ">=" | "<=" | "+" | "-" | "*" | "/" | "%" }
 
 // Currently named_args and handled slightly differently to assignments:
 // named_args have no whitespace and take one expression immediately after the

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree-2.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree-2.snap
@@ -1,19 +1,29 @@
 ---
 source: src/parser.rs
-assertion_line: 403
-expression: "parse_to_pest_tree(r#\"USA\"#, Rule::string)"
+assertion_line: 545
+expression: "parse_to_pest_tree(r#\"\"USA\"\"#, Rule::string_literal)"
 
 ---
 Ok(
     [
         Pair {
-            rule: string,
+            rule: string_literal,
             span: Span {
-                str: "USA",
+                str: "\"USA\"",
                 start: 0,
-                end: 3,
+                end: 5,
             },
-            inner: [],
+            inner: [
+                Pair {
+                    rule: string,
+                    span: Span {
+                        str: "USA",
+                        start: 1,
+                        end: 4,
+                    },
+                    inner: [],
+                },
+            ],
         },
     ],
 )

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree-5.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree-5.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser.rs
-assertion_line: 409
+assertion_line: 572
 expression: "parse_to_pest_tree(r#\"    filter country = \"USA\"\"#, Rule::transformation)"
 
 ---
@@ -42,13 +42,23 @@ Ok(
                     inner: [],
                 },
                 Pair {
-                    rule: string,
+                    rule: string_literal,
                     span: Span {
-                        str: "USA",
-                        start: 22,
-                        end: 25,
+                        str: "\"USA\"",
+                        start: 21,
+                        end: 26,
                     },
-                    inner: [],
+                    inner: [
+                        Pair {
+                            rule: string,
+                            span: Span {
+                                str: "USA",
+                                start: 22,
+                                end: 25,
+                            },
+                            inner: [],
+                        },
+                    ],
                 },
             ],
         },

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-2.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-2.snap
@@ -1,7 +1,7 @@
 ---
 source: src/parser.rs
-assertion_line: 484
-expression: "parse_to_pest_tree(r#\"\n    from employees\n    filter country = \"USA\"\n    \"#.trim(),\n                   Rule::pipeline)"
+assertion_line: 647
+expression: "parse_to_pest_tree(r#\"\n    from employees\n    filter country = \"USA\"\n    \"#.trim(),\n    Rule::pipeline)"
 
 ---
 Ok(
@@ -78,13 +78,23 @@ Ok(
                             inner: [],
                         },
                         Pair {
-                            rule: string,
+                            rule: string_literal,
                             span: Span {
-                                str: "USA",
-                                start: 37,
-                                end: 40,
+                                str: "\"USA\"",
+                                start: 36,
+                                end: 41,
                             },
-                            inner: [],
+                            inner: [
+                                Pair {
+                                    rule: string,
+                                    span: Span {
+                                        str: "USA",
+                                        start: 37,
+                                        end: 40,
+                                    },
+                                    inner: [],
+                                },
+                            ],
                         },
                     ],
                 },

--- a/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-3.snap
+++ b/src/snapshots/prql__parser__test__parse_to_pest_tree_pipeline-3.snap
@@ -1,7 +1,7 @@
 ---
 source: src/parser.rs
-assertion_line: 492
-expression: "parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"USA\"                           # Each line transforms the previous result.\nderive [                                         # This adds columns / variables.\n  gross_salary: salary + payroll_tax,\n  gross_cost:   gross_salary + benefits_cost     # Variables can use other variables.\n]\nfilter gross_cost > 0\naggregate by:[title, country] [                  # `by` are the columns to group by.\n    average salary,                              # These are aggregation calcs run on each group.\n    sum     salary,\n    average gross_salary,\n    sum     gross_salary,\n    average gross_cost,\n    sum_gross_cost: sum gross_cost,\n    count: count,\n]\nsort sum_gross_cost\nfilter count > 200\ntake 20\n    \"#.trim(),\n                   Rule::pipeline)"
+assertion_line: 655
+expression: "parse_to_pest_tree(r#\"\nfrom employees\nfilter country = \"USA\"                           # Each line transforms the previous result.\nderive [                                         # This adds columns / variables.\n  gross_salary: salary + payroll_tax,\n  gross_cost:   gross_salary + benefits_cost     # Variables can use other variables.\n]\nfilter gross_cost > 0\naggregate by:[title, country] [                  # `by` are the columns to group by.\n    average salary,                              # These are aggregation calcs run on each group.\n    sum     salary,\n    average gross_salary,\n    sum     gross_salary,\n    average gross_cost,\n    sum_gross_cost: sum gross_cost,\n    count: count,\n]\nsort sum_gross_cost\nfilter count > 200\ntake 20\n    \"#.trim(),\n    Rule::pipeline)"
 
 ---
 Ok(
@@ -78,13 +78,23 @@ Ok(
                             inner: [],
                         },
                         Pair {
-                            rule: string,
+                            rule: string_literal,
                             span: Span {
-                                str: "USA",
-                                start: 33,
-                                end: 36,
+                                str: "\"USA\"",
+                                start: 32,
+                                end: 37,
                             },
-                            inner: [],
+                            inner: [
+                                Pair {
+                                    rule: string,
+                                    span: Span {
+                                        str: "USA",
+                                        start: 33,
+                                        end: 36,
+                                    },
+                                    inner: [],
+                                },
+                            ],
                         },
                     ],
                 },


### PR DESCRIPTION
Pest doesn't make this easy -- the automatic whitespace is convenient, until you need precise control over it
