### PR TITLE
Print prompt on TTY stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ name = "prql"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "atty",
  "clap",
  "clio",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,20 @@ description = "PRQL is a modern language for transforming data — a simpler and
 edition = "2021"
 license = "Apache-2.0"
 name = "prql"
-version = "0.0.1"
 rust-version = "1.58.0"
+version = "0.0.1"
 
 [dependencies]
 anyhow = "^1.0"
 clio = "^0.2"
 color-eyre = "^0.6"
+atty = {version = "^0.2", optional = true}
 enum-as-inner = "^0.4.0"
 itertools = "^0.10"
 pest = "^2.1"
 pest_derive = "^2.1"
-sqlformat = "^0.1.8"
 serde_yaml = "^0.8"
+sqlformat = "^0.1.8"
 
 [dependencies.clap]
 features = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ version = "0.0.1"
 
 [dependencies]
 anyhow = "^1.0"
+atty = "^0.2"
 clio = "^0.2"
 color-eyre = "^0.6"
-atty = {version = "^0.2", optional = true}
 enum-as-inner = "^0.4.0"
 itertools = "^0.10"
 pest = "^2.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,11 +30,23 @@ pub struct CompileCommand {
     format: Dialect,
 }
 
+fn is_stdin(input: &Input) -> bool {
+    input.path() == "-"
+}
+
 impl Cli {
     pub fn execute(&mut self) -> Result<(), Error> {
         match self {
             Cli::Compile(command) => {
                 let mut source = String::new();
+
+                // Don't wait without a prompt when running `prql compile` —
+                // it's confusing whether it's waiting for input or not. This
+                // offers the prompt.
+                if is_stdin(&command.input) && atty::is(atty::Stream::Stdin) {
+                    println!("Enter PRQL, then ctrl-d:");
+                    println!();
+                }
                 command.input.read_to_string(&mut source)?;
 
                 match command.format {


### PR DESCRIPTION
This takes a different approach to #180 suggests — it prints a message
rather than exiting with `--help`.

Closes #180.
