### PR TITLE
Fix scoping of variables following `aggregate`

### DIFF
--- a/src/snapshots/prql__materializer__test__materialize-2.snap
+++ b/src/snapshots/prql__materializer__test__materialize-2.snap
@@ -1,6 +1,5 @@
 ---
 source: src/materializer.rs
-assertion_line: 442
 expression: materialize(ast)?
 ---
 Query:
@@ -98,29 +97,9 @@ Query:
                   SString:
                     - String: COUNT(*)
         - Sort:
-            - SString:
-                - String: SUM(
-                - Expr:
-                    Terms:
-                      - Terms:
-                          - Ident: salary
-                          - Raw: +
-                          - Ident: payroll_tax
-                      - Raw: +
-                      - Ident: benefits_cost
-                - String: )
+            - Ident: sum_gross_cost
         - Filter:
-            - SString:
-                - String: SUM(
-                - Expr:
-                    Terms:
-                      - Terms:
-                          - Ident: salary
-                          - Raw: +
-                          - Ident: payroll_tax
-                      - Raw: +
-                      - Ident: benefits_cost
-                - String: )
+            - Ident: sum_gross_cost
             - Raw: ">"
             - Raw: "200"
         - Take: 20

--- a/src/snapshots/prql__materializer__test__replace_variables-2.snap
+++ b/src/snapshots/prql__materializer__test__replace_variables-2.snap
@@ -1,6 +1,5 @@
 ---
 source: src/materializer.rs
-assertion_line: 241
 expression: "&fold.fold_item(ast)?"
 ---
 Query:
@@ -85,25 +84,9 @@ Query:
                 rvalue:
                   Ident: count
         - Sort:
-            - Terms:
-                - Ident: sum
-                - Terms:
-                    - Terms:
-                        - Ident: salary
-                        - Raw: +
-                        - Ident: payroll_tax
-                    - Raw: +
-                    - Ident: benefits_cost
+            - Ident: sum_gross_cost
         - Filter:
-            - Terms:
-                - Ident: sum
-                - Terms:
-                    - Terms:
-                        - Ident: salary
-                        - Raw: +
-                        - Ident: payroll_tax
-                    - Raw: +
-                    - Ident: benefits_cost
+            - Ident: sum_gross_cost
             - Raw: ">"
             - Raw: "200"
         - Take: 20

--- a/src/snapshots/prql__translator__test__prql_to_sql-2.snap
+++ b/src/snapshots/prql__translator__test__prql_to_sql-2.snap
@@ -1,6 +1,5 @@
 ---
 source: src/translator.rs
-assertion_line: 789
 expression: sql
 ---
 SELECT
@@ -22,4 +21,4 @@ GROUP BY
 HAVING
   COUNT(*) > 200
 ORDER BY
-  SUM(salary + payroll_tax + benefits_cost)
+  sum_gross_cost


### PR DESCRIPTION
This ended up being much simpler than I expected. I'm not sure if there
are corner cases — it relies on SQL respecting variables after any
`GROUP BY` — I'm fairly confident this holds for `HAVING` & `ORDER BY`
clauses. But possibly I'm missing something.

Closes #213
