### PR TITLE
Aggregate also selects by columns

### DIFF
--- a/examples/employees/0_average-title-salary.prql
+++ b/examples/employees/0_average-title-salary.prql
@@ -1,0 +1,23 @@
+# Task: rank the employee titles according to the average salary for each department.
+
+# My solution:
+# - for each employee, find their average salary,
+# - join employees with their departments and titles (duplicating employees for each of their titles and departments)
+# - group by department and title, aggregating average salary
+# - join with department to get department name
+
+from employees
+join side:left salaries [salaries.emp_no = employees.emp_no]
+aggregate by:[employees.emp_no] [
+  emp_salary: average salary
+]
+join side:left titles [titles.emp_no = table_0.emp_no]
+join dept_emp [dept_emp.emp_no = table_0.emp_no]
+aggregate by:[dept_emp.dept_no, titles.title] [
+  avg_salary: average emp_salary
+]
+join side:left departments [departments.dept_no = table_1.dept_no]
+select [dept_name, title, avg_salary]
+
+# Now writing about this I realize that I would have needed to select from employees table at all.
+# I could have only aggregated salaries table by emp_no. Oh well.

--- a/examples/employees/1_gender-by-departments.prql
+++ b/examples/employees/1_gender-by-departments.prql
@@ -1,0 +1,15 @@
+# Task: The company active pursues gender equality.
+# Prepare an analysis based on salaries and gender distribution by departments.
+
+from employees
+join salaries [salaries.emp_no = employees.emp_no]
+aggregate by:[employees.emp_no, gender] [
+  emp_salary: average salary
+]
+join dept_emp [dept_emp.emp_no = table_0.emp_no]
+aggregate by:[dept_emp.dept_no, gender] [
+  salary_avg: average emp_salary,
+  salary_sd: stddev emp_salary,
+]
+join departments [departments.dept_no = table_1.dept_no]
+select [dept_name, gender, salary_avg, salary_sd]

--- a/examples/employees/2_gender-by-managers.prql
+++ b/examples/employees/2_gender-by-managers.prql
@@ -1,0 +1,22 @@
+# Task: The company active pursues gender equality.
+# Prepare an analysis based on salaries and gender distribution by managers.
+
+from employees
+join salaries [salaries.emp_no = employees.emp_no]
+aggregate by:[employees.emp_no, gender] [
+  emp_salary: average salary
+]
+join dept_emp [dept_emp.emp_no = table_0.emp_no]
+join dept_manager [
+  (dept_manager.dept_no = dept_emp.dept_no) AND s"(dept_emp.from_date, dept_emp.to_date) OVERLAPS (dept_manager.from_date, dept_manager.to_date)"
+]
+aggregate by:[dept_manager.emp_no, gender] [
+  salary_avg: average emp_salary,
+  salary_sd: stddev emp_salary
+]
+derive [
+  mng_no: dept_manager.emp_no
+]
+join employees [employees.emp_no = table_1.mng_no]
+derive [mng_name: s"employees.first_name || ' ' || employees.last_name"]
+select [mng_name, gender, salary_avg, salary_sd]

--- a/examples/employees/3_department-distributions.prql
+++ b/examples/employees/3_department-distributions.prql
@@ -1,0 +1,11 @@
+# Task: Find distributions of titles, salaries and genders over different departments.
+
+from dept_emp
+join salaries side:left [
+  (salaries.emp_no = dept_emp.emp_no) AND s"(salaries.from_date, salaries.to_date) OVERLAPS (dept_emp.from_date, dept_emp.to_date)"]
+aggregate by:[dept_emp.emp_no, dept_emp.dept_no] [
+  salary: average salaries.salary
+]
+join employees [table_0.emp_no = employees.emp_no]
+join titles [titles.emp_no = employees.emp_no]
+select [dept_no, salary, employees.gender, titles.title]

--- a/examples/employees/README.md
+++ b/examples/employees/README.md
@@ -1,0 +1,15 @@
+Example queries using [employees database](https://github.com/vrajmohan/pgsql-sample-data.git).
+
+Clone and init the database (requires a local PostgreSQL instance):
+ 
+    $ psql -U postgres -c 'CREATE DATABASE employees;'
+    $ git clone https://github.com/vrajmohan/pgsql-sample-data.git
+    $ psql -U postgres -d employees -f pgsql-sample-data/employee/employees.dump
+
+Execute a PRQL query:
+
+    $ cargo run compile examples/employees/average-title-salary.prql | psql -U postgres -d employees
+
+Also print the query:
+
+    $ cargo run compile my_file.prql | { tee /dev/stderr; echo -e "\nResult:" >&2 } | psql -U postgres -d employees

--- a/examples/employees/README.md
+++ b/examples/employees/README.md
@@ -1,7 +1,7 @@
 Example queries using [employees database](https://github.com/vrajmohan/pgsql-sample-data.git).
 
 Clone and init the database (requires a local PostgreSQL instance):
- 
+
     $ psql -U postgres -c 'CREATE DATABASE employees;'
     $ git clone https://github.com/vrajmohan/pgsql-sample-data.git
     $ psql -U postgres -d employees -f pgsql-sample-data/employee/employees.dump

--- a/src/snapshots/prql__translator__test__prql_to_sql-2.snap
+++ b/src/snapshots/prql__translator__test__prql_to_sql-2.snap
@@ -3,7 +3,9 @@ source: src/translator.rs
 expression: sql
 ---
 SELECT
-  TOP (20) SUM(salary + payroll_tax + benefits_cost) AS sum_gross_cost,
+  TOP (20) title,
+  country,
+  SUM(salary + payroll_tax + benefits_cost) AS sum_gross_cost,
   COUNT(*) AS ct,
   AVG(salary),
   SUM(salary),

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -162,19 +162,21 @@ fn select_columns_of_pipeline(pipeline: &Pipeline) -> Result<Vec<SelectItem>> {
                     .map(|assign| assign.clone().try_into())
                     .collect::<Result<Vec<SelectItem>>>()?,
             ),
-            Transformation::Aggregate { calcs, assigns, .. } => {
+            Transformation::Aggregate {
+                by, calcs, assigns, ..
+            } => {
                 is_inclusive = false;
                 selects.clear();
-                // This is chaining a) the assigns (such as `sum_salary: sum
-                // salary`), and b) the calcs (such as `sum salary`); and converting
-                // them into SelectItems.
-                selects.extend(
-                    assigns
-                        .iter()
-                        .map(|x| x.clone().try_into())
-                        .chain(calcs.iter().map(|x| x.clone().try_into()))
-                        .collect::<Result<Vec<SelectItem>>>()?,
-                )
+
+                for x in by {
+                    selects.push(x.clone().try_into()?);
+                }
+                for x in assigns {
+                    selects.push(x.clone().try_into()?);
+                }
+                for x in calcs {
+                    selects.push(x.clone().try_into()?);
+                }
             }
             _ => {}
         }
@@ -698,7 +700,9 @@ Query:
         assert_display_snapshot!(sql,
             @r###"
         SELECT
-          TOP (20) AVG(salary)
+          TOP (20) title,
+          country,
+          AVG(salary)
         FROM
           employees
         WHERE
@@ -838,6 +842,7 @@ take 20
         ),
         average_salaries AS (
           SELECT
+            country,
             AVG(salary) AS average_country_salary
           FROM
             salaries
@@ -909,6 +914,8 @@ Query:
         ),
         table_1 AS (
           SELECT
+            title,
+            country,
             average salary
           FROM
             table_0
@@ -920,6 +927,8 @@ Query:
         ),
         table_2 AS (
           SELECT
+            title,
+            country,
             average salary
           FROM
             table_1

--- a/tests/test_transpile.rs
+++ b/tests/test_transpile.rs
@@ -47,7 +47,9 @@ filter ct > 200
 take 20
 "#)?, @r###"
     SELECT
-      TOP (20) SUM(salary + payroll_tax + benefits_cost) AS sum_gross_cost,
+      TOP (20) title,
+      country,
+      SUM(salary + payroll_tax + benefits_cost) AS sum_gross_cost,
       COUNT(*) AS count,
       AVG(salary),
       SUM(salary),
@@ -136,6 +138,7 @@ select [dept_name, title, avg_salary]
     assert_snapshot!(result, @r###"
     WITH table_0 AS (
       SELECT
+        employees.emp_no,
         AVG(salary) AS emp_salary
       FROM
         employees
@@ -145,6 +148,8 @@ select [dept_name, title, avg_salary]
     ),
     table_1 AS (
       SELECT
+        dept_emp.dept_no,
+        titles.title,
         AVG(emp_salary) AS avg_salary
       FROM
         table_0


### PR DESCRIPTION
Addition to #208

If you do:

```
from salaries
aggregate by:[emp_no] [
  emp_salary: average salary
]
join dept_emp [dept_emp.emp_no = emp_no]
```

You get:
```
SELECT
  AVG(salary) AS emp_salary
FROM
  salaries
GROUP BY
  emp_no
```

Result does not contain `emp_no` in select, which means that you cannot do subsequent:

```
join dept_emp [dept_emp.emp_no = emp_no]
```

You can add additional `select [emp_no]`, but I would argue that the desired result in 99% of cases is to include all `by` columns in the select. Only `emp_salary` does not have much use (except for distributions of the salary) if you don't know who it belongs to. 

In the case where you don't want that you can still use `select [only_columns_that_I_want]`.
