### PR TITLE
add docs.rs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Issues](https://github.com/max-sixty/prql/issues?q=is%3Aissue+is%3Aopen+label%3A
 ### Documentation
 
 Currently the documentation exists in [tests](tests/test_transpile.rs),
-[examples](https://github.com/max-sixty/prql/tree/main/examples), and some
+[examples](https://github.com/max-sixty/prql/tree/main/examples), [docs.rs](https://docs.rs/prql/latest/prql/) and some
 [Notes](#notes) below.
 
 If you're up for contributing and don't have a preference for writing code or


### PR DESCRIPTION
ref: #232

For now, just add the docs.rs URL to the Readme.

I agree with a separate site like Insta, but think it would be better after WASM is completed.