### PR TITLE
Allow tabs as whitespace

### DIFF
--- a/examples/employees-0.md
+++ b/examples/employees-0.md
@@ -18,7 +18,6 @@ aggregate by:[dept_emp.dept_no, t.title] [
 ]
 join departments [dept_no]
 select [dept_name, title, avg_salary]
-
 ```
 
 ```sql

--- a/prql/src/parser.rs
+++ b/prql/src/parser.rs
@@ -1120,4 +1120,20 @@ take 20
         "###);
         Ok(())
     }
+
+    #[test]
+    fn test_tab_characters() -> Result<()> {
+        // #248
+
+        let prql = "from c_invoice
+join doc:c_doctype [c_invoice_id]
+select [
+\tinvoice_no,
+\tdocstatus
+]";
+        let result = parse(prql);
+        assert!(result.is_ok());
+
+        Ok(())
+    }
 }

--- a/prql/src/parser.rs
+++ b/prql/src/parser.rs
@@ -1123,7 +1123,7 @@ take 20
 
     #[test]
     fn test_tab_characters() -> Result<()> {
-        // #248
+        // #284
 
         let prql = "from c_invoice
 join doc:c_doctype [c_invoice_id]

--- a/prql/src/prql.pest
+++ b/prql/src/prql.pest
@@ -12,7 +12,7 @@
 //   sequence of idents. We could instead parse these explicitly, and then
 //   disallow `1 1`.
 
-WHITESPACE = _{ " " }
+WHITESPACE = _{ " " | "\t" }
 // Need to exclude # in strings (and maybe confirm whether this the syntax we want)
 COMMENT = _{ "#" ~ (!NEWLINE ~ ANY) * }
 

--- a/prql/tests/integration/examples.rs
+++ b/prql/tests/integration/examples.rs
@@ -1,3 +1,5 @@
+// TODO: we could add a task in CI to assert that there's no git diff in the
+// examples path?
 use insta::{assert_snapshot, glob};
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
We should eventually autoformat them away, but they should be allowed.

Closes #284 
