### PR TITLE
Remove TODO

### DIFF
--- a/prql/tests/integration/examples.rs
+++ b/prql/tests/integration/examples.rs
@@ -1,5 +1,3 @@
-// TODO: we could add a task in CI to assert that there's no git diff in the
-// examples path?
 use insta::{assert_snapshot, glob};
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
This didn't make sense — the design of this makes this unnecessary,
since we already use `insta` here. I'm not sure how it got out of sync
before (it was just a single linebreak IIRC),
but it should be a rarity.
