### PR TITLE
Add link to reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PRQL
 
-[![Language Docs](https://img.shields.io/badge/DOCS-LANGUAGE-blue?style=for-the-badge)](lang.prql.builders)
+[![Language Docs](https://img.shields.io/badge/DOCS-LANGUAGE-blue?style=for-the-badge)](https://lang.prql.builders)
 [![Discord](https://img.shields.io/discord/936728116712316989?style=for-the-badge)](https://discord.gg/eQcfaCmsNc)
 [![Rust API Docs](https://img.shields.io/badge/DOCS-RUST-brightgreen?style=for-the-badge&logo=rust)](https://docs.rs/prql/)
 <!-- Doesn't seem to support a different `message` [![docs.rs](https://img.shields.io/docsrs/prql?style=for-the-badge&label=rust&message=rust&logo=rust)](https://docs.rs/prql/) -->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # PRQL
 
-[![GitHub CI Status](https://img.shields.io/github/workflow/status/max-sixty/prql/tests?logo=github&style=for-the-badge)](https://github.com/max-sixty/prql/actions?query=workflow:tests)
+[![Language Docs](https://img.shields.io/badge/DOCS-LANGUAGE-blue?style=for-the-badge)](lang.prql.builders)
 [![Discord](https://img.shields.io/discord/936728116712316989?style=for-the-badge)](https://discord.gg/eQcfaCmsNc)
-[![docs.rs](https://img.shields.io/docsrs/prql?style=for-the-badge)](https://docs.rs/prql/)
+[![Rust API Docs](https://img.shields.io/badge/DOCS-RUST-brightgreen?style=for-the-badge&logo=rust)](https://docs.rs/prql/)
+<!-- Doesn't seem to support a different `message` [![docs.rs](https://img.shields.io/docsrs/prql?style=for-the-badge&label=rust&message=rust&logo=rust)](https://docs.rs/prql/) -->
+[![GitHub CI Status](https://img.shields.io/github/workflow/status/max-sixty/prql/tests?logo=github&style=for-the-badge)](https://github.com/max-sixty/prql/actions?query=workflow:tests)
 [![GitHub contributors](https://img.shields.io/github/contributors/max-sixty/prql?style=for-the-badge)](https://github.com/max-sixty/prql/graphs/contributors)
 [![Stars](https://img.shields.io/github/stars/max-sixty/prql?style=for-the-badge)](https://github.com/max-sixty/prql/stargazers)
 


### PR DESCRIPTION
I've set up a domain prql.builders, and linked to the language docs at https://lang.prql.builders.

`.builders` is not perfect. The other one that was reasonable was `prql.tools`. We could do `prql`rs`, but its main users would be PRQL users rather than rust developers (and it's a minor pain to buy the domain since it's actually Serbian).
