### PR TITLE
Fix atomic table splitting

### DIFF
--- a/examples/variables-2.md
+++ b/examples/variables-2.md
@@ -21,21 +21,15 @@ WITH table_0 AS (
     employees
   GROUP BY
     emp_no
-),
-table_1 AS (
-  SELECT
-    AVG(emp_salary) / 1000 AS salary_k
-  FROM
-    table_0
-    JOIN titles USING(emp_no)
-  GROUP BY
-    title
-  LIMIT
-    10
 )
 SELECT
-  *,
-  salary_k * 1000 AS salary
+  AVG(emp_salary) / 1000 AS salary_k,
+  AVG(emp_salary) / 1000 * 1000 AS salary
 FROM
-  table_1
+  table_0
+  JOIN titles USING(emp_no)
+GROUP BY
+  title
+LIMIT
+  10
 ```

--- a/examples/variables-2.md
+++ b/examples/variables-2.md
@@ -24,7 +24,7 @@ WITH table_0 AS (
 )
 SELECT
   AVG(emp_salary) / 1000 AS salary_k,
-  AVG(emp_salary) / 1000 * 1000 AS salary
+  salary_k * 1000 AS salary
 FROM
   table_0
   JOIN titles USING(emp_no)

--- a/prql/src/translator.rs
+++ b/prql/src/translator.rs
@@ -324,40 +324,55 @@ fn sql_query_of_atomic_table(table: AtomicTable) -> Result<sql_ast::Query> {
 
 /// Convert a pipeline into a number of pipelines which can each "fit" into a SELECT.
 fn atomic_pipelines_of_pipeline(pipeline: &Pipeline) -> Result<Vec<Pipeline>> {
-    // Before starting a new CTE, we can have a pipeline with:
-    // - 1 aggregate,
-    // - 1 take, and then 0 other transformations,
-    // - many filters, which can be combined. After combining them we can
-    //   have 1 filter before the aggregate (`WHERE`) and 1 filter after the
-    //   aggregate (`HAVING`),
-    // - many joins, but only before aggregate, filter, take and sort.
+    // Insert a cut, when we find transformation that out of order:
+    // - joins,
+    // - filters (for WHERE)
+    // - aggregate (max 1x)
+    // - sort (max 1x)
+    // - filters (for HAVING)
+    // - take (max 1x)
+    //
+    // Select and derive should already be extracted during resolving phase.
     //
     // So we loop through the Pipeline, and cut it into cte-sized pipelines,
     // which we'll then compose together.
 
     let mut counts: HashMap<&str, u32> = HashMap::new();
     let mut splits = vec![0];
-    for (i, transformation) in pipeline.iter().enumerate() {
-        if transformation.name() == "join"
-            && (counts.get("aggregate").is_some()
-                || counts.get("filter").is_some()
-                || counts.get("sort").is_some())
-        {
+    for (i, transform) in pipeline.iter().enumerate() {
+        
+        let split = match transform.name() {
+            "join" => {
+                counts.get("filter").is_some()
+                || counts.get("aggregate").is_some()
+                || counts.get("sort").is_some()
+                || counts.get("take").is_some()
+            },
+            "aggregate" => {
+                counts.get("aggregate").is_some()
+                || counts.get("sort").is_some()
+                || counts.get("take").is_some()
+            }
+            "filter" => {
+                counts.get("take").is_some()
+            },
+            "sort" => {
+                counts.get("sort").is_some()
+                || counts.get("take").is_some()
+            },
+            "take" => {
+                counts.get("take").is_some()
+            },
+            
+            _ => false,
+        };
+
+        if split {
             splits.push(i);
             counts.clear();
         }
 
-        if transformation.name() == "aggregate" && counts.get("aggregate") == Some(&1) {
-            splits.push(i);
-            counts.clear();
-        }
-
-        *counts.entry(transformation.name()).or_insert(0) += 1;
-
-        if counts.get("take") == Some(&1) {
-            splits.push(i + 1);
-            counts.clear();
-        }
+        *counts.entry(transform.name()).or_insert(0) += 1;
     }
 
     splits.push(pipeline.len());
@@ -712,6 +727,24 @@ SString:
         let pipeline: Pipeline = from_str(yaml)?;
         let queries = atomic_pipelines_of_pipeline(&pipeline)?;
         assert_eq!(queries.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ctes_of_pipeline_4() -> Result<()> {
+        // A take, then a select
+        let yaml: &str = r###"
+    - From:
+        name: employees
+        alias: ~
+    - Take: 20
+    - Select:
+        - Ident: first_name
+        "###;
+
+        let pipeline: Pipeline = from_str(yaml)?;
+        let queries = atomic_pipelines_of_pipeline(&pipeline)?;
+        assert_eq!(queries.len(), 1);
         Ok(())
     }
 

--- a/prql/src/translator.rs
+++ b/prql/src/translator.rs
@@ -340,29 +340,21 @@ fn atomic_pipelines_of_pipeline(pipeline: &Pipeline) -> Result<Vec<Pipeline>> {
     let mut counts: HashMap<&str, u32> = HashMap::new();
     let mut splits = vec![0];
     for (i, transform) in pipeline.iter().enumerate() {
-
         let split = match transform.name() {
             "join" => {
                 counts.get("filter").is_some()
-                || counts.get("aggregate").is_some()
-                || counts.get("sort").is_some()
-                || counts.get("take").is_some()
-            },
+                    || counts.get("aggregate").is_some()
+                    || counts.get("sort").is_some()
+                    || counts.get("take").is_some()
+            }
             "aggregate" => {
                 counts.get("aggregate").is_some()
-                || counts.get("sort").is_some()
-                || counts.get("take").is_some()
+                    || counts.get("sort").is_some()
+                    || counts.get("take").is_some()
             }
-            "filter" => {
-                counts.get("take").is_some()
-            },
-            "sort" => {
-                counts.get("sort").is_some()
-                || counts.get("take").is_some()
-            },
-            "take" => {
-                counts.get("take").is_some()
-            },
+            "filter" => counts.get("take").is_some(),
+            "sort" => counts.get("sort").is_some() || counts.get("take").is_some(),
+            "take" => counts.get("take").is_some(),
 
             _ => false,
         };

--- a/prql/src/translator.rs
+++ b/prql/src/translator.rs
@@ -340,7 +340,7 @@ fn atomic_pipelines_of_pipeline(pipeline: &Pipeline) -> Result<Vec<Pipeline>> {
     let mut counts: HashMap<&str, u32> = HashMap::new();
     let mut splits = vec![0];
     for (i, transform) in pipeline.iter().enumerate() {
-        
+
         let split = match transform.name() {
             "join" => {
                 counts.get("filter").is_some()
@@ -363,7 +363,7 @@ fn atomic_pipelines_of_pipeline(pipeline: &Pipeline) -> Result<Vec<Pipeline>> {
             "take" => {
                 counts.get("take").is_some()
             },
-            
+
             _ => false,
         };
 

--- a/prql/tests/integration/snapshots/integration__examples__run_examples@variables-2.prql.snap
+++ b/prql/tests/integration/snapshots/integration__examples__run_examples@variables-2.prql.snap
@@ -14,7 +14,7 @@ WITH table_0 AS (
 )
 SELECT
   AVG(emp_salary) / 1000 AS salary_k,
-  AVG(emp_salary) / 1000 * 1000 AS salary
+  salary_k * 1000 AS salary
 FROM
   table_0
   JOIN titles USING(emp_no)

--- a/prql/tests/integration/snapshots/integration__examples__run_examples@variables-2.prql.snap
+++ b/prql/tests/integration/snapshots/integration__examples__run_examples@variables-2.prql.snap
@@ -11,20 +11,14 @@ WITH table_0 AS (
     employees
   GROUP BY
     emp_no
-),
-table_1 AS (
-  SELECT
-    AVG(emp_salary) / 1000 AS salary_k
-  FROM
-    table_0
-    JOIN titles USING(emp_no)
-  GROUP BY
-    title
-  LIMIT
-    10
 )
 SELECT
-  *,
-  salary_k * 1000 AS salary
+  AVG(emp_salary) / 1000 AS salary_k,
+  AVG(emp_salary) / 1000 * 1000 AS salary
 FROM
-  table_1
+  table_0
+  JOIN titles USING(emp_no)
+GROUP BY
+  title
+LIMIT
+  10


### PR DESCRIPTION
Changes translator, such that

```
from employees
take 10
select first_name
```
produces a single SELECT statement.