### PR TITLE
Add sort to sementic context

### DIFF
--- a/prql/src/ast.rs
+++ b/prql/src/ast.rs
@@ -101,7 +101,7 @@ pub enum Transform {
         by: Vec<Node>,
         select: Vec<Node>,
     },
-    Sort(Vec<Node>),
+    Sort(Vec<ColumnSort<Node>>),
     Take(i64),
     Join {
         side: JoinSide,
@@ -131,8 +131,8 @@ impl Transform {
             Transform::Select(nodes)
             | Transform::Filter(Filter(nodes))
             | Transform::Derive(nodes)
-            | Transform::Aggregate { by: nodes, .. }
-            | Transform::Sort(nodes) => nodes.first(),
+            | Transform::Aggregate { by: nodes, .. } => nodes.first(),
+            Transform::Sort(columns) => columns.first().map(|c| &c.column),
             Transform::Join { filter, .. } => filter.nodes().first(),
             Transform::Take(_) => None,
         }
@@ -210,6 +210,18 @@ pub enum JoinSide {
 pub struct TableRef {
     pub name: String,
     pub alias: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ColumnSort<T = Node> {
+    pub direction: SortDirection,
+    pub column: T,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum SortDirection {
+    Asc,
+    Desc,
 }
 
 impl Node {
@@ -294,6 +306,12 @@ impl From<Item> for Node {
             span: None,
             declared_at: None,
         }
+    }
+}
+
+impl Default for SortDirection {
+    fn default() -> Self {
+        SortDirection::Asc
     }
 }
 

--- a/prql/src/parser.rs
+++ b/prql/src/parser.rs
@@ -1312,4 +1312,85 @@ select [
                         named_args: []
         "###);
     }
+
+    #[test]
+    fn test_sort() {
+        assert_yaml_snapshot!(parse("
+        from invoices
+        sort issued_at
+        ").unwrap(), @r###"
+        ---
+        version: ~
+        dialect: Generic
+        nodes:
+          - Pipeline:
+              - From:
+                  name: invoices
+                  alias: ~
+              - Sort:
+                  - direction: Asc
+                    column:
+                      Ident: issued_at
+        "###);
+
+        assert_yaml_snapshot!(parse("
+        from invoices
+        sort desc:issued_at
+        ").unwrap(), @r###"
+        ---
+        version: ~
+        dialect: Generic
+        nodes:
+          - Pipeline:
+              - From:
+                  name: invoices
+                  alias: ~
+              - Sort:
+                  - direction: Desc
+                    column:
+                      Ident: issued_at
+        "###);
+
+        assert_yaml_snapshot!(parse("
+        from invoices
+        sort asc:issued_at
+        ").unwrap(), @r###"
+        ---
+        version: ~
+        dialect: Generic
+        nodes:
+          - Pipeline:
+              - From:
+                  name: invoices
+                  alias: ~
+              - Sort:
+                  - direction: Asc
+                    column:
+                      Ident: issued_at
+        "###);
+
+        assert_yaml_snapshot!(parse("
+        from invoices
+        sort [asc:issued_at, desc:amount, num_of_articles]
+        ").unwrap(), @r###"
+        ---
+        version: ~
+        dialect: Generic
+        nodes:
+          - Pipeline:
+              - From:
+                  name: invoices
+                  alias: ~
+              - Sort:
+                  - direction: Asc
+                    column:
+                      Ident: issued_at
+                  - direction: Desc
+                    column:
+                      Ident: amount
+                  - direction: Asc
+                    column:
+                      Ident: num_of_articles
+        "###);
+    }
 }

--- a/prql/src/semantic/mod.rs
+++ b/prql/src/semantic/mod.rs
@@ -3,8 +3,8 @@ mod materializer;
 mod reporting;
 mod resolver;
 
-pub use self::context::{Context, Declaration, VarDec};
-pub use materializer::{materialize, SelectedColumns};
+pub use self::context::{Context, Declaration};
+pub use materializer::{materialize, MaterializedFrame};
 pub use reporting::print;
 pub use resolver::resolve;
 
@@ -19,7 +19,7 @@ use anyhow::Result;
 pub fn resolve_and_materialize(
     nodes: Vec<Node>,
     context: Option<Context>,
-) -> Result<(Vec<Node>, Context, SelectedColumns)> {
+) -> Result<(Vec<Node>, Context, MaterializedFrame)> {
     let (nodes, context) = resolve(nodes, context)?;
     materialize(nodes, context)
 }
@@ -28,7 +28,7 @@ pub fn resolve_and_materialize(
 pub fn process_pipeline(
     pipeline: Pipeline,
     context: Option<Context>,
-) -> Result<(Pipeline, Context, SelectedColumns)> {
+) -> Result<(Pipeline, Context, MaterializedFrame)> {
     let (nodes, context, select) =
         resolve_and_materialize(vec![Item::Pipeline(pipeline).into()], context)?;
     let pipeline = nodes.into_only()?.item.into_pipeline()?;

--- a/prql/src/semantic/reporting.rs
+++ b/prql/src/semantic/reporting.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use anyhow::{Ok, Result};
 use ariadne::{Color, Label, Report, ReportBuilder, ReportKind, Source};
 
-use super::{Context, Declaration, VarDec};
+use super::{Context, Declaration};
 use crate::ast::FuncDef;
 use crate::internals::{AstFold, Node};
 
@@ -24,8 +24,7 @@ pub fn print(nodes: &[Node], context: &Context, source_id: String, source: Strin
     // traverse declarations
     for (d, _) in &context.declarations {
         match d {
-            Declaration::Variable(VarDec { declaration: n, .. })
-            | Declaration::Function(FuncDef { body: n, .. }) => {
+            Declaration::Variable(n) | Declaration::Function(FuncDef { body: n, .. }) => {
                 labeler.fold_node(*(*n).clone()).unwrap();
             }
             Declaration::Table(_) => todo!(),

--- a/prql/src/semantic/snapshots/prql__semantic__materializer__test__materialize_2.snap
+++ b/prql/src/semantic/snapshots/prql__semantic__materializer__test__materialize_2.snap
@@ -27,18 +27,6 @@ expression: mat
           - Ident: title
           - Ident: country
         select: []
-    - Sort:
-        - SString:
-            - String: SUM(
-            - Expr:
-                Expr:
-                  - Expr:
-                      - Ident: salary
-                      - Raw: +
-                      - Ident: payroll_tax
-                  - Raw: +
-                  - Ident: benefits_cost
-            - String: )
     - Filter:
         - Expr:
             - SString:

--- a/prql/src/semantic/snapshots/prql__semantic__materializer__test__replace_variables_2.snap
+++ b/prql/src/semantic/snapshots/prql__semantic__materializer__test__replace_variables_2.snap
@@ -27,18 +27,6 @@ expression: "&mat"
           - Ident: title
           - Ident: country
         select: []
-    - Sort:
-        - SString:
-            - String: SUM(
-            - Expr:
-                Expr:
-                  - Expr:
-                      - Ident: salary
-                      - Raw: +
-                      - Ident: payroll_tax
-                  - Raw: +
-                  - Ident: benefits_cost
-            - String: )
     - Filter:
         - Expr:
             - SString:

--- a/prql/src/snapshots/prql__parser__test__parse_query.snap
+++ b/prql/src/snapshots/prql__parser__test__parse_query.snap
@@ -78,7 +78,9 @@ Query:
                   expr:
                     Ident: count
         - Sort:
-            - Ident: sum_gross_cost
+            - direction: Asc
+              column:
+                Ident: sum_gross_cost
         - Filter:
             - Expr:
                 - Ident: ct


### PR DESCRIPTION
Introduces sort syntax for `asc` and `desc`:

```elm
from Employees
sort [id]
sort [age, desc:last_name, asc:first_name]
```

Includes refactor in preparation for #300 