### PR TITLE
Ranges and `between` function

### DIFF
--- a/prql/src/ast.rs
+++ b/prql/src/ast.rs
@@ -34,6 +34,7 @@ pub enum Item {
     // to start with a simple expression.
     InlinePipeline(InlinePipeline),
     List(Vec<ListItem>),
+    Range(Range),
     Expr(Vec<Node>),
     FuncDef(FuncDef),
     FuncCall(FuncCall),
@@ -222,6 +223,12 @@ pub struct ColumnSort<T = Node> {
 pub enum SortDirection {
     Asc,
     Desc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Range {
+    pub start: Option<Box<Node>>,
+    pub end: Option<Box<Node>>,
 }
 
 impl Node {

--- a/prql/src/ast_fold.rs
+++ b/prql/src/ast_fold.rs
@@ -96,6 +96,10 @@ pub fn fold_item<T: ?Sized + AstFold>(fold: &mut T, item: Item) -> Result<Item> 
                 .map(|x| fold.fold_node(x.into_inner()).map(ListItem))
                 .try_collect()?,
         ),
+        Item::Range(range) => Item::Range(Range {
+            start: fold_optional_box(fold, range.start)?,
+            end: fold_optional_box(fold, range.end)?,
+        }),
         Item::Query(query) => Item::Query(Query {
             nodes: fold.fold_nodes(query.nodes)?,
             ..query
@@ -131,6 +135,13 @@ pub fn fold_item<T: ?Sized + AstFold>(fold: &mut T, item: Item) -> Result<Item> 
         // them.
         Item::String(_) | Item::Raw(_) => item,
     })
+}
+
+pub fn fold_optional_box<T: ?Sized + AstFold>(
+    fold: &mut T,
+    opt: Option<Box<Node>>,
+) -> Result<Option<Box<Node>>> {
+    Ok(opt.map(|n| fold.fold_node(*n)).transpose()?.map(Box::from))
 }
 
 pub fn fold_interpolate_item<T: ?Sized + AstFold>(

--- a/prql/src/ast_fold.rs
+++ b/prql/src/ast_fold.rs
@@ -97,6 +97,9 @@ pub fn fold_item<T: ?Sized + AstFold>(fold: &mut T, item: Item) -> Result<Item> 
                 .try_collect()?,
         ),
         Item::Range(range) => Item::Range(Range {
+            // This aren't strictly in the hierarchy, so we don't need to
+            // have an assoc. function for `fold_optional_box` — we just
+            // call out to the function in this module
             start: fold_optional_box(fold, range.start)?,
             end: fold_optional_box(fold, range.end)?,
         }),

--- a/prql/src/prql.pest
+++ b/prql/src/prql.pest
@@ -71,7 +71,7 @@ func_call = { ident ~ (named_term_simple | term_simple)+ }
 func_curry = { ident ~ (named_term_simple | term_simple)* }
 
 term = _{ ( s_string | f_string | func_call | term_simple ) }
-term_simple = _{ ( s_string | f_string | ident | parenthesized_expr | list | number | string_literal | inline_pipeline ) }
+term_simple = _{ ( s_string | f_string | ident | parenthesized_expr | list | range | number | string_literal | inline_pipeline ) }
 list = { "[" ~ NEWLINE* ~ named_expr ~ ("," ~ NEWLINE* ~ named_expr )* ~ ","? ~ NEWLINE* ~ "]" }
 parenthesized_expr = _{ "(" ~ expr ~ ")" }
 
@@ -93,7 +93,10 @@ quote = _{ "\"" | "'" }
 string = { ( !( "\\" | PEEK ) ~ ANY )+ }
 string_literal = ${ PUSH(quote) ~ string ~ POP }
 
-number = ${ ( ASCII_DIGIT | "." )+ }
+number = ${ ( ASCII_DIGIT )+ ~ ("." ~ ( ASCII_DIGIT )+)? }
+
+// this could be generalized to use term_simple
+range = ${ number? ~ ".." ~ number? }
 
 // These separate idents from each other — i.e. `foo bar and baz` will parse into
 // [`foo bar`, `and`, `baz`], where `foo bar` is presumably a function call.

--- a/prql/src/semantic/context.rs
+++ b/prql/src/semantic/context.rs
@@ -31,7 +31,7 @@ pub struct Context {
     pub(super) functions: HashMap<String, usize>,
 
     /// table aliases
-    pub(super) tables: HashMap<String, String>,
+    pub(super) namespaces: HashMap<String, String>,
 
     /// All declarations, even those out of scope
     pub(super) declarations: Vec<(Declaration, Option<Span>)>,
@@ -105,7 +105,7 @@ impl Context {
             "%" | "_" | "$" => true,
             _ => {
                 // redirect namespace to $
-                self.tables.insert(name.clone(), "$".to_string());
+                self.namespaces.insert(name.clone(), "$".to_string());
 
                 current.extend(
                     (space.drain()).filter(|(_, id)| self.frame.columns.iter().any(|c| c == id)),
@@ -124,7 +124,8 @@ impl Context {
         self.variables.retain(|name, _| match name.as_str() {
             "_" | "$" | "%" => true,
             _ => {
-                self.tables.insert(name.clone(), table_name.to_string());
+                self.namespaces
+                    .insert(name.clone(), table_name.to_string());
                 false
             }
         });
@@ -154,12 +155,12 @@ impl Context {
 
     pub fn declare_table(&mut self, t: &TableRef) {
         let name = if let Some(alias) = &t.alias {
-            self.tables.insert(t.name.clone(), alias.clone());
+            self.namespaces.insert(t.name.clone(), alias.clone());
             alias.clone()
         } else {
             t.name.clone()
         };
-        self.tables.remove(&name);
+        self.namespaces.remove(&name);
 
         self.variables.insert(name.clone(), Default::default());
 
@@ -239,16 +240,21 @@ impl Context {
         // add column to frame
         if in_frame {
             if let Some((ns, "*")) = name {
-                let mut namespace = ns.to_string();
-                while let Some(ns) = self.tables.get(&namespace) {
-                    namespace = ns.clone();
-                }
+                let namespace = self.resolve_namespace(ns);
 
                 self.frame.columns.push(TableColumn::All(namespace));
             } else {
                 self.frame.columns.push(TableColumn::Declared(id));
             }
         }
+    }
+
+    fn resolve_namespace(&self, namespace: &str) -> String {
+        let mut namespace = namespace;
+        while let Some(t) = self.namespaces.get(namespace) {
+            namespace = t;
+        }
+        namespace.to_string()
     }
 
     pub fn lookup_variable(&mut self, ident: &str) -> Result<Option<usize>, String> {
@@ -258,12 +264,12 @@ impl Context {
             return Ok(None);
         }
 
-        let mut namespace = namespace.to_string();
+        let mut namespace = namespace;
 
         // try to find the namespace
         if namespace.is_empty() {
-            namespace = if let Some(ns) = self.lookup_namespace_of(variable)? {
-                ns
+            if let Some(ns) = self.lookup_namespace_of(variable)? {
+                namespace = ns
             } else {
                 // matched to *, but multiple possible namespaces
                 // -> return None, treating this ident as raw
@@ -272,9 +278,7 @@ impl Context {
         }
 
         // resolve table alias
-        while let Some(ns) = self.tables.get(&namespace) {
-            namespace = ns.clone();
-        }
+        let namespace = self.resolve_namespace(&namespace);
 
         let ns = (self.variables.get(&namespace))
             .ok_or_else(|| format!("Unknown table `{namespace}`"))?;
@@ -295,28 +299,38 @@ impl Context {
         }
     }
 
-    pub fn lookup_namespace_of(&mut self, variable: &str) -> Result<Option<String>, String> {
+    /// Finds a namespace of a variable.
+    pub fn lookup_namespace_of(&self, variable: &str) -> Result<Option<&String>, String> {
         if let Some(ns) = self.inverse.get(variable) {
-            if ns.len() == 1 {
-                return Ok(ns.iter().next().cloned());
-            }
-
-            if ns.len() > 1 {
-                return Err(format!(
+            // lookup the inverse index
+            
+            match ns.len() {
+                0 => unreachable!("inverse index contains empty lists?"),
+                
+                // single match, great!
+                1 => Ok(ns.iter().next()),
+                
+                // ambiguous
+                _ => Err(format!(
                     "Ambiguous variable. Could be from either of {:?}",
                     ns
-                ));
+                ))
             }
         } else if let Some(ns) = self.inverse.get("*") {
-            if ns.len() == 1 {
-                return Ok(ns.iter().next().cloned());
+            // this variable can be from a namespace that we don't know all columns of
+
+            match ns.len() {
+                0 => unreachable!("inverse index contains empty lists?"),
+                
+                // single match, great!
+                1 => Ok(ns.iter().next()),
+                
+                // don't report ambiguous variable, database may be able to resolve them
+                _ => Ok(None)
             }
-            // don't report ambiguous variable, database may be able to resolve them
-            if ns.len() > 1 {
-                return Ok(None);
-            }
+        } else {
+            Err(format!("Unknown variable `{variable}`"))
         }
-        Err(format!("Unknown variable `{variable}`"))
     }
 
     pub fn lookup_namespaces_of(&mut self, variable: &str) -> HashSet<String> {

--- a/prql/src/semantic/context.rs
+++ b/prql/src/semantic/context.rs
@@ -124,8 +124,7 @@ impl Context {
         self.variables.retain(|name, _| match name.as_str() {
             "_" | "$" | "%" => true,
             _ => {
-                self.namespaces
-                    .insert(name.clone(), table_name.to_string());
+                self.namespaces.insert(name.clone(), table_name.to_string());
                 false
             }
         });
@@ -278,7 +277,7 @@ impl Context {
         }
 
         // resolve table alias
-        let namespace = self.resolve_namespace(&namespace);
+        let namespace = self.resolve_namespace(namespace);
 
         let ns = (self.variables.get(&namespace))
             .ok_or_else(|| format!("Unknown table `{namespace}`"))?;
@@ -303,30 +302,30 @@ impl Context {
     pub fn lookup_namespace_of(&self, variable: &str) -> Result<Option<&String>, String> {
         if let Some(ns) = self.inverse.get(variable) {
             // lookup the inverse index
-            
+
             match ns.len() {
                 0 => unreachable!("inverse index contains empty lists?"),
-                
+
                 // single match, great!
                 1 => Ok(ns.iter().next()),
-                
+
                 // ambiguous
                 _ => Err(format!(
                     "Ambiguous variable. Could be from either of {:?}",
                     ns
-                ))
+                )),
             }
         } else if let Some(ns) = self.inverse.get("*") {
             // this variable can be from a namespace that we don't know all columns of
 
             match ns.len() {
                 0 => unreachable!("inverse index contains empty lists?"),
-                
+
                 // single match, great!
                 1 => Ok(ns.iter().next()),
-                
+
                 // don't report ambiguous variable, database may be able to resolve them
-                _ => Ok(None)
+                _ => Ok(None),
             }
         } else {
             Err(format!("Unknown variable `{variable}`"))

--- a/prql/src/stdlib.prql
+++ b/prql/src/stdlib.prql
@@ -21,7 +21,7 @@ func count_distinct column = s"COUNT(DISTINCT `{column}`)"
 # TODO: Introduce a notation for getting start and end out of a ranges
 # could be range.0? or range.start? But to make this happen, we need to make
 # changes to how variables are resolved.
-func between range value = s"{value} BETWEEN {range}"
+func in range value = s"{value} BETWEEN {range}"
 
 # Casting functions
 

--- a/prql/src/stdlib.prql
+++ b/prql/src/stdlib.prql
@@ -19,7 +19,7 @@ func count column = s"COUNT({column})"
 func count_distinct column = s"COUNT(DISTINCT `{column}`)"
 
 # TODO: Introduce a notation for getting start and end out of a ranges
-# could be range.0? or range.start? But to make this happen, we need to make 
+# could be range.0? or range.start? But to make this happen, we need to make
 # changes to how variables are resolved.
 func between range value = s"{value} BETWEEN {range}"
 

--- a/prql/src/stdlib.prql
+++ b/prql/src/stdlib.prql
@@ -18,6 +18,11 @@ func count column = s"COUNT({column})"
 # abbreviation of that?)
 func count_distinct column = s"COUNT(DISTINCT `{column}`)"
 
+# TODO: Introduce a notation for getting start and end out of a ranges
+# could be range.0? or range.start? But to make this happen, we need to make 
+# changes to how variables are resolved.
+func between range value = s"{value} BETWEEN {range}"
+
 # Casting functions
 
 func as column type = s"CAST({column} AS {type})"

--- a/prql/src/translator.rs
+++ b/prql/src/translator.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use super::ast::*;
 use super::utils::*;
 use crate::ast::JoinFilter;
+use crate::error::{Error, Reason};
 use crate::semantic::{self, MaterializedFrame};
 
 /// Translate a PRQL AST into a SQL string.
@@ -478,6 +479,18 @@ impl TryFrom<Item> for Expr {
                         // need to parse every single expression into sqlparser ast.
                         .join(" "),
                 ))
+            }
+            Item::Range(r) => {
+                fn assert_bound(bound: Option<Box<Node>>) -> Result<Node, Error> {
+                    bound.map(|b| *b).ok_or_else(|| {
+                        Error::new(Reason::Simple(
+                            "range requires both bounds to be used this way".to_string(),
+                        ))
+                    })
+                }
+                let start: Expr = assert_bound(r.start)?.item.try_into()?;
+                let end: Expr = assert_bound(r.end)?.item.try_into()?;
+                Expr::Identifier(sql_ast::Ident::new(format!("{} AND {}", start, end)))
             }
             Item::String(s) => Expr::Value(sql_ast::Value::SingleQuotedString(s)),
             // Fairly hacky — convert everything to a string, then concat it,
@@ -1199,6 +1212,37 @@ take 20
           Employees.last_name DESC,
           Employees.first_name
         "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ranges() -> Result<()> {
+        let query: Query = parse(
+            r###"
+        from employees
+        filter (age | between 18..40)
+        "###,
+        )?;
+
+        assert_display_snapshot!((translate(&query)?), @r###"
+        SELECT
+          employees.*
+        FROM
+          employees
+        WHERE
+          age BETWEEN 18
+          AND 40
+        "###);
+
+        let query: Query = parse(
+            r###"
+        from employees
+        filter (age | between ..40)
+        "###,
+        )?;
+
+        assert!(translate(&query).is_err());
 
         Ok(())
     }

--- a/prql/src/translator.rs
+++ b/prql/src/translator.rs
@@ -250,8 +250,8 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
         })
     }
     // Find the filters that come before the aggregation.
-    let where_ = filter_of_pipeline(before).unwrap();
-    let having = filter_of_pipeline(after).unwrap();
+    let where_ = filter_of_pipeline(before)?;
+    let having = filter_of_pipeline(after)?;
 
     let take = table
         .pipeline
@@ -471,8 +471,8 @@ impl TryFrom<Item> for Expr {
                 Expr::Identifier(sql_ast::Ident::new(
                     items
                         .into_iter()
-                        .map(|node| TryInto::<Expr>::try_into(node.item).unwrap())
-                        .collect::<Vec<Expr>>()
+                        .map(|node| TryInto::<Expr>::try_into(node.item))
+                        .collect::<Result<Vec<Expr>>>()?
                         .iter()
                         .map(|x| x.to_string())
                         // Currently a hack, but maybe OK, since we don't
@@ -1221,7 +1221,7 @@ take 20
         let query: Query = parse(
             r###"
         from employees
-        filter (age | between 18..40)
+        filter (age | in 18..40)
         "###,
         )?;
 
@@ -1238,7 +1238,7 @@ take 20
         let query: Query = parse(
             r###"
         from employees
-        filter (age | between ..40)
+        filter (age | in ..40)
         "###,
         )?;
 


### PR DESCRIPTION
Prepares for #300 
Checks a mark of #301  

I've added this:
```
from employees
filter (age | between 18..40)
```

I've chosen `between` for the function name, because `in` seems too concise. If anyone feels different, we can change it.

Currently ranges can currently contain only number literals, and not expressions. Should this constraint be removed?

TODO: docs
