### PR TITLE
Fix and text string escapes

### DIFF
--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -535,17 +535,38 @@ mod test {
 
         // Single quotes within double quotes should produce a string containing
         // the single quotes (and vice versa).
-        assert_yaml_snapshot!( ast_of_string(r#""' U S A '""#, Rule::string_literal)? , @r###"
+        assert_yaml_snapshot!(ast_of_string(r#""' U S A '""#, Rule::string_literal)? , @r###"
         ---
         String: "' U S A '"
         "###);
-        assert_yaml_snapshot!( ast_of_string(r#"'" U S A "'"#, Rule::string_literal)? , @r###"
+        assert_yaml_snapshot!(ast_of_string(r#"'" U S A "'"#, Rule::string_literal)? , @r###"
         ---
         String: "\" U S A \""
         "###);
 
         assert!(ast_of_string(r#"" U S A"#, Rule::string_literal).is_err());
         assert!(ast_of_string(r#"" U S A '"#, Rule::string_literal).is_err());
+
+        // Escapes get passed through (the insta snapshot has them escaped I
+        // think, which isn't that clear, so repeated below).
+        let escaped_string = ast_of_string(r#"" \U S A ""#, Rule::string_literal)?;
+        assert_yaml_snapshot!(escaped_string, @r###"
+        ---
+        String: " \\U S A "
+        "###);
+        assert_eq!(escaped_string.item.as_string().unwrap(), r#" \U S A "#);
+
+        // Currently we don't allow escaping closing quotes — because it's not
+        // trivial to do in pest, and I'm not sure it's a great idea either — we
+        // should arguably encourage r-strings. (Though no objection if someone
+        // wants to implement it, this test is recording current behavior rather
+        // than maintaining a contract).
+        let escaped_quotes = ast_of_string(r#"" Canada \""#, Rule::string_literal)?;
+        assert_yaml_snapshot!(escaped_quotes, @r###"
+        ---
+        String: " Canada \\"
+        "###);
+        assert_eq!(escaped_quotes.item.as_string().unwrap(), r#" Canada \"#);
 
         Ok(())
     }

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -73,13 +73,15 @@ term_simple = _{ ( s_string | f_string | ident | parenthesized_expr | list | ran
 list = { "[" ~ NEWLINE* ~ named_expr ~ ("," ~ NEWLINE* ~ named_expr )* ~ ","? ~ NEWLINE* ~ "]" }
 parenthesized_expr = _{ "(" ~ expr ~ ")" }
 
-// TODO: escapes
+// We haven't implemented escapes — I think we can mostly pass those through to
+// SQL, but there may be things we're missing.
 // https://pest.rs/book/examples/rust/literals.html
 
-// We need to have a non-silent rule which contains the quotes, because of
-// https://github.com/pest-parser/pest/issues/583, and then when converting to
-// AST, we only keep the `string` and discard the `string_literal` given it
-// contains the quotes.
+// We need to have a non-silent rule which contains the quotes
+// — `string_literal` in this case — because of
+// https://github.com/pest-parser/pest/issues/583. Then when converting to AST,
+// we only keep the `string` and discard the `string_literal` given it contains
+// the quotes.
 //
 // TODO: I'm still a bit unclear how preceeding and trailing spaces are working
 // -- it seems that inner spaces are included without an atomic operator (or
@@ -88,7 +90,7 @@ parenthesized_expr = _{ "(" ~ expr ~ ")" }
 
 quote = _{ "\"" | "'" }
 // PEEK refers to the opening quote; either `"` or `'`.
-string = { ( !( "\\" | PEEK ) ~ ANY )+ }
+string = { ( !( PEEK ) ~ ANY )+ }
 string_literal = ${ PUSH(quote) ~ string ~ POP }
 
 number = ${ ( ASCII_DIGIT )+ ~ ("." ~ ( ASCII_DIGIT )+)? }
@@ -103,7 +105,7 @@ operator = ${ "and" | "or" | "not" | "==" | "!=" | "=" | ">" | "<" | ">=" | "<="
 
 s_string = ${ "s" ~ PUSH(quote) ~ ( interpolate_string | ( "{" ~ expr ~ "}" ))* ~ POP }
 f_string = ${ "f" ~ PUSH(quote) ~ ( interpolate_string | ( "{" ~ expr ~ "}" ))* ~ POP }
-interpolate_string = { ( !( "\\" | PEEK | "{" ) ~ ANY )+ }
+interpolate_string = { ( !( PEEK | "{" ) ~ ANY )+ }
 
 // For assigns, table aliases and named arguments
 named_expr = { (ident ~ ":")? ~ expr }


### PR DESCRIPTION
The existing code (which I wrote) seems to mistakenly end strings on \ characters.

Note that I didn't implement escaping quotes -- it's not that easy in pest, and r-strings are just better for it anyway.
