### PR TITLE
Speed up mdbook tests

### DIFF
--- a/reference/book.toml
+++ b/reference/book.toml
@@ -23,17 +23,21 @@ git-repository-url = "https://github.com/prql/prql"
 #
 # Note that we use `-c` and not `-a` or `-t` in rsync, since if we copy
 # modification times, then it'll run in an endless loop when running `trunk
-# serve`.
+# serve`. We write to stderr because stdout is used by mdbook.
 #
 # If there's a better way of doing this (including one that works on Windows,
 # and doesn't swallow actual errors), we should change.
-command = "sh -c 'cd $(git rev-parse --show-toplevel)/prql-web && trunk build --public-url=dist && rsync -cvri dist ../reference/src/ && echo \"Copied!\" && exit 1'"
+command = "sh -c 'echo \"Building prql-web from mdbook\" 1>&2; cd $(git rev-parse --show-toplevel)/prql-web && trunk build --public-url=dist && rsync -cvri dist ../reference/src/ && echo \"Copied!\" && exit 1'"
 
 # Hack to install the current version of the `prql` preprocessor; similar
 # limitations as the `trunk` preprocessor.
 [preprocessor.install-prql]
 before = ["prql"]
-command = "sh -c 'cd $(git rev-parse --show-toplevel)/reference/mdbook-prql/ && cargo install --locked --path . && exit 1'"
+# We install with `--debug` because this is in the critical path of tests, and
+# runtime performance doesn't matter.
+# command = "sh -c 'cd $(git rev-parse --show-toplevel)/reference/mdbook-prql/ && cargo install --locked --path . && exit 1'"
+
+command = "sh -c 'echo \"Installing mdbook-prql from mdbook\" 1>&2; cd $(git rev-parse --show-toplevel)/reference/mdbook-prql/ && cargo install --locked --debug --path . && exit 1'"
 
 [preprocessor.prql]
 


### PR DESCRIPTION
Most of the time is taken up by installing mdbook-prql, a preprocessor whose runtime performance is immaterial, so compile it in debug mode
