### PR TITLE
Implement sort syntax of `+`/`-`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ GROUP BY
 HAVING
   COUNT(*) > 200
 ORDER BY
-  sum_gross_cost
+  sum_gross_cost,
+  country DESC
 ```
 
 Even this simple query demonstrates some of the problems with SQL's lack of
@@ -90,7 +91,7 @@ group [title, country] (                      # `group` runs a pipeline over eac
     ct: count,
   ]
 )
-sort sum_gross_cost
+sort [sum_gross_cost, -country]
 filter ct > 200
 take 20
 ```

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -496,6 +496,22 @@ Canada
           - Ident: b
         "###);
         assert_ne!(ab, a_comma_b);
+
+        assert_debug_snapshot!(
+            parse_tree_of_str(r#"[amount, +amount, -amount]"#, Rule::list).unwrap()
+        );
+        // Operators in list items
+        assert_yaml_snapshot!(ast_of_string(r#"[amount, +amount, -amount]"#, Rule::list).unwrap(), @r###"
+        ---
+        List:
+          - Ident: amount
+          - Expr:
+              - Operator: +
+              - Ident: amount
+          - Expr:
+              - Operator: "-"
+              - Ident: amount
+        "###);
     }
 
     #[test]
@@ -1319,18 +1335,21 @@ select [
                     name: sort
                     args:
                       - List:
-                          - Operator: "-"
-                          - Ident: issued_at
+                          - Expr:
+                              - Operator: "-"
+                              - Ident: issued_at
                     named_args: {}
                 - FuncCall:
                     name: sort
                     args:
                       - List:
                           - Ident: issued_at
-                          - Operator: "-"
-                          - Ident: amount
-                          - Operator: +
-                          - Ident: num_of_articles
+                          - Expr:
+                              - Operator: "-"
+                              - Ident: amount
+                          - Expr:
+                              - Operator: +
+                              - Ident: num_of_articles
                     named_args: {}
         "###);
 

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -63,10 +63,13 @@ named_arg   = { ident ~ ":" ~ !":" ~ (assign | expr) }
 assign      = { ident ~ "=" ~ !"=" ~ expr }
 assign_call = { ident ~ "=" ~ !"=" ~ expr_call }
 
-// Expression that can contain a function call and a leading `+` or `-`
-expr_call = _{ operator_add? ~ (func_call | expr) }
+// That these `expr*` rules aren't silent causes a lot of extra items in the
+// parse tree, but we remove them in the AST. We might be able to have them
+// silent, though they also need to be non-atomic.
 
-// We add an `operator_add?` to the `expr` rule to allow for a leading `+` or `-`.
+// Expression that can contain a function call and a leading `+` or `-`
+expr_call = { operator_add? ~ (func_call | expr) }
+
 expr = !{ expr_compare ~ (operator_logical ~ expr_compare)* }
 expr_compare = !{ expr_add ~ (operator_compare ~ expr_add)? }
 expr_add = !{ expr_mul ~ (operator_add ~ expr_mul)* }

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -63,10 +63,6 @@ named_arg   = { ident ~ ":" ~ !":" ~ (assign | expr) }
 assign      = { ident ~ "=" ~ !"=" ~ expr }
 assign_call = { ident ~ "=" ~ !"=" ~ expr_call }
 
-// That these `expr*` rules aren't silent causes a lot of extra items in the
-// parse tree, but we remove them in the AST. We might be able to have them
-// silent, though they also need to be non-atomic.
-
 // Expression that can contain a function call and a leading `+` or `-`
 expr_call = { operator_add? ~ (func_call | expr) }
 

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -45,7 +45,7 @@ pub fn cast_transform(func_call: FuncCall, span: Option<Span>) -> Result<Transfo
             }
         }
         "sort" => {
-            let ([by], []) = unpack(dbg!(func_call), [])?;
+            let ([by], []) = unpack(func_call, [])?;
 
             let by = by
                 .coerce_to_vec()
@@ -352,7 +352,6 @@ mod tests {
         )
         .unwrap();
 
-        dbg!(&query);
         let (result, _) = resolve(query.nodes, context).unwrap();
         assert_yaml_snapshot!(result, @r###"
         ---

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -45,29 +45,58 @@ pub fn cast_transform(func_call: FuncCall, span: Option<Span>) -> Result<Transfo
             }
         }
         "sort" => {
-            let ([by], []) = unpack(func_call, [])?;
+            let ([by], []) = unpack(dbg!(func_call), [])?;
 
             let by = by
                 .coerce_to_vec()
                 .into_iter()
                 .map(|node| {
-                    let (column, direction) = match node.item {
-                        Item::Assign(named_expr) => {
-                            let direction = match named_expr.name.as_str() {
-                                "asc" => SortDirection::Asc,
-                                "desc" => SortDirection::Desc,
-                                _ => {
-                                    return Err(Error::new(Reason::Expected {
-                                        who: Some("sort".to_string()),
-                                        expected: "asc or desc".to_string(),
-                                        found: named_expr.name,
-                                    })
-                                    .with_span(node.span))
-                                }
-                            };
-                            (*named_expr.expr, direction)
+                    let (column, direction) = match &node.item {
+                        // If it's `+foo`, then it's two items; if `foo` then one.
+                        Item::Ident(_) => (node, SortDirection::default()),
+                        Item::Expr(nodes) => match &nodes[..] {
+                            [Node {
+                                item: Item::Operator(op),
+                                ..
+                            }, column]
+                            // We could use a guard, but we instead fall through
+                            // for a better error message.
+                            // if op == "+" || op == "-" =>
+                            => {
+                                let direction = match op.as_str() {
+                                    "+" => SortDirection::Asc,
+                                    "-" => SortDirection::Desc,
+                                    _ => {
+                                        return Err(Error::new(Reason::Expected {
+                                            who: Some("sort".to_string()),
+                                            expected: "+ or -".to_string(),
+                                            found: op.to_string(),
+                                        })
+                                        .with_span(node.span))
+                                    }
+                                };
+                                (column.clone(), direction)
+                            }
+                            _ => {
+                                return Err(Error::new(Reason::Expected {
+                                    who: Some("sort".to_string()),
+                                    expected: "column name, optionally prefixed with + or -"
+                                        .to_string(),
+                                    found: node.item.to_string(),
+                                })
+                                .with_span(node.span))
+                            }
+                        },
+                        _ => {
+                            // Copy-pasted from above; can we consolidate?
+                            return Err(Error::new(Reason::Expected {
+                                who: Some("sort".to_string()),
+                                expected: "column name, optionally prefixed with + or -"
+                                    .to_string(),
+                                found: node.item.to_string(),
+                            })
+                            .with_span(node.span));
                         }
-                        _ => (node, SortDirection::default()),
                     };
 
                     if matches!(column.item, Item::Ident(_)) {
@@ -314,9 +343,11 @@ mod tests {
         let query = parse(
             "
         from invoices
-        sort [amount]
-        # sort [-issued_at, desc=amount, num_of_articles]
-        # sort [-amount]
+        sort [issued_at, -amount, +num_of_articles]
+        sort issued_at
+        sort (-issued_at)
+        sort [issued_at]
+        sort [-issued_at]
         ",
         )
         .unwrap();
@@ -337,7 +368,33 @@ mod tests {
                   Sort:
                     - direction: Asc
                       column:
+                        Ident: issued_at
+                    - direction: Desc
+                      column:
                         Ident: amount
+                    - direction: Asc
+                      column:
+                        Ident: num_of_articles
+              - Transform:
+                  Sort:
+                    - direction: Asc
+                      column:
+                        Ident: issued_at
+              - Transform:
+                  Sort:
+                    - direction: Desc
+                      column:
+                        Ident: issued_at
+              - Transform:
+                  Sort:
+                    - direction: Asc
+                      column:
+                        Ident: issued_at
+              - Transform:
+                  Sort:
+                    - direction: Desc
+                      column:
+                        Ident: issued_at
         "###);
     }
 }

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__inline_pipeline.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__inline_pipeline.snap
@@ -12,7 +12,7 @@ expression: "parse_tree_of_str(\"(salary | percentile 50)\", Rule::nested_pipeli
         },
         inner: [
             Pair {
-                rule: expr,
+                rule: expr_call,
                 span: Span {
                     str: "salary ",
                     start: 1,
@@ -20,7 +20,7 @@ expression: "parse_tree_of_str(\"(salary | percentile 50)\", Rule::nested_pipeli
                 },
                 inner: [
                     Pair {
-                        rule: expr_compare,
+                        rule: expr,
                         span: Span {
                             str: "salary ",
                             start: 1,
@@ -28,7 +28,7 @@ expression: "parse_tree_of_str(\"(salary | percentile 50)\", Rule::nested_pipeli
                         },
                         inner: [
                             Pair {
-                                rule: expr_add,
+                                rule: expr_compare,
                                 span: Span {
                                     str: "salary ",
                                     start: 1,
@@ -36,7 +36,7 @@ expression: "parse_tree_of_str(\"(salary | percentile 50)\", Rule::nested_pipeli
                                 },
                                 inner: [
                                     Pair {
-                                        rule: expr_mul,
+                                        rule: expr_add,
                                         span: Span {
                                             str: "salary ",
                                             start: 1,
@@ -44,13 +44,23 @@ expression: "parse_tree_of_str(\"(salary | percentile 50)\", Rule::nested_pipeli
                                         },
                                         inner: [
                                             Pair {
-                                                rule: ident,
+                                                rule: expr_mul,
                                                 span: Span {
-                                                    str: "salary",
+                                                    str: "salary ",
                                                     start: 1,
-                                                    end: 7,
+                                                    end: 8,
                                                 },
-                                                inner: [],
+                                                inner: [
+                                                    Pair {
+                                                        rule: ident,
+                                                        span: Span {
+                                                            str: "salary",
+                                                            start: 1,
+                                                            end: 7,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                ],
                                             },
                                         ],
                                     },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-2.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-2.snap
@@ -61,7 +61,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: expr,
+                                                        rule: expr_call,
                                                         span: Span {
                                                             str: "a",
                                                             start: 8,
@@ -69,7 +69,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr_compare,
+                                                                rule: expr,
                                                                 span: Span {
                                                                     str: "a",
                                                                     start: 8,
@@ -77,7 +77,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_add,
+                                                                        rule: expr_compare,
                                                                         span: Span {
                                                                             str: "a",
                                                                             start: 8,
@@ -85,7 +85,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_mul,
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "a",
                                                                                     start: 8,
@@ -93,13 +93,23 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: ident,
+                                                                                        rule: expr_mul,
                                                                                         span: Span {
                                                                                             str: "a",
                                                                                             start: 8,
                                                                                             end: 9,
                                                                                         },
-                                                                                        inner: [],
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "a",
+                                                                                                    start: 8,
+                                                                                                    end: 9,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
                                                                                     },
                                                                                 ],
                                                                             },
@@ -110,7 +120,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                         ],
                                                     },
                                                     Pair {
-                                                        rule: expr,
+                                                        rule: expr_call,
                                                         span: Span {
                                                             str: "b",
                                                             start: 11,
@@ -118,7 +128,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr_compare,
+                                                                rule: expr,
                                                                 span: Span {
                                                                     str: "b",
                                                                     start: 11,
@@ -126,7 +136,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_add,
+                                                                        rule: expr_compare,
                                                                         span: Span {
                                                                             str: "b",
                                                                             start: 11,
@@ -134,7 +144,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_mul,
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "b",
                                                                                     start: 11,
@@ -142,13 +152,23 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: ident,
+                                                                                        rule: expr_mul,
                                                                                         span: Span {
                                                                                             str: "b",
                                                                                             start: 11,
                                                                                             end: 12,
                                                                                         },
-                                                                                        inner: [],
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "b",
+                                                                                                    start: 11,
+                                                                                                    end: 12,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
                                                                                     },
                                                                                 ],
                                                                             },
@@ -159,7 +179,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                         ],
                                                     },
                                                     Pair {
-                                                        rule: expr,
+                                                        rule: expr_call,
                                                         span: Span {
                                                             str: "c",
                                                             start: 14,
@@ -167,7 +187,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr_compare,
+                                                                rule: expr,
                                                                 span: Span {
                                                                     str: "c",
                                                                     start: 14,
@@ -175,7 +195,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_add,
+                                                                        rule: expr_compare,
                                                                         span: Span {
                                                                             str: "c",
                                                                             start: 14,
@@ -183,7 +203,7 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_mul,
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "c",
                                                                                     start: 14,
@@ -191,13 +211,23 @@ expression: "parse_tree_of_str(\"select [a, b, c]\", Rule::func_curry)?"
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: ident,
+                                                                                        rule: expr_mul,
                                                                                         span: Span {
                                                                                             str: "c",
                                                                                             start: 14,
                                                                                             end: 15,
                                                                                         },
-                                                                                        inner: [],
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "c",
+                                                                                                    start: 14,
+                                                                                                    end: 15,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
                                                                                     },
                                                                                 ],
                                                                             },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-3.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-3.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/src/parser.rs
-expression: "parse_tree_of_str(\"group [title, country] (\n                aggregate [sum salary]\n            )\",\n                  Rule::pipeline)?"
+expression: "parse_tree_of_str(\"group [title, country] (\n                aggregate [sum salary]\n            )\",\n        Rule::pipeline)?"
 ---
 [
     Pair {
@@ -69,7 +69,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr,
+                                                                rule: expr_call,
                                                                 span: Span {
                                                                     str: "title",
                                                                     start: 7,
@@ -77,7 +77,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_compare,
+                                                                        rule: expr,
                                                                         span: Span {
                                                                             str: "title",
                                                                             start: 7,
@@ -85,7 +85,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_add,
+                                                                                rule: expr_compare,
                                                                                 span: Span {
                                                                                     str: "title",
                                                                                     start: 7,
@@ -93,7 +93,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_mul,
+                                                                                        rule: expr_add,
                                                                                         span: Span {
                                                                                             str: "title",
                                                                                             start: 7,
@@ -101,13 +101,23 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: ident,
+                                                                                                rule: expr_mul,
                                                                                                 span: Span {
                                                                                                     str: "title",
                                                                                                     start: 7,
                                                                                                     end: 12,
                                                                                                 },
-                                                                                                inner: [],
+                                                                                                inner: [
+                                                                                                    Pair {
+                                                                                                        rule: ident,
+                                                                                                        span: Span {
+                                                                                                            str: "title",
+                                                                                                            start: 7,
+                                                                                                            end: 12,
+                                                                                                        },
+                                                                                                        inner: [],
+                                                                                                    },
+                                                                                                ],
                                                                                             },
                                                                                         ],
                                                                                     },
@@ -118,7 +128,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                 ],
                                                             },
                                                             Pair {
-                                                                rule: expr,
+                                                                rule: expr_call,
                                                                 span: Span {
                                                                     str: "country",
                                                                     start: 14,
@@ -126,7 +136,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_compare,
+                                                                        rule: expr,
                                                                         span: Span {
                                                                             str: "country",
                                                                             start: 14,
@@ -134,7 +144,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_add,
+                                                                                rule: expr_compare,
                                                                                 span: Span {
                                                                                     str: "country",
                                                                                     start: 14,
@@ -142,7 +152,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_mul,
+                                                                                        rule: expr_add,
                                                                                         span: Span {
                                                                                             str: "country",
                                                                                             start: 14,
@@ -150,13 +160,23 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: ident,
+                                                                                                rule: expr_mul,
                                                                                                 span: Span {
                                                                                                     str: "country",
                                                                                                     start: 14,
                                                                                                     end: 21,
                                                                                                 },
-                                                                                                inner: [],
+                                                                                                inner: [
+                                                                                                    Pair {
+                                                                                                        rule: ident,
+                                                                                                        span: Span {
+                                                                                                            str: "country",
+                                                                                                            start: 14,
+                                                                                                            end: 21,
+                                                                                                        },
+                                                                                                        inner: [],
+                                                                                                    },
+                                                                                                ],
                                                                                             },
                                                                                         ],
                                                                                     },
@@ -282,7 +302,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                                                 },
                                                                                                                 inner: [
                                                                                                                     Pair {
-                                                                                                                        rule: func_call,
+                                                                                                                        rule: expr_call,
                                                                                                                         span: Span {
                                                                                                                             str: "sum salary",
                                                                                                                             start: 52,
@@ -290,24 +310,24 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                                                         },
                                                                                                                         inner: [
                                                                                                                             Pair {
-                                                                                                                                rule: ident,
+                                                                                                                                rule: func_call,
                                                                                                                                 span: Span {
-                                                                                                                                    str: "sum",
+                                                                                                                                    str: "sum salary",
                                                                                                                                     start: 52,
-                                                                                                                                    end: 55,
-                                                                                                                                },
-                                                                                                                                inner: [],
-                                                                                                                            },
-                                                                                                                            Pair {
-                                                                                                                                rule: expr,
-                                                                                                                                span: Span {
-                                                                                                                                    str: "salary",
-                                                                                                                                    start: 56,
                                                                                                                                     end: 62,
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: expr_compare,
+                                                                                                                                        rule: ident,
+                                                                                                                                        span: Span {
+                                                                                                                                            str: "sum",
+                                                                                                                                            start: 52,
+                                                                                                                                            end: 55,
+                                                                                                                                        },
+                                                                                                                                        inner: [],
+                                                                                                                                    },
+                                                                                                                                    Pair {
+                                                                                                                                        rule: expr,
                                                                                                                                         span: Span {
                                                                                                                                             str: "salary",
                                                                                                                                             start: 56,
@@ -315,7 +335,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_add,
+                                                                                                                                                rule: expr_compare,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "salary",
                                                                                                                                                     start: 56,
@@ -323,7 +343,7 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_mul,
+                                                                                                                                                        rule: expr_add,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "salary",
                                                                                                                                                             start: 56,
@@ -331,13 +351,23 @@ expression: "parse_tree_of_str(\"group [title, country] (\n                aggre
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: ident,
+                                                                                                                                                                rule: expr_mul,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "salary",
                                                                                                                                                                     start: 56,
                                                                                                                                                                     end: 62,
                                                                                                                                                                 },
-                                                                                                                                                                inner: [],
+                                                                                                                                                                inner: [
+                                                                                                                                                                    Pair {
+                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        span: Span {
+                                                                                                                                                                            str: "salary",
+                                                                                                                                                                            start: 56,
+                                                                                                                                                                            end: 62,
+                                                                                                                                                                        },
+                                                                                                                                                                        inner: [],
+                                                                                                                                                                    },
+                                                                                                                                                                ],
                                                                                                                                                             },
                                                                                                                                                         ],
                                                                                                                                                     },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-5.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-5.snap
@@ -12,7 +12,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
         },
         inner: [
             Pair {
-                rule: expr,
+                rule: expr_call,
                 span: Span {
                     str: "a",
                     start: 1,
@@ -20,7 +20,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                 },
                 inner: [
                     Pair {
-                        rule: expr_compare,
+                        rule: expr,
                         span: Span {
                             str: "a",
                             start: 1,
@@ -28,7 +28,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                         },
                         inner: [
                             Pair {
-                                rule: expr_add,
+                                rule: expr_compare,
                                 span: Span {
                                     str: "a",
                                     start: 1,
@@ -36,7 +36,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                                 },
                                 inner: [
                                     Pair {
-                                        rule: expr_mul,
+                                        rule: expr_add,
                                         span: Span {
                                             str: "a",
                                             start: 1,
@@ -44,13 +44,23 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                                         },
                                         inner: [
                                             Pair {
-                                                rule: ident,
+                                                rule: expr_mul,
                                                 span: Span {
                                                     str: "a",
                                                     start: 1,
                                                     end: 2,
                                                 },
-                                                inner: [],
+                                                inner: [
+                                                    Pair {
+                                                        rule: ident,
+                                                        span: Span {
+                                                            str: "a",
+                                                            start: 1,
+                                                            end: 2,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                ],
                                             },
                                         ],
                                     },
@@ -61,7 +71,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                 ],
             },
             Pair {
-                rule: expr,
+                rule: expr_call,
                 span: Span {
                     str: "b",
                     start: 4,
@@ -69,7 +79,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                 },
                 inner: [
                     Pair {
-                        rule: expr_compare,
+                        rule: expr,
                         span: Span {
                             str: "b",
                             start: 4,
@@ -77,7 +87,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                         },
                         inner: [
                             Pair {
-                                rule: expr_add,
+                                rule: expr_compare,
                                 span: Span {
                                     str: "b",
                                     start: 4,
@@ -85,7 +95,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                                 },
                                 inner: [
                                     Pair {
-                                        rule: expr_mul,
+                                        rule: expr_add,
                                         span: Span {
                                             str: "b",
                                             start: 4,
@@ -93,13 +103,23 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                                         },
                                         inner: [
                                             Pair {
-                                                rule: ident,
+                                                rule: expr_mul,
                                                 span: Span {
                                                     str: "b",
                                                     start: 4,
                                                     end: 5,
                                                 },
-                                                inner: [],
+                                                inner: [
+                                                    Pair {
+                                                        rule: ident,
+                                                        span: Span {
+                                                            str: "b",
+                                                            start: 4,
+                                                            end: 5,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                ],
                                             },
                                         ],
                                     },
@@ -110,7 +130,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                 ],
             },
             Pair {
-                rule: expr,
+                rule: expr_call,
                 span: Span {
                     str: "c",
                     start: 7,
@@ -118,7 +138,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                 },
                 inner: [
                     Pair {
-                        rule: expr_compare,
+                        rule: expr,
                         span: Span {
                             str: "c",
                             start: 7,
@@ -126,7 +146,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                         },
                         inner: [
                             Pair {
-                                rule: expr_add,
+                                rule: expr_compare,
                                 span: Span {
                                     str: "c",
                                     start: 7,
@@ -134,7 +154,7 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                                 },
                                 inner: [
                                     Pair {
-                                        rule: expr_mul,
+                                        rule: expr_add,
                                         span: Span {
                                             str: "c",
                                             start: 7,
@@ -142,13 +162,23 @@ expression: "parse_tree_of_str(\"[a, b, c,]\", Rule::list)?"
                                         },
                                         inner: [
                                             Pair {
-                                                rule: ident,
+                                                rule: expr_mul,
                                                 span: Span {
                                                     str: "c",
                                                     start: 7,
                                                     end: 8,
                                                 },
-                                                inner: [],
+                                                inner: [
+                                                    Pair {
+                                                        rule: ident,
+                                                        span: Span {
+                                                            str: "c",
+                                                            start: 7,
+                                                            end: 8,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                ],
                                             },
                                         ],
                                     },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-6.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-6.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/src/parser.rs
-expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  gross_cost   = gross_salary + benefits_cost\n]\"#,\n                  Rule::list)?"
+expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  gross_cost   = gross_salary + benefits_cost\n]\"#,\n        Rule::list)?"
 ---
 [
     Pair {
@@ -29,7 +29,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                         inner: [],
                     },
                     Pair {
-                        rule: expr,
+                        rule: expr_call,
                         span: Span {
                             str: "salary + payroll_tax",
                             start: 19,
@@ -37,7 +37,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                         },
                         inner: [
                             Pair {
-                                rule: expr_compare,
+                                rule: expr,
                                 span: Span {
                                     str: "salary + payroll_tax",
                                     start: 19,
@@ -45,7 +45,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                                 },
                                 inner: [
                                     Pair {
-                                        rule: expr_add,
+                                        rule: expr_compare,
                                         span: Span {
                                             str: "salary + payroll_tax",
                                             start: 19,
@@ -53,49 +53,59 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                                         },
                                         inner: [
                                             Pair {
-                                                rule: expr_mul,
+                                                rule: expr_add,
                                                 span: Span {
-                                                    str: "salary ",
+                                                    str: "salary + payroll_tax",
                                                     start: 19,
-                                                    end: 26,
-                                                },
-                                                inner: [
-                                                    Pair {
-                                                        rule: ident,
-                                                        span: Span {
-                                                            str: "salary",
-                                                            start: 19,
-                                                            end: 25,
-                                                        },
-                                                        inner: [],
-                                                    },
-                                                ],
-                                            },
-                                            Pair {
-                                                rule: operator_add,
-                                                span: Span {
-                                                    str: "+",
-                                                    start: 26,
-                                                    end: 27,
-                                                },
-                                                inner: [],
-                                            },
-                                            Pair {
-                                                rule: expr_mul,
-                                                span: Span {
-                                                    str: "payroll_tax",
-                                                    start: 28,
                                                     end: 39,
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: ident,
+                                                        rule: expr_mul,
+                                                        span: Span {
+                                                            str: "salary ",
+                                                            start: 19,
+                                                            end: 26,
+                                                        },
+                                                        inner: [
+                                                            Pair {
+                                                                rule: ident,
+                                                                span: Span {
+                                                                    str: "salary",
+                                                                    start: 19,
+                                                                    end: 25,
+                                                                },
+                                                                inner: [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    Pair {
+                                                        rule: operator_add,
+                                                        span: Span {
+                                                            str: "+",
+                                                            start: 26,
+                                                            end: 27,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                    Pair {
+                                                        rule: expr_mul,
                                                         span: Span {
                                                             str: "payroll_tax",
                                                             start: 28,
                                                             end: 39,
                                                         },
-                                                        inner: [],
+                                                        inner: [
+                                                            Pair {
+                                                                rule: ident,
+                                                                span: Span {
+                                                                    str: "payroll_tax",
+                                                                    start: 28,
+                                                                    end: 39,
+                                                                },
+                                                                inner: [],
+                                                            },
+                                                        ],
                                                     },
                                                 ],
                                             },
@@ -125,7 +135,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                         inner: [],
                     },
                     Pair {
-                        rule: expr,
+                        rule: expr_call,
                         span: Span {
                             str: "gross_salary + benefits_cost",
                             start: 58,
@@ -133,7 +143,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                         },
                         inner: [
                             Pair {
-                                rule: expr_compare,
+                                rule: expr,
                                 span: Span {
                                     str: "gross_salary + benefits_cost",
                                     start: 58,
@@ -141,7 +151,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                                 },
                                 inner: [
                                     Pair {
-                                        rule: expr_add,
+                                        rule: expr_compare,
                                         span: Span {
                                             str: "gross_salary + benefits_cost",
                                             start: 58,
@@ -149,49 +159,59 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                                         },
                                         inner: [
                                             Pair {
-                                                rule: expr_mul,
+                                                rule: expr_add,
                                                 span: Span {
-                                                    str: "gross_salary ",
+                                                    str: "gross_salary + benefits_cost",
                                                     start: 58,
-                                                    end: 71,
-                                                },
-                                                inner: [
-                                                    Pair {
-                                                        rule: ident,
-                                                        span: Span {
-                                                            str: "gross_salary",
-                                                            start: 58,
-                                                            end: 70,
-                                                        },
-                                                        inner: [],
-                                                    },
-                                                ],
-                                            },
-                                            Pair {
-                                                rule: operator_add,
-                                                span: Span {
-                                                    str: "+",
-                                                    start: 71,
-                                                    end: 72,
-                                                },
-                                                inner: [],
-                                            },
-                                            Pair {
-                                                rule: expr_mul,
-                                                span: Span {
-                                                    str: "benefits_cost",
-                                                    start: 73,
                                                     end: 86,
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: ident,
+                                                        rule: expr_mul,
+                                                        span: Span {
+                                                            str: "gross_salary ",
+                                                            start: 58,
+                                                            end: 71,
+                                                        },
+                                                        inner: [
+                                                            Pair {
+                                                                rule: ident,
+                                                                span: Span {
+                                                                    str: "gross_salary",
+                                                                    start: 58,
+                                                                    end: 70,
+                                                                },
+                                                                inner: [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    Pair {
+                                                        rule: operator_add,
+                                                        span: Span {
+                                                            str: "+",
+                                                            start: 71,
+                                                            end: 72,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                    Pair {
+                                                        rule: expr_mul,
                                                         span: Span {
                                                             str: "benefits_cost",
                                                             start: 73,
                                                             end: 86,
                                                         },
-                                                        inner: [],
+                                                        inner: [
+                                                            Pair {
+                                                                rule: ident,
+                                                                span: Span {
+                                                                    str: "benefits_cost",
+                                                                    start: 73,
+                                                                    end: 86,
+                                                                },
+                                                                inner: [],
+                                                            },
+                                                        ],
                                                     },
                                                 ],
                                             },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-8.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-8.snap
@@ -110,7 +110,7 @@ expression: "parse_tree_of_str(\"join country [id==employee_id]\", Rule::func_cu
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: expr,
+                                                        rule: expr_call,
                                                         span: Span {
                                                             str: "id==employee_id",
                                                             start: 14,
@@ -118,7 +118,7 @@ expression: "parse_tree_of_str(\"join country [id==employee_id]\", Rule::func_cu
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr_compare,
+                                                                rule: expr,
                                                                 span: Span {
                                                                     str: "id==employee_id",
                                                                     start: 14,
@@ -126,15 +126,15 @@ expression: "parse_tree_of_str(\"join country [id==employee_id]\", Rule::func_cu
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_add,
+                                                                        rule: expr_compare,
                                                                         span: Span {
-                                                                            str: "id",
+                                                                            str: "id==employee_id",
                                                                             start: 14,
-                                                                            end: 16,
+                                                                            end: 29,
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_mul,
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "id",
                                                                                     start: 14,
@@ -142,37 +142,37 @@ expression: "parse_tree_of_str(\"join country [id==employee_id]\", Rule::func_cu
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: ident,
+                                                                                        rule: expr_mul,
                                                                                         span: Span {
                                                                                             str: "id",
                                                                                             start: 14,
                                                                                             end: 16,
                                                                                         },
-                                                                                        inner: [],
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "id",
+                                                                                                    start: 14,
+                                                                                                    end: 16,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
                                                                                     },
                                                                                 ],
                                                                             },
-                                                                        ],
-                                                                    },
-                                                                    Pair {
-                                                                        rule: operator_compare,
-                                                                        span: Span {
-                                                                            str: "==",
-                                                                            start: 16,
-                                                                            end: 18,
-                                                                        },
-                                                                        inner: [],
-                                                                    },
-                                                                    Pair {
-                                                                        rule: expr_add,
-                                                                        span: Span {
-                                                                            str: "employee_id",
-                                                                            start: 18,
-                                                                            end: 29,
-                                                                        },
-                                                                        inner: [
                                                                             Pair {
-                                                                                rule: expr_mul,
+                                                                                rule: operator_compare,
+                                                                                span: Span {
+                                                                                    str: "==",
+                                                                                    start: 16,
+                                                                                    end: 18,
+                                                                                },
+                                                                                inner: [],
+                                                                            },
+                                                                            Pair {
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "employee_id",
                                                                                     start: 18,
@@ -180,13 +180,23 @@ expression: "parse_tree_of_str(\"join country [id==employee_id]\", Rule::func_cu
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: ident,
+                                                                                        rule: expr_mul,
                                                                                         span: Span {
                                                                                             str: "employee_id",
                                                                                             start: 18,
                                                                                             end: 29,
                                                                                         },
-                                                                                        inner: [],
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "employee_id",
+                                                                                                    start: 18,
+                                                                                                    end: 29,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
                                                                                     },
                                                                                 ],
                                                                             },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-9.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-9.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/src/parser.rs
-expression: "parse_tree_of_str(\"join side:left country [id==employee_id]\",\n                  Rule::func_curry)?"
+expression: "parse_tree_of_str(\"join side:left country [id==employee_id]\",\n        Rule::func_curry)?"
 ---
 [
     Pair {
@@ -178,7 +178,7 @@ expression: "parse_tree_of_str(\"join side:left country [id==employee_id]\",\n  
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: expr,
+                                                        rule: expr_call,
                                                         span: Span {
                                                             str: "id==employee_id",
                                                             start: 24,
@@ -186,7 +186,7 @@ expression: "parse_tree_of_str(\"join side:left country [id==employee_id]\",\n  
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr_compare,
+                                                                rule: expr,
                                                                 span: Span {
                                                                     str: "id==employee_id",
                                                                     start: 24,
@@ -194,15 +194,15 @@ expression: "parse_tree_of_str(\"join side:left country [id==employee_id]\",\n  
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_add,
+                                                                        rule: expr_compare,
                                                                         span: Span {
-                                                                            str: "id",
+                                                                            str: "id==employee_id",
                                                                             start: 24,
-                                                                            end: 26,
+                                                                            end: 39,
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_mul,
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "id",
                                                                                     start: 24,
@@ -210,37 +210,37 @@ expression: "parse_tree_of_str(\"join side:left country [id==employee_id]\",\n  
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: ident,
+                                                                                        rule: expr_mul,
                                                                                         span: Span {
                                                                                             str: "id",
                                                                                             start: 24,
                                                                                             end: 26,
                                                                                         },
-                                                                                        inner: [],
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "id",
+                                                                                                    start: 24,
+                                                                                                    end: 26,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
                                                                                     },
                                                                                 ],
                                                                             },
-                                                                        ],
-                                                                    },
-                                                                    Pair {
-                                                                        rule: operator_compare,
-                                                                        span: Span {
-                                                                            str: "==",
-                                                                            start: 26,
-                                                                            end: 28,
-                                                                        },
-                                                                        inner: [],
-                                                                    },
-                                                                    Pair {
-                                                                        rule: expr_add,
-                                                                        span: Span {
-                                                                            str: "employee_id",
-                                                                            start: 28,
-                                                                            end: 39,
-                                                                        },
-                                                                        inner: [
                                                                             Pair {
-                                                                                rule: expr_mul,
+                                                                                rule: operator_compare,
+                                                                                span: Span {
+                                                                                    str: "==",
+                                                                                    start: 26,
+                                                                                    end: 28,
+                                                                                },
+                                                                                inner: [],
+                                                                            },
+                                                                            Pair {
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "employee_id",
                                                                                     start: 28,
@@ -248,13 +248,23 @@ expression: "parse_tree_of_str(\"join side:left country [id==employee_id]\",\n  
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: ident,
+                                                                                        rule: expr_mul,
                                                                                         span: Span {
                                                                                             str: "employee_id",
                                                                                             start: 28,
                                                                                             end: 39,
                                                                                         },
-                                                                                        inner: [],
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "employee_id",
+                                                                                                    start: 28,
+                                                                                                    end: 39,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
                                                                                     },
                                                                                 ],
                                                                             },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_list-7.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_list-7.snap
@@ -1,90 +1,62 @@
 ---
 source: prql-compiler/src/parser.rs
-expression: "parse_tree_of_str(r#\"[1 + 1, 2]\"#, Rule::list).unwrap()"
+expression: "parse_tree_of_str(r#\"[amount, +amount, -amount]\"#, Rule::list).unwrap()"
 ---
 [
     Pair {
         rule: list,
         span: Span {
-            str: "[1 + 1, 2]",
+            str: "[amount, +amount, -amount]",
             start: 0,
-            end: 10,
+            end: 26,
         },
         inner: [
             Pair {
                 rule: expr_call,
                 span: Span {
-                    str: "1 + 1",
+                    str: "amount",
                     start: 1,
-                    end: 6,
+                    end: 7,
                 },
                 inner: [
                     Pair {
                         rule: expr,
                         span: Span {
-                            str: "1 + 1",
+                            str: "amount",
                             start: 1,
-                            end: 6,
+                            end: 7,
                         },
                         inner: [
                             Pair {
                                 rule: expr_compare,
                                 span: Span {
-                                    str: "1 + 1",
+                                    str: "amount",
                                     start: 1,
-                                    end: 6,
+                                    end: 7,
                                 },
                                 inner: [
                                     Pair {
                                         rule: expr_add,
                                         span: Span {
-                                            str: "1 + 1",
+                                            str: "amount",
                                             start: 1,
-                                            end: 6,
+                                            end: 7,
                                         },
                                         inner: [
                                             Pair {
                                                 rule: expr_mul,
                                                 span: Span {
-                                                    str: "1 ",
+                                                    str: "amount",
                                                     start: 1,
-                                                    end: 3,
+                                                    end: 7,
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: number,
+                                                        rule: ident,
                                                         span: Span {
-                                                            str: "1",
+                                                            str: "amount",
                                                             start: 1,
-                                                            end: 2,
-                                                        },
-                                                        inner: [],
-                                                    },
-                                                ],
-                                            },
-                                            Pair {
-                                                rule: operator_add,
-                                                span: Span {
-                                                    str: "+",
-                                                    start: 3,
-                                                    end: 4,
-                                                },
-                                                inner: [],
-                                            },
-                                            Pair {
-                                                rule: expr_mul,
-                                                span: Span {
-                                                    str: "1",
-                                                    start: 5,
-                                                    end: 6,
-                                                },
-                                                inner: [
-                                                    Pair {
-                                                        rule: number,
-                                                        span: Span {
-                                                            str: "1",
-                                                            start: 5,
-                                                            end: 6,
+                                                            end: 7,
                                                         },
                                                         inner: [],
                                                     },
@@ -101,49 +73,126 @@ expression: "parse_tree_of_str(r#\"[1 + 1, 2]\"#, Rule::list).unwrap()"
             Pair {
                 rule: expr_call,
                 span: Span {
-                    str: "2",
-                    start: 8,
-                    end: 9,
+                    str: "+amount",
+                    start: 9,
+                    end: 16,
                 },
                 inner: [
                     Pair {
+                        rule: operator_add,
+                        span: Span {
+                            str: "+",
+                            start: 9,
+                            end: 10,
+                        },
+                        inner: [],
+                    },
+                    Pair {
                         rule: expr,
                         span: Span {
-                            str: "2",
-                            start: 8,
-                            end: 9,
+                            str: "amount",
+                            start: 10,
+                            end: 16,
                         },
                         inner: [
                             Pair {
                                 rule: expr_compare,
                                 span: Span {
-                                    str: "2",
-                                    start: 8,
-                                    end: 9,
+                                    str: "amount",
+                                    start: 10,
+                                    end: 16,
                                 },
                                 inner: [
                                     Pair {
                                         rule: expr_add,
                                         span: Span {
-                                            str: "2",
-                                            start: 8,
-                                            end: 9,
+                                            str: "amount",
+                                            start: 10,
+                                            end: 16,
                                         },
                                         inner: [
                                             Pair {
                                                 rule: expr_mul,
                                                 span: Span {
-                                                    str: "2",
-                                                    start: 8,
-                                                    end: 9,
+                                                    str: "amount",
+                                                    start: 10,
+                                                    end: 16,
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: number,
+                                                        rule: ident,
                                                         span: Span {
-                                                            str: "2",
-                                                            start: 8,
-                                                            end: 9,
+                                                            str: "amount",
+                                                            start: 10,
+                                                            end: 16,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            Pair {
+                rule: expr_call,
+                span: Span {
+                    str: "-amount",
+                    start: 18,
+                    end: 25,
+                },
+                inner: [
+                    Pair {
+                        rule: operator_add,
+                        span: Span {
+                            str: "-",
+                            start: 18,
+                            end: 19,
+                        },
+                        inner: [],
+                    },
+                    Pair {
+                        rule: expr,
+                        span: Span {
+                            str: "amount",
+                            start: 19,
+                            end: 25,
+                        },
+                        inner: [
+                            Pair {
+                                rule: expr_compare,
+                                span: Span {
+                                    str: "amount",
+                                    start: 19,
+                                    end: 25,
+                                },
+                                inner: [
+                                    Pair {
+                                        rule: expr_add,
+                                        span: Span {
+                                            str: "amount",
+                                            start: 19,
+                                            end: 25,
+                                        },
+                                        inner: [
+                                            Pair {
+                                                rule: expr_mul,
+                                                span: Span {
+                                                    str: "amount",
+                                                    start: 19,
+                                                    end: 25,
+                                                },
+                                                inner: [
+                                                    Pair {
+                                                        rule: ident,
+                                                        span: Span {
+                                                            str: "amount",
+                                                            start: 19,
+                                                            end: 25,
                                                         },
                                                         inner: [],
                                                     },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_pipeline_parse_tree-3.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_pipeline_parse_tree-3.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/src/parser.rs
-expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"                           # Each line transforms the previous result.\nderive [                                         # This adds columns / variables.\n  gross_salary = salary + payroll_tax,\n  gross_cost   = gross_salary + benefits_cost    # Variables can use other variables.\n]\nfilter gross_cost > 0\ngroup [title, country] (\n    aggregate [                                  # `by` are the columns to group by.\n        average salary,                          # These are aggregation calcs run on each group.\n        sum     salary,\n        average gross_salary,\n        sum     gross_salary,\n        average gross_cost,\n        sum_gross_cost = sum gross_cost,\n        count = count,\n    ]\n)\nsort sum_gross_cost\nfilter count > 200\ntake 20\n    \"#.trim(),\n                  Rule::pipeline).unwrap()"
+expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"                           # Each line transforms the previous result.\nderive [                                         # This adds columns / variables.\n  gross_salary = salary + payroll_tax,\n  gross_cost   = gross_salary + benefits_cost    # Variables can use other variables.\n]\nfilter gross_cost > 0\ngroup [title, country] (\n    aggregate [                                  # `by` are the columns to group by.\n        average salary,                          # These are aggregation calcs run on each group.\n        sum     salary,\n        average gross_salary,\n        sum     gross_salary,\n        average gross_cost,\n        sum_gross_cost = sum gross_cost,\n        count = count,\n    ]\n)\nsort sum_gross_cost\nfilter count > 200\ntake 20\n    \"#.trim(),\n        Rule::pipeline).unwrap()"
 ---
 [
     Pair {
@@ -270,7 +270,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                         inner: [],
                                                                     },
                                                                     Pair {
-                                                                        rule: expr,
+                                                                        rule: expr_call,
                                                                         span: Span {
                                                                             str: "salary + payroll_tax",
                                                                             start: 208,
@@ -278,7 +278,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_compare,
+                                                                                rule: expr,
                                                                                 span: Span {
                                                                                     str: "salary + payroll_tax",
                                                                                     start: 208,
@@ -286,7 +286,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_add,
+                                                                                        rule: expr_compare,
                                                                                         span: Span {
                                                                                             str: "salary + payroll_tax",
                                                                                             start: 208,
@@ -294,49 +294,59 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: expr_mul,
+                                                                                                rule: expr_add,
                                                                                                 span: Span {
-                                                                                                    str: "salary ",
+                                                                                                    str: "salary + payroll_tax",
                                                                                                     start: 208,
-                                                                                                    end: 215,
-                                                                                                },
-                                                                                                inner: [
-                                                                                                    Pair {
-                                                                                                        rule: ident,
-                                                                                                        span: Span {
-                                                                                                            str: "salary",
-                                                                                                            start: 208,
-                                                                                                            end: 214,
-                                                                                                        },
-                                                                                                        inner: [],
-                                                                                                    },
-                                                                                                ],
-                                                                                            },
-                                                                                            Pair {
-                                                                                                rule: operator_add,
-                                                                                                span: Span {
-                                                                                                    str: "+",
-                                                                                                    start: 215,
-                                                                                                    end: 216,
-                                                                                                },
-                                                                                                inner: [],
-                                                                                            },
-                                                                                            Pair {
-                                                                                                rule: expr_mul,
-                                                                                                span: Span {
-                                                                                                    str: "payroll_tax",
-                                                                                                    start: 217,
                                                                                                     end: 228,
                                                                                                 },
                                                                                                 inner: [
                                                                                                     Pair {
-                                                                                                        rule: ident,
+                                                                                                        rule: expr_mul,
+                                                                                                        span: Span {
+                                                                                                            str: "salary ",
+                                                                                                            start: 208,
+                                                                                                            end: 215,
+                                                                                                        },
+                                                                                                        inner: [
+                                                                                                            Pair {
+                                                                                                                rule: ident,
+                                                                                                                span: Span {
+                                                                                                                    str: "salary",
+                                                                                                                    start: 208,
+                                                                                                                    end: 214,
+                                                                                                                },
+                                                                                                                inner: [],
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    },
+                                                                                                    Pair {
+                                                                                                        rule: operator_add,
+                                                                                                        span: Span {
+                                                                                                            str: "+",
+                                                                                                            start: 215,
+                                                                                                            end: 216,
+                                                                                                        },
+                                                                                                        inner: [],
+                                                                                                    },
+                                                                                                    Pair {
+                                                                                                        rule: expr_mul,
                                                                                                         span: Span {
                                                                                                             str: "payroll_tax",
                                                                                                             start: 217,
                                                                                                             end: 228,
                                                                                                         },
-                                                                                                        inner: [],
+                                                                                                        inner: [
+                                                                                                            Pair {
+                                                                                                                rule: ident,
+                                                                                                                span: Span {
+                                                                                                                    str: "payroll_tax",
+                                                                                                                    start: 217,
+                                                                                                                    end: 228,
+                                                                                                                },
+                                                                                                                inner: [],
+                                                                                                            },
+                                                                                                        ],
                                                                                                     },
                                                                                                 ],
                                                                                             },
@@ -366,7 +376,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                         inner: [],
                                                                     },
                                                                     Pair {
-                                                                        rule: expr,
+                                                                        rule: expr_call,
                                                                         span: Span {
                                                                             str: "gross_salary + benefits_cost    # Variables can use other variables.",
                                                                             start: 247,
@@ -374,7 +384,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_compare,
+                                                                                rule: expr,
                                                                                 span: Span {
                                                                                     str: "gross_salary + benefits_cost    # Variables can use other variables.",
                                                                                     start: 247,
@@ -382,7 +392,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_add,
+                                                                                        rule: expr_compare,
                                                                                         span: Span {
                                                                                             str: "gross_salary + benefits_cost    # Variables can use other variables.",
                                                                                             start: 247,
@@ -390,49 +400,59 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: expr_mul,
+                                                                                                rule: expr_add,
                                                                                                 span: Span {
-                                                                                                    str: "gross_salary ",
+                                                                                                    str: "gross_salary + benefits_cost    # Variables can use other variables.",
                                                                                                     start: 247,
-                                                                                                    end: 260,
-                                                                                                },
-                                                                                                inner: [
-                                                                                                    Pair {
-                                                                                                        rule: ident,
-                                                                                                        span: Span {
-                                                                                                            str: "gross_salary",
-                                                                                                            start: 247,
-                                                                                                            end: 259,
-                                                                                                        },
-                                                                                                        inner: [],
-                                                                                                    },
-                                                                                                ],
-                                                                                            },
-                                                                                            Pair {
-                                                                                                rule: operator_add,
-                                                                                                span: Span {
-                                                                                                    str: "+",
-                                                                                                    start: 260,
-                                                                                                    end: 261,
-                                                                                                },
-                                                                                                inner: [],
-                                                                                            },
-                                                                                            Pair {
-                                                                                                rule: expr_mul,
-                                                                                                span: Span {
-                                                                                                    str: "benefits_cost    # Variables can use other variables.",
-                                                                                                    start: 262,
                                                                                                     end: 315,
                                                                                                 },
                                                                                                 inner: [
                                                                                                     Pair {
-                                                                                                        rule: ident,
+                                                                                                        rule: expr_mul,
                                                                                                         span: Span {
-                                                                                                            str: "benefits_cost",
-                                                                                                            start: 262,
-                                                                                                            end: 275,
+                                                                                                            str: "gross_salary ",
+                                                                                                            start: 247,
+                                                                                                            end: 260,
+                                                                                                        },
+                                                                                                        inner: [
+                                                                                                            Pair {
+                                                                                                                rule: ident,
+                                                                                                                span: Span {
+                                                                                                                    str: "gross_salary",
+                                                                                                                    start: 247,
+                                                                                                                    end: 259,
+                                                                                                                },
+                                                                                                                inner: [],
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    },
+                                                                                                    Pair {
+                                                                                                        rule: operator_add,
+                                                                                                        span: Span {
+                                                                                                            str: "+",
+                                                                                                            start: 260,
+                                                                                                            end: 261,
                                                                                                         },
                                                                                                         inner: [],
+                                                                                                    },
+                                                                                                    Pair {
+                                                                                                        rule: expr_mul,
+                                                                                                        span: Span {
+                                                                                                            str: "benefits_cost    # Variables can use other variables.",
+                                                                                                            start: 262,
+                                                                                                            end: 315,
+                                                                                                        },
+                                                                                                        inner: [
+                                                                                                            Pair {
+                                                                                                                rule: ident,
+                                                                                                                span: Span {
+                                                                                                                    str: "benefits_cost",
+                                                                                                                    start: 262,
+                                                                                                                    end: 275,
+                                                                                                                },
+                                                                                                                inner: [],
+                                                                                                            },
+                                                                                                        ],
                                                                                                     },
                                                                                                 ],
                                                                                             },
@@ -620,7 +640,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr,
+                                                                rule: expr_call,
                                                                 span: Span {
                                                                     str: "title",
                                                                     start: 347,
@@ -628,7 +648,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_compare,
+                                                                        rule: expr,
                                                                         span: Span {
                                                                             str: "title",
                                                                             start: 347,
@@ -636,7 +656,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_add,
+                                                                                rule: expr_compare,
                                                                                 span: Span {
                                                                                     str: "title",
                                                                                     start: 347,
@@ -644,7 +664,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_mul,
+                                                                                        rule: expr_add,
                                                                                         span: Span {
                                                                                             str: "title",
                                                                                             start: 347,
@@ -652,13 +672,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: ident,
+                                                                                                rule: expr_mul,
                                                                                                 span: Span {
                                                                                                     str: "title",
                                                                                                     start: 347,
                                                                                                     end: 352,
                                                                                                 },
-                                                                                                inner: [],
+                                                                                                inner: [
+                                                                                                    Pair {
+                                                                                                        rule: ident,
+                                                                                                        span: Span {
+                                                                                                            str: "title",
+                                                                                                            start: 347,
+                                                                                                            end: 352,
+                                                                                                        },
+                                                                                                        inner: [],
+                                                                                                    },
+                                                                                                ],
                                                                                             },
                                                                                         ],
                                                                                     },
@@ -669,7 +699,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                 ],
                                                             },
                                                             Pair {
-                                                                rule: expr,
+                                                                rule: expr_call,
                                                                 span: Span {
                                                                     str: "country",
                                                                     start: 354,
@@ -677,7 +707,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_compare,
+                                                                        rule: expr,
                                                                         span: Span {
                                                                             str: "country",
                                                                             start: 354,
@@ -685,7 +715,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_add,
+                                                                                rule: expr_compare,
                                                                                 span: Span {
                                                                                     str: "country",
                                                                                     start: 354,
@@ -693,7 +723,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_mul,
+                                                                                        rule: expr_add,
                                                                                         span: Span {
                                                                                             str: "country",
                                                                                             start: 354,
@@ -701,13 +731,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: ident,
+                                                                                                rule: expr_mul,
                                                                                                 span: Span {
                                                                                                     str: "country",
                                                                                                     start: 354,
                                                                                                     end: 361,
                                                                                                 },
-                                                                                                inner: [],
+                                                                                                inner: [
+                                                                                                    Pair {
+                                                                                                        rule: ident,
+                                                                                                        span: Span {
+                                                                                                            str: "country",
+                                                                                                            start: 354,
+                                                                                                            end: 361,
+                                                                                                        },
+                                                                                                        inner: [],
+                                                                                                    },
+                                                                                                ],
                                                                                             },
                                                                                         ],
                                                                                     },
@@ -833,7 +873,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                 },
                                                                                                                 inner: [
                                                                                                                     Pair {
-                                                                                                                        rule: func_call,
+                                                                                                                        rule: expr_call,
                                                                                                                         span: Span {
                                                                                                                             str: "average salary",
                                                                                                                             start: 458,
@@ -841,24 +881,24 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         },
                                                                                                                         inner: [
                                                                                                                             Pair {
-                                                                                                                                rule: ident,
+                                                                                                                                rule: func_call,
                                                                                                                                 span: Span {
-                                                                                                                                    str: "average",
+                                                                                                                                    str: "average salary",
                                                                                                                                     start: 458,
-                                                                                                                                    end: 465,
-                                                                                                                                },
-                                                                                                                                inner: [],
-                                                                                                                            },
-                                                                                                                            Pair {
-                                                                                                                                rule: expr,
-                                                                                                                                span: Span {
-                                                                                                                                    str: "salary",
-                                                                                                                                    start: 466,
                                                                                                                                     end: 472,
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: expr_compare,
+                                                                                                                                        rule: ident,
+                                                                                                                                        span: Span {
+                                                                                                                                            str: "average",
+                                                                                                                                            start: 458,
+                                                                                                                                            end: 465,
+                                                                                                                                        },
+                                                                                                                                        inner: [],
+                                                                                                                                    },
+                                                                                                                                    Pair {
+                                                                                                                                        rule: expr,
                                                                                                                                         span: Span {
                                                                                                                                             str: "salary",
                                                                                                                                             start: 466,
@@ -866,7 +906,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_add,
+                                                                                                                                                rule: expr_compare,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "salary",
                                                                                                                                                     start: 466,
@@ -874,7 +914,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_mul,
+                                                                                                                                                        rule: expr_add,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "salary",
                                                                                                                                                             start: 466,
@@ -882,13 +922,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: ident,
+                                                                                                                                                                rule: expr_mul,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "salary",
                                                                                                                                                                     start: 466,
                                                                                                                                                                     end: 472,
                                                                                                                                                                 },
-                                                                                                                                                                inner: [],
+                                                                                                                                                                inner: [
+                                                                                                                                                                    Pair {
+                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        span: Span {
+                                                                                                                                                                            str: "salary",
+                                                                                                                                                                            start: 466,
+                                                                                                                                                                            end: 472,
+                                                                                                                                                                        },
+                                                                                                                                                                        inner: [],
+                                                                                                                                                                    },
+                                                                                                                                                                ],
                                                                                                                                                             },
                                                                                                                                                         ],
                                                                                                                                                     },
@@ -901,7 +951,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         ],
                                                                                                                     },
                                                                                                                     Pair {
-                                                                                                                        rule: func_call,
+                                                                                                                        rule: expr_call,
                                                                                                                         span: Span {
                                                                                                                             str: "sum     salary",
                                                                                                                             start: 556,
@@ -909,24 +959,24 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         },
                                                                                                                         inner: [
                                                                                                                             Pair {
-                                                                                                                                rule: ident,
+                                                                                                                                rule: func_call,
                                                                                                                                 span: Span {
-                                                                                                                                    str: "sum",
+                                                                                                                                    str: "sum     salary",
                                                                                                                                     start: 556,
-                                                                                                                                    end: 559,
-                                                                                                                                },
-                                                                                                                                inner: [],
-                                                                                                                            },
-                                                                                                                            Pair {
-                                                                                                                                rule: expr,
-                                                                                                                                span: Span {
-                                                                                                                                    str: "salary",
-                                                                                                                                    start: 564,
                                                                                                                                     end: 570,
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: expr_compare,
+                                                                                                                                        rule: ident,
+                                                                                                                                        span: Span {
+                                                                                                                                            str: "sum",
+                                                                                                                                            start: 556,
+                                                                                                                                            end: 559,
+                                                                                                                                        },
+                                                                                                                                        inner: [],
+                                                                                                                                    },
+                                                                                                                                    Pair {
+                                                                                                                                        rule: expr,
                                                                                                                                         span: Span {
                                                                                                                                             str: "salary",
                                                                                                                                             start: 564,
@@ -934,7 +984,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_add,
+                                                                                                                                                rule: expr_compare,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "salary",
                                                                                                                                                     start: 564,
@@ -942,7 +992,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_mul,
+                                                                                                                                                        rule: expr_add,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "salary",
                                                                                                                                                             start: 564,
@@ -950,13 +1000,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: ident,
+                                                                                                                                                                rule: expr_mul,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "salary",
                                                                                                                                                                     start: 564,
                                                                                                                                                                     end: 570,
                                                                                                                                                                 },
-                                                                                                                                                                inner: [],
+                                                                                                                                                                inner: [
+                                                                                                                                                                    Pair {
+                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        span: Span {
+                                                                                                                                                                            str: "salary",
+                                                                                                                                                                            start: 564,
+                                                                                                                                                                            end: 570,
+                                                                                                                                                                        },
+                                                                                                                                                                        inner: [],
+                                                                                                                                                                    },
+                                                                                                                                                                ],
                                                                                                                                                             },
                                                                                                                                                         ],
                                                                                                                                                     },
@@ -969,7 +1029,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         ],
                                                                                                                     },
                                                                                                                     Pair {
-                                                                                                                        rule: func_call,
+                                                                                                                        rule: expr_call,
                                                                                                                         span: Span {
                                                                                                                             str: "average gross_salary",
                                                                                                                             start: 580,
@@ -977,24 +1037,24 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         },
                                                                                                                         inner: [
                                                                                                                             Pair {
-                                                                                                                                rule: ident,
+                                                                                                                                rule: func_call,
                                                                                                                                 span: Span {
-                                                                                                                                    str: "average",
+                                                                                                                                    str: "average gross_salary",
                                                                                                                                     start: 580,
-                                                                                                                                    end: 587,
-                                                                                                                                },
-                                                                                                                                inner: [],
-                                                                                                                            },
-                                                                                                                            Pair {
-                                                                                                                                rule: expr,
-                                                                                                                                span: Span {
-                                                                                                                                    str: "gross_salary",
-                                                                                                                                    start: 588,
                                                                                                                                     end: 600,
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: expr_compare,
+                                                                                                                                        rule: ident,
+                                                                                                                                        span: Span {
+                                                                                                                                            str: "average",
+                                                                                                                                            start: 580,
+                                                                                                                                            end: 587,
+                                                                                                                                        },
+                                                                                                                                        inner: [],
+                                                                                                                                    },
+                                                                                                                                    Pair {
+                                                                                                                                        rule: expr,
                                                                                                                                         span: Span {
                                                                                                                                             str: "gross_salary",
                                                                                                                                             start: 588,
@@ -1002,7 +1062,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_add,
+                                                                                                                                                rule: expr_compare,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "gross_salary",
                                                                                                                                                     start: 588,
@@ -1010,7 +1070,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_mul,
+                                                                                                                                                        rule: expr_add,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "gross_salary",
                                                                                                                                                             start: 588,
@@ -1018,13 +1078,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: ident,
+                                                                                                                                                                rule: expr_mul,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "gross_salary",
                                                                                                                                                                     start: 588,
                                                                                                                                                                     end: 600,
                                                                                                                                                                 },
-                                                                                                                                                                inner: [],
+                                                                                                                                                                inner: [
+                                                                                                                                                                    Pair {
+                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        span: Span {
+                                                                                                                                                                            str: "gross_salary",
+                                                                                                                                                                            start: 588,
+                                                                                                                                                                            end: 600,
+                                                                                                                                                                        },
+                                                                                                                                                                        inner: [],
+                                                                                                                                                                    },
+                                                                                                                                                                ],
                                                                                                                                                             },
                                                                                                                                                         ],
                                                                                                                                                     },
@@ -1037,7 +1107,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         ],
                                                                                                                     },
                                                                                                                     Pair {
-                                                                                                                        rule: func_call,
+                                                                                                                        rule: expr_call,
                                                                                                                         span: Span {
                                                                                                                             str: "sum     gross_salary",
                                                                                                                             start: 610,
@@ -1045,24 +1115,24 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         },
                                                                                                                         inner: [
                                                                                                                             Pair {
-                                                                                                                                rule: ident,
+                                                                                                                                rule: func_call,
                                                                                                                                 span: Span {
-                                                                                                                                    str: "sum",
+                                                                                                                                    str: "sum     gross_salary",
                                                                                                                                     start: 610,
-                                                                                                                                    end: 613,
-                                                                                                                                },
-                                                                                                                                inner: [],
-                                                                                                                            },
-                                                                                                                            Pair {
-                                                                                                                                rule: expr,
-                                                                                                                                span: Span {
-                                                                                                                                    str: "gross_salary",
-                                                                                                                                    start: 618,
                                                                                                                                     end: 630,
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: expr_compare,
+                                                                                                                                        rule: ident,
+                                                                                                                                        span: Span {
+                                                                                                                                            str: "sum",
+                                                                                                                                            start: 610,
+                                                                                                                                            end: 613,
+                                                                                                                                        },
+                                                                                                                                        inner: [],
+                                                                                                                                    },
+                                                                                                                                    Pair {
+                                                                                                                                        rule: expr,
                                                                                                                                         span: Span {
                                                                                                                                             str: "gross_salary",
                                                                                                                                             start: 618,
@@ -1070,7 +1140,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_add,
+                                                                                                                                                rule: expr_compare,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "gross_salary",
                                                                                                                                                     start: 618,
@@ -1078,7 +1148,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_mul,
+                                                                                                                                                        rule: expr_add,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "gross_salary",
                                                                                                                                                             start: 618,
@@ -1086,13 +1156,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: ident,
+                                                                                                                                                                rule: expr_mul,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "gross_salary",
                                                                                                                                                                     start: 618,
                                                                                                                                                                     end: 630,
                                                                                                                                                                 },
-                                                                                                                                                                inner: [],
+                                                                                                                                                                inner: [
+                                                                                                                                                                    Pair {
+                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        span: Span {
+                                                                                                                                                                            str: "gross_salary",
+                                                                                                                                                                            start: 618,
+                                                                                                                                                                            end: 630,
+                                                                                                                                                                        },
+                                                                                                                                                                        inner: [],
+                                                                                                                                                                    },
+                                                                                                                                                                ],
                                                                                                                                                             },
                                                                                                                                                         ],
                                                                                                                                                     },
@@ -1105,7 +1185,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         ],
                                                                                                                     },
                                                                                                                     Pair {
-                                                                                                                        rule: func_call,
+                                                                                                                        rule: expr_call,
                                                                                                                         span: Span {
                                                                                                                             str: "average gross_cost",
                                                                                                                             start: 640,
@@ -1113,24 +1193,24 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                         },
                                                                                                                         inner: [
                                                                                                                             Pair {
-                                                                                                                                rule: ident,
+                                                                                                                                rule: func_call,
                                                                                                                                 span: Span {
-                                                                                                                                    str: "average",
+                                                                                                                                    str: "average gross_cost",
                                                                                                                                     start: 640,
-                                                                                                                                    end: 647,
-                                                                                                                                },
-                                                                                                                                inner: [],
-                                                                                                                            },
-                                                                                                                            Pair {
-                                                                                                                                rule: expr,
-                                                                                                                                span: Span {
-                                                                                                                                    str: "gross_cost",
-                                                                                                                                    start: 648,
                                                                                                                                     end: 658,
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: expr_compare,
+                                                                                                                                        rule: ident,
+                                                                                                                                        span: Span {
+                                                                                                                                            str: "average",
+                                                                                                                                            start: 640,
+                                                                                                                                            end: 647,
+                                                                                                                                        },
+                                                                                                                                        inner: [],
+                                                                                                                                    },
+                                                                                                                                    Pair {
+                                                                                                                                        rule: expr,
                                                                                                                                         span: Span {
                                                                                                                                             str: "gross_cost",
                                                                                                                                             start: 648,
@@ -1138,7 +1218,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_add,
+                                                                                                                                                rule: expr_compare,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "gross_cost",
                                                                                                                                                     start: 648,
@@ -1146,7 +1226,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_mul,
+                                                                                                                                                        rule: expr_add,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "gross_cost",
                                                                                                                                                             start: 648,
@@ -1154,13 +1234,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: ident,
+                                                                                                                                                                rule: expr_mul,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "gross_cost",
                                                                                                                                                                     start: 648,
                                                                                                                                                                     end: 658,
                                                                                                                                                                 },
-                                                                                                                                                                inner: [],
+                                                                                                                                                                inner: [
+                                                                                                                                                                    Pair {
+                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        span: Span {
+                                                                                                                                                                            str: "gross_cost",
+                                                                                                                                                                            start: 648,
+                                                                                                                                                                            end: 658,
+                                                                                                                                                                        },
+                                                                                                                                                                        inner: [],
+                                                                                                                                                                    },
+                                                                                                                                                                ],
                                                                                                                                                             },
                                                                                                                                                         ],
                                                                                                                                                     },
@@ -1190,7 +1280,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                 inner: [],
                                                                                                                             },
                                                                                                                             Pair {
-                                                                                                                                rule: func_call,
+                                                                                                                                rule: expr_call,
                                                                                                                                 span: Span {
                                                                                                                                     str: "sum gross_cost",
                                                                                                                                     start: 685,
@@ -1198,24 +1288,24 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: ident,
+                                                                                                                                        rule: func_call,
                                                                                                                                         span: Span {
-                                                                                                                                            str: "sum",
+                                                                                                                                            str: "sum gross_cost",
                                                                                                                                             start: 685,
-                                                                                                                                            end: 688,
-                                                                                                                                        },
-                                                                                                                                        inner: [],
-                                                                                                                                    },
-                                                                                                                                    Pair {
-                                                                                                                                        rule: expr,
-                                                                                                                                        span: Span {
-                                                                                                                                            str: "gross_cost",
-                                                                                                                                            start: 689,
                                                                                                                                             end: 699,
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_compare,
+                                                                                                                                                rule: ident,
+                                                                                                                                                span: Span {
+                                                                                                                                                    str: "sum",
+                                                                                                                                                    start: 685,
+                                                                                                                                                    end: 688,
+                                                                                                                                                },
+                                                                                                                                                inner: [],
+                                                                                                                                            },
+                                                                                                                                            Pair {
+                                                                                                                                                rule: expr,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "gross_cost",
                                                                                                                                                     start: 689,
@@ -1223,7 +1313,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_add,
+                                                                                                                                                        rule: expr_compare,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "gross_cost",
                                                                                                                                                             start: 689,
@@ -1231,7 +1321,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: expr_mul,
+                                                                                                                                                                rule: expr_add,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "gross_cost",
                                                                                                                                                                     start: 689,
@@ -1239,13 +1329,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                                 },
                                                                                                                                                                 inner: [
                                                                                                                                                                     Pair {
-                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        rule: expr_mul,
                                                                                                                                                                         span: Span {
                                                                                                                                                                             str: "gross_cost",
                                                                                                                                                                             start: 689,
                                                                                                                                                                             end: 699,
                                                                                                                                                                         },
-                                                                                                                                                                        inner: [],
+                                                                                                                                                                        inner: [
+                                                                                                                                                                            Pair {
+                                                                                                                                                                                rule: ident,
+                                                                                                                                                                                span: Span {
+                                                                                                                                                                                    str: "gross_cost",
+                                                                                                                                                                                    start: 689,
+                                                                                                                                                                                    end: 699,
+                                                                                                                                                                                },
+                                                                                                                                                                                inner: [],
+                                                                                                                                                                            },
+                                                                                                                                                                        ],
                                                                                                                                                                     },
                                                                                                                                                                 ],
                                                                                                                                                             },
@@ -1277,7 +1377,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                 inner: [],
                                                                                                                             },
                                                                                                                             Pair {
-                                                                                                                                rule: expr,
+                                                                                                                                rule: expr_call,
                                                                                                                                 span: Span {
                                                                                                                                     str: "count",
                                                                                                                                     start: 717,
@@ -1285,7 +1385,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                 },
                                                                                                                                 inner: [
                                                                                                                                     Pair {
-                                                                                                                                        rule: expr_compare,
+                                                                                                                                        rule: expr,
                                                                                                                                         span: Span {
                                                                                                                                             str: "count",
                                                                                                                                             start: 717,
@@ -1293,7 +1393,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                         },
                                                                                                                                         inner: [
                                                                                                                                             Pair {
-                                                                                                                                                rule: expr_add,
+                                                                                                                                                rule: expr_compare,
                                                                                                                                                 span: Span {
                                                                                                                                                     str: "count",
                                                                                                                                                     start: 717,
@@ -1301,7 +1401,7 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                 },
                                                                                                                                                 inner: [
                                                                                                                                                     Pair {
-                                                                                                                                                        rule: expr_mul,
+                                                                                                                                                        rule: expr_add,
                                                                                                                                                         span: Span {
                                                                                                                                                             str: "count",
                                                                                                                                                             start: 717,
@@ -1309,13 +1409,23 @@ expression: "parse_tree_of_str(r#\"\nfrom employees\nfilter country == \"USA\"  
                                                                                                                                                         },
                                                                                                                                                         inner: [
                                                                                                                                                             Pair {
-                                                                                                                                                                rule: ident,
+                                                                                                                                                                rule: expr_mul,
                                                                                                                                                                 span: Span {
                                                                                                                                                                     str: "count",
                                                                                                                                                                     start: 717,
                                                                                                                                                                     end: 722,
                                                                                                                                                                 },
-                                                                                                                                                                inner: [],
+                                                                                                                                                                inner: [
+                                                                                                                                                                    Pair {
+                                                                                                                                                                        rule: ident,
+                                                                                                                                                                        span: Span {
+                                                                                                                                                                            str: "count",
+                                                                                                                                                                            start: 717,
+                                                                                                                                                                            end: 722,
+                                                                                                                                                                        },
+                                                                                                                                                                        inner: [],
+                                                                                                                                                                    },
+                                                                                                                                                                ],
                                                                                                                                                             },
                                                                                                                                                         ],
                                                                                                                                                     },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_pipeline_parse_tree.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_pipeline_parse_tree.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/src/parser.rs
-expression: "parse_tree_of_str(r#\"\n            from employees\n            select [a, b]\n            \"#.trim(),\n                  Rule::pipeline).unwrap()"
+expression: "parse_tree_of_str(r#\"\n            from employees\n            select [a, b]\n            \"#.trim(),\n        Rule::pipeline).unwrap()"
 ---
 [
     Pair {
@@ -137,7 +137,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr,
+                                                                rule: expr_call,
                                                                 span: Span {
                                                                     str: "a",
                                                                     start: 35,
@@ -145,7 +145,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_compare,
+                                                                        rule: expr,
                                                                         span: Span {
                                                                             str: "a",
                                                                             start: 35,
@@ -153,7 +153,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_add,
+                                                                                rule: expr_compare,
                                                                                 span: Span {
                                                                                     str: "a",
                                                                                     start: 35,
@@ -161,7 +161,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_mul,
+                                                                                        rule: expr_add,
                                                                                         span: Span {
                                                                                             str: "a",
                                                                                             start: 35,
@@ -169,13 +169,23 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: ident,
+                                                                                                rule: expr_mul,
                                                                                                 span: Span {
                                                                                                     str: "a",
                                                                                                     start: 35,
                                                                                                     end: 36,
                                                                                                 },
-                                                                                                inner: [],
+                                                                                                inner: [
+                                                                                                    Pair {
+                                                                                                        rule: ident,
+                                                                                                        span: Span {
+                                                                                                            str: "a",
+                                                                                                            start: 35,
+                                                                                                            end: 36,
+                                                                                                        },
+                                                                                                        inner: [],
+                                                                                                    },
+                                                                                                ],
                                                                                             },
                                                                                         ],
                                                                                     },
@@ -186,7 +196,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                 ],
                                                             },
                                                             Pair {
-                                                                rule: expr,
+                                                                rule: expr_call,
                                                                 span: Span {
                                                                     str: "b",
                                                                     start: 38,
@@ -194,7 +204,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_compare,
+                                                                        rule: expr,
                                                                         span: Span {
                                                                             str: "b",
                                                                             start: 38,
@@ -202,7 +212,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: expr_add,
+                                                                                rule: expr_compare,
                                                                                 span: Span {
                                                                                     str: "b",
                                                                                     start: 38,
@@ -210,7 +220,7 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                                 },
                                                                                 inner: [
                                                                                     Pair {
-                                                                                        rule: expr_mul,
+                                                                                        rule: expr_add,
                                                                                         span: Span {
                                                                                             str: "b",
                                                                                             start: 38,
@@ -218,13 +228,23 @@ expression: "parse_tree_of_str(r#\"\n            from employees\n            sel
                                                                                         },
                                                                                         inner: [
                                                                                             Pair {
-                                                                                                rule: ident,
+                                                                                                rule: expr_mul,
                                                                                                 span: Span {
                                                                                                     str: "b",
                                                                                                     start: 38,
                                                                                                     end: 39,
                                                                                                 },
-                                                                                                inner: [],
+                                                                                                inner: [
+                                                                                                    Pair {
+                                                                                                        rule: ident,
+                                                                                                        span: Span {
+                                                                                                            str: "b",
+                                                                                                            start: 38,
+                                                                                                            end: 39,
+                                                                                                        },
+                                                                                                        inner: [],
+                                                                                                    },
+                                                                                                ],
                                                                                             },
                                                                                         ],
                                                                                     },

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_s_string.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_s_string.snap
@@ -4,7 +4,7 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
 ---
 [
     Pair {
-        rule: expr,
+        rule: expr_call,
         span: Span {
             str: "s\"SUM({col})\"",
             start: 0,
@@ -12,7 +12,7 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
         },
         inner: [
             Pair {
-                rule: expr_compare,
+                rule: expr,
                 span: Span {
                     str: "s\"SUM({col})\"",
                     start: 0,
@@ -20,7 +20,7 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                 },
                 inner: [
                     Pair {
-                        rule: expr_add,
+                        rule: expr_compare,
                         span: Span {
                             str: "s\"SUM({col})\"",
                             start: 0,
@@ -28,7 +28,7 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                         },
                         inner: [
                             Pair {
-                                rule: expr_mul,
+                                rule: expr_add,
                                 span: Span {
                                     str: "s\"SUM({col})\"",
                                     start: 0,
@@ -36,7 +36,7 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                                 },
                                 inner: [
                                     Pair {
-                                        rule: s_string,
+                                        rule: expr_mul,
                                         span: Span {
                                             str: "s\"SUM({col})\"",
                                             start: 0,
@@ -44,24 +44,24 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                                         },
                                         inner: [
                                             Pair {
-                                                rule: interpolate_string_inner,
+                                                rule: s_string,
                                                 span: Span {
-                                                    str: "SUM(",
-                                                    start: 2,
-                                                    end: 6,
-                                                },
-                                                inner: [],
-                                            },
-                                            Pair {
-                                                rule: expr,
-                                                span: Span {
-                                                    str: "col",
-                                                    start: 7,
-                                                    end: 10,
+                                                    str: "s\"SUM({col})\"",
+                                                    start: 0,
+                                                    end: 13,
                                                 },
                                                 inner: [
                                                     Pair {
-                                                        rule: expr_compare,
+                                                        rule: interpolate_string_inner,
+                                                        span: Span {
+                                                            str: "SUM(",
+                                                            start: 2,
+                                                            end: 6,
+                                                        },
+                                                        inner: [],
+                                                    },
+                                                    Pair {
+                                                        rule: expr_call,
                                                         span: Span {
                                                             str: "col",
                                                             start: 7,
@@ -69,7 +69,7 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                                                         },
                                                         inner: [
                                                             Pair {
-                                                                rule: expr_add,
+                                                                rule: expr,
                                                                 span: Span {
                                                                     str: "col",
                                                                     start: 7,
@@ -77,7 +77,7 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: expr_mul,
+                                                                        rule: expr_compare,
                                                                         span: Span {
                                                                             str: "col",
                                                                             start: 7,
@@ -85,13 +85,33 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                                                                         },
                                                                         inner: [
                                                                             Pair {
-                                                                                rule: ident,
+                                                                                rule: expr_add,
                                                                                 span: Span {
                                                                                     str: "col",
                                                                                     start: 7,
                                                                                     end: 10,
                                                                                 },
-                                                                                inner: [],
+                                                                                inner: [
+                                                                                    Pair {
+                                                                                        rule: expr_mul,
+                                                                                        span: Span {
+                                                                                            str: "col",
+                                                                                            start: 7,
+                                                                                            end: 10,
+                                                                                        },
+                                                                                        inner: [
+                                                                                            Pair {
+                                                                                                rule: ident,
+                                                                                                span: Span {
+                                                                                                    str: "col",
+                                                                                                    start: 7,
+                                                                                                    end: 10,
+                                                                                                },
+                                                                                                inner: [],
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                ],
                                                                             },
                                                                         ],
                                                                     },
@@ -99,16 +119,16 @@ expression: "parse_tree_of_str(r#\"s\"SUM({col})\"\"#, Rule::expr_call)?"
                                                             },
                                                         ],
                                                     },
+                                                    Pair {
+                                                        rule: interpolate_string_inner,
+                                                        span: Span {
+                                                            str: ")",
+                                                            start: 11,
+                                                            end: 12,
+                                                        },
+                                                        inner: [],
+                                                    },
                                                 ],
-                                            },
-                                            Pair {
-                                                rule: interpolate_string_inner,
-                                                span: Span {
-                                                    str: ")",
-                                                    start: 11,
-                                                    end: 12,
-                                                },
-                                                inner: [],
                                             },
                                         ],
                                     },

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -1190,21 +1190,20 @@ take 20
     fn test_sorts() -> Result<()> {
         let query: Query = parse(
             r###"
-        from Employees
-        sort [id]
-        sort [age, desc=last_name, asc=first_name]
+        from invoices
+        sort [issued_at, -amount, +num_of_articles]
         "###,
         )?;
 
         assert_display_snapshot!((resolve_and_translate(query)?), @r###"
         SELECT
-          Employees.*
+          invoices.*
         FROM
-          Employees
+          invoices
         ORDER BY
-          age,
-          last_name DESC,
-          first_name
+          issued_at,
+          amount DESC,
+          num_of_articles
         "###);
 
         Ok(())

--- a/reference/src/transforms.md
+++ b/reference/src/transforms.md
@@ -100,7 +100,7 @@ sort (-age)
 
 ```prql
 from employees
-sort [age, -tenure]
+sort [age, -tenure, +salary]
 ```
 
 ## Take

--- a/reference/src/transforms.md
+++ b/reference/src/transforms.md
@@ -10,7 +10,7 @@ Core principle of the language is a pipeline, which is a series of sequential tr
 from {table reference}
 ```
 
-*Example:*
+#### Examples
 
 ```prql
 from employees
@@ -24,7 +24,7 @@ from employees
 select [{expression}]
 ```
 
-*Example:*
+#### Examples
 
 ```prql
 from employees
@@ -39,7 +39,7 @@ select [first_name, last_name]
 derive [{new_name} = {expression}]
 ```
 
-*Example:*
+#### Examples
 
 ```prql
 from employees
@@ -62,11 +62,45 @@ derive [
 filter {boolean expression}
 ```
 
-*Example:*
+#### Examples
 
 ```prql_no_test
 from employees
 filter (length last_name < 3)
+```
+
+## Sort
+
+`sort` orders rows based on the values of one or more columns.
+
+```prql_no_test
+sort [{direction}{column}]
+```
+
+#### Arguments
+
+- One or multiple columns
+- Each column can be prefixed with:
+  - `+`, for ascending order, the default
+  - `-`, for descending order
+
+#### Examples
+
+```prql
+from employees
+sort age
+```
+
+```prql
+from employees
+sort (-age)
+```
+
+> Note that `sort -age` is not valid; `-age` needs to be surrounded by parentheses.
+
+```prql
+from employees
+sort [age, -tenure]
 ```
 
 ## Take
@@ -77,30 +111,11 @@ filter (length last_name < 3)
 take {n}
 ```
 
-*Example:*
+#### Examples
 
 ```prql
 from employees
 take 10
-```
-
-## Sort
-
-> orders the rows by the values of selected columns
-
-```prql_no_test
-sort {column}
-```
-
-*Arguments:*
-
-- a column identifier of the key to sort by
-
-*Example:*
-
-```prql
-from employees
-sort age
 ```
 
 ## Join
@@ -111,21 +126,21 @@ sort age
 join side:{inner|left|right|full} {table} {[conditions]}
 ```
 
-*Arguments:*
+#### Arguments
 
 - `side` decides which rows to include. Defaults to `inner`
 - table reference
 - list of conditions
   - If all terms are column identifiers, this will compile to `USING(...)`. In this case, both of the tables must have specified column. The result will only contain one column instead one for each table.
 
-*Example:*
+#### Examples
 
 ```prql
 from employees
 join side:left positions [id==employee_id]
 ```
 
-*Example:*
+#### Examples
 
 ```prql
 from employees
@@ -179,7 +194,7 @@ group role (
 aggregate [{expression or assign operations}]
 ```
 
-*Example:*
+#### Examples
 
 ```prql
 from employees

--- a/reference/tests/examples/transforms-10.prql
+++ b/reference/tests/examples/transforms-10.prql
@@ -1,5 +1,7 @@
 from employees
-aggregate [
-  average salary,
-  ct = count
-]
+group [title, country] (
+  aggregate [
+    average salary,
+    ct = count
+  ]
+)

--- a/reference/tests/examples/transforms-11.prql
+++ b/reference/tests/examples/transforms-11.prql
@@ -1,0 +1,3 @@
+from employees
+sort join_date
+take 1

--- a/reference/tests/examples/transforms-12.prql
+++ b/reference/tests/examples/transforms-12.prql
@@ -1,0 +1,5 @@
+from employees
+aggregate [
+  average salary,
+  ct = count
+]

--- a/reference/tests/examples/transforms-4.prql
+++ b/reference/tests/examples/transforms-4.prql
@@ -1,2 +1,2 @@
 from employees
-take 10
+sort age

--- a/reference/tests/examples/transforms-5.prql
+++ b/reference/tests/examples/transforms-5.prql
@@ -1,2 +1,2 @@
 from employees
-sort age
+sort (-age)

--- a/reference/tests/examples/transforms-6.prql
+++ b/reference/tests/examples/transforms-6.prql
@@ -1,2 +1,2 @@
 from employees
-sort (-age)
+sort [age, -tenure, +salary]

--- a/reference/tests/examples/transforms-6.prql
+++ b/reference/tests/examples/transforms-6.prql
@@ -1,2 +1,2 @@
 from employees
-join side:left positions [id==employee_id]
+sort (-age)

--- a/reference/tests/examples/transforms-7.prql
+++ b/reference/tests/examples/transforms-7.prql
@@ -1,2 +1,2 @@
 from employees
-join side:full positions [emp_no]
+sort [age, -tenure]

--- a/reference/tests/examples/transforms-7.prql
+++ b/reference/tests/examples/transforms-7.prql
@@ -1,2 +1,2 @@
 from employees
-sort [age, -tenure]
+take 10

--- a/reference/tests/examples/transforms-8.prql
+++ b/reference/tests/examples/transforms-8.prql
@@ -1,7 +1,2 @@
 from employees
-group [title, country] (
-  aggregate [
-    average salary,
-    ct = count
-  ]
-)
+join side:left positions [id==employee_id]

--- a/reference/tests/examples/transforms-9.prql
+++ b/reference/tests/examples/transforms-9.prql
@@ -1,3 +1,2 @@
 from employees
-sort join_date
-take 1
+join side:full positions [emp_no]

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-11.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-11.prql.snap
@@ -1,12 +1,13 @@
 ---
 source: reference/tests/snapshot.rs
 expression: sql
-input_file: reference/tests/examples/transforms-7.prql
+input_file: reference/tests/examples/transforms-11.prql
 ---
 SELECT
   employees.*
 FROM
   employees
 ORDER BY
-  age,
-  tenure DESC
+  join_date
+LIMIT
+  1

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-12.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-12.prql.snap
@@ -1,15 +1,10 @@
 ---
 source: reference/tests/snapshot.rs
 expression: sql
-input_file: reference/tests/examples/transforms-10.prql
+input_file: reference/tests/examples/transforms-12.prql
 ---
 SELECT
-  title,
-  country,
   AVG(salary),
   COUNT(*) AS ct
 FROM
   employees
-GROUP BY
-  title,
-  country

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-4.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-4.prql.snap
@@ -7,5 +7,5 @@ SELECT
   employees.*
 FROM
   employees
-LIMIT
-  10
+ORDER BY
+  age

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-5.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-5.prql.snap
@@ -8,4 +8,4 @@ SELECT
 FROM
   employees
 ORDER BY
-  age
+  age DESC

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-6.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-6.prql.snap
@@ -4,8 +4,8 @@ expression: sql
 input_file: reference/tests/examples/transforms-6.prql
 ---
 SELECT
-  employees.*,
-  positions.*
+  employees.*
 FROM
   employees
-  LEFT JOIN positions ON id = employee_id
+ORDER BY
+  age DESC

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-6.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-6.prql.snap
@@ -8,4 +8,6 @@ SELECT
 FROM
   employees
 ORDER BY
-  age DESC
+  age,
+  tenure DESC,
+  salary

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-7.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-7.prql.snap
@@ -7,6 +7,5 @@ SELECT
   employees.*
 FROM
   employees
-ORDER BY
-  age,
-  tenure DESC
+LIMIT
+  10

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-8.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-8.prql.snap
@@ -4,12 +4,8 @@ expression: sql
 input_file: reference/tests/examples/transforms-8.prql
 ---
 SELECT
-  title,
-  country,
-  AVG(salary),
-  COUNT(*) AS ct
+  employees.*,
+  positions.*
 FROM
   employees
-GROUP BY
-  title,
-  country
+  LEFT JOIN positions ON id = employee_id

--- a/reference/tests/snapshots/snapshot__run_reference_examples@transforms-9.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_examples@transforms-9.prql.snap
@@ -4,10 +4,9 @@ expression: sql
 input_file: reference/tests/examples/transforms-9.prql
 ---
 SELECT
-  employees.*
+  employees.*,
+  positions.*,
+  emp_no
 FROM
-  employees
-ORDER BY
-  join_date
-LIMIT
-  1
+  employees FULL
+  JOIN positions USING(emp_no)


### PR DESCRIPTION
It looks like a lot of lines changed, but actually that's mostly from making a pest rule non-silent, which adds another layer to parse trees, which indents a lot of snapshots.

I'm actually not sure whether we need all those `expr` items to be non-silent. But not worth spending time on at this stage.