### PR TITLE
Add dependabot for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+
+  - package-ecosystem: "npm"
+    directory: "/playground"
+    schedule:
+      interval: daily


### PR DESCRIPTION
This may be too noisy; we can ignore patches if needed
