### PR TITLE
Enable negative bounds in ranges

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     # Currently excluded since we need to use the PYPI_API_TOKEN
     # if: "startsWith(github.ref, 'refs/tags/')"
-    if: false
+    if: "false"
     needs: [build-python-wheels]
     steps:
       - uses: actions/download-artifact@v3

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -1440,8 +1440,12 @@ select [
         assert_yaml_snapshot!(parse("
         from employees
         filter (age | between 18..40)
-        derive [greater_than_ten = 11..]
-        derive [less_than_ten = ..9]
+        derive [
+          greater_than_ten = 11..,
+          less_than_ten = ..9,
+          negative = (-5..),
+          more_negative = -10..,
+        ]
         ").unwrap(), @r###"
         ---
         version: ~
@@ -1486,11 +1490,6 @@ select [
                                     Literal:
                                       Integer: 11
                                   end: ~
-                    named_args: {}
-                - FuncCall:
-                    name: derive
-                    args:
-                      - List:
                           - Assign:
                               name: less_than_ten
                               expr:
@@ -1499,6 +1498,22 @@ select [
                                   end:
                                     Literal:
                                       Integer: 9
+                          - Assign:
+                              name: negative
+                              expr:
+                                Range:
+                                  start:
+                                    Literal:
+                                      Integer: -5
+                                  end: ~
+                          - Assign:
+                              name: more_negative
+                              expr:
+                                Range:
+                                  start:
+                                    Literal:
+                                      Integer: -10
+                                  end: ~
                     named_args: {}
         "###);
     }

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -29,6 +29,8 @@ pipe = _{ NEWLINE | "|" }
 pipeline = { WHITESPACE* ~ func_curry ~ (pipe ~ func_curry)* }
 
 ident = @{ !operator ~ !(keyword ~ WHITESPACE) ~ (ASCII_ALPHA | "$") ~ (ASCII_ALPHANUMERIC | "." | "_" | "*" )* }
+// For sorting
+signed_ident = { ( "+" | "-" ) ~ ident }
 keyword = _{ "prql" | "table" | "func" }
 
 // A central issue around the terms vs expr is that we want to be able to parse:
@@ -56,16 +58,16 @@ keyword = _{ "prql" | "table" | "func" }
 // - 1
 // - 2
 
-// white space is required to prevent matching s"string"
-func_call = ${ ident ~ WHITESPACE+ ~ (named_arg | assign | expr)+ }
+// whitespace is required to prevent matching s"string".
+// Forbid `operator` so `a - b` can't parse as `a` & `-b`.
+func_call = ${ ident ~ WHITESPACE+ ~ (!operator ~ (named_arg | assign | expr))+ }
 func_curry = { ident ~ (named_arg | assign | expr)* }
 
 named_arg   = { ident ~ ":" ~ !":" ~ (assign | expr) }
 assign      = { ident ~ "=" ~ !"=" ~ expr }
 assign_call = { ident ~ "=" ~ !"=" ~ expr_call }
 
-// Expression that can contain a function call and a leading `+` or `-`
-expr_call = { operator_add? ~ (func_call | expr) }
+expr_call = { (func_call | expr) }
 
 expr = !{ expr_coalesce ~ (operator_logical ~ expr_coalesce)* }
 expr_coalesce = { expr_compare ~ (operator_coalesce ~ expr_compare)* }
@@ -73,7 +75,9 @@ expr_compare = { expr_add ~ (operator_compare ~ expr_add)? }
 expr_add = _{ expr_mul ~ (operator_add ~ expr_mul)* }
 expr_mul = _{ term ~ (operator_mul ~ term)* }
 
-term = _{ ( s_string | f_string | range | literal | ident | nested_expr | nested_pipeline | list ) }
+term = _{ ( s_string | f_string | range | literal | ident | nested_expr | nested_pipeline | signed_term | list ) }
+// signed_term is for sorting.
+signed_term = _{ ( operator_add ~ ( nested_expr | ident )) }
 literal = _{ interval | number | boolean | null | string | timestamp | date | time }
 list = { "[" ~ (NEWLINE* ~ (assign_call | expr_call) ~ ("," ~ NEWLINE* ~ (assign_call | expr_call) )* ~ ","?)? ~ NEWLINE* ~ "]" }
 nested_expr = _{ "(" ~ expr_call ~ ")" }
@@ -102,7 +106,7 @@ string_inner = { ( !( PEEK ) ~ ANY )+ }
 // Either > 3 quotes, or just one. Currently both of those can be multiline.
 string = ${ ( opening_quote ) ~ string_inner ~ POP }
 
-number = ${ ( ASCII_DIGIT )+ ~ ("." ~ ( ASCII_DIGIT )+)? }
+number = ${ operator_add? ~ ( ASCII_DIGIT )+ ~ ("." ~ ( ASCII_DIGIT )+)? }
 
 boolean = ${ "true" | "false" }
 

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -1680,7 +1680,7 @@ take 20
         assert_display_snapshot!((resolve_and_translate(parse(r###"
         from foo
         sort day
-        window range:0..4 (
+        window range:-4..4 (
             derive [next_four_days = sum b]
         )
         "###,
@@ -1689,7 +1689,7 @@ take 20
           foo.*,
           SUM(b) OVER (
             ORDER BY
-              day RANGE BETWEEN CURRENT ROW
+              day RANGE BETWEEN 4 PRECEDING
               AND 4 FOLLOWING
           ) AS next_four_days
         FROM

--- a/reference/src/transforms/window.md
+++ b/reference/src/transforms/window.md
@@ -35,16 +35,14 @@ Some examples:
 | `rows:0..`      | current row and all following rows until the end of the table      |
 | `rows:..`       | all rows, which same as not having window at all                   |
 
-> Note: currently, negative integer literals (`-3`) are not implemented.
-
 ## Example
 
-```prql_no_test
+```prql
 from employees
 group employee_id (
   sort month
   window rows:-5.. (
-    derive semi_annual_comp = sum paycheck
+    derive [semi_annual_comp = sum paycheck]
   )
 )
 ```

--- a/reference/tests/prql/transforms/window-0.prql
+++ b/reference/tests/prql/transforms/window-0.prql
@@ -1,11 +1,7 @@
-from orders
-sort day
-window rolling:3 (
-  derive [total_last_3_days = sum price]
-)
-group [order_month] (
-  sort day
-  window expanding:true (
-    derive [monthly_running_total = sum price]
+from employees
+group employee_id (
+  sort month
+  window rows:-5.. (
+    derive [semi_annual_comp = sum paycheck]
   )
 )

--- a/reference/tests/prql/transforms/window-1.prql
+++ b/reference/tests/prql/transforms/window-1.prql
@@ -1,0 +1,11 @@
+from orders
+sort day
+window rolling:3 (
+  derive [total_last_3_days = sum price]
+)
+group [order_month] (
+  sort day
+  window expanding:true (
+    derive [monthly_running_total = sum price]
+  )
+)

--- a/reference/tests/snapshots/snapshot__run_reference_prql@window-0.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_prql@window-0.prql.snap
@@ -4,17 +4,12 @@ expression: sql
 input_file: reference/tests/prql/transforms/window-0.prql
 ---
 SELECT
-  orders.*,
-  SUM(price) OVER (
+  employees.*,
+  SUM(paycheck) OVER (
+    PARTITION BY employee_id
     ORDER BY
-      day ROWS BETWEEN 2 PRECEDING
-      AND CURRENT ROW
-  ) AS total_last_3_days,
-  SUM(price) OVER (
-    PARTITION BY order_month
-    ORDER BY
-      day ROWS BETWEEN UNBOUNDED PRECEDING
-      AND CURRENT ROW
-  ) AS monthly_running_total
+      month ROWS BETWEEN 5 PRECEDING
+      AND UNBOUNDED FOLLOWING
+  ) AS semi_annual_comp
 FROM
-  orders
+  employees

--- a/reference/tests/snapshots/snapshot__run_reference_prql@window-1.prql.snap
+++ b/reference/tests/snapshots/snapshot__run_reference_prql@window-1.prql.snap
@@ -1,0 +1,20 @@
+---
+source: reference/tests/snapshot.rs
+expression: sql
+input_file: reference/tests/prql/transforms/window-1.prql
+---
+SELECT
+  orders.*,
+  SUM(price) OVER (
+    ORDER BY
+      day ROWS BETWEEN 2 PRECEDING
+      AND CURRENT ROW
+  ) AS total_last_3_days,
+  SUM(price) OVER (
+    PARTITION BY order_month
+    ORDER BY
+      day ROWS BETWEEN UNBOUNDED PRECEDING
+      AND CURRENT ROW
+  ) AS monthly_running_total
+FROM
+  orders


### PR DESCRIPTION
Overcomes the issues in #517 by changing how the `sort` terms are
parsed.
