### PR TITLE
Install wasm-pack in playground publish, v2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,7 @@ jobs:
 
       # playground
       - uses: jetli/wasm-bindgen-action@v0.1.0
+      - uses: jetli/wasm-pack-action@v0.3.0
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Sorry, I used wasm-bindgen on the previous one, and only can see the
error after the merge.
