### PR TITLE
Don't run cargo audit on every commit

### DIFF
--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -1,18 +1,8 @@
 name: Cargo audit
 
 on:
-  pull_request:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-  push:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-    branches:
-      - main
   schedule:
-    - cron: "33 6 * * 1"
+    - cron: "33 6 * * *"
 
 jobs:
   audit:


### PR DESCRIPTION
There are times when a new advisory comes out but there's an upstream issue; we don't want to fail the build in those cases. It would be ideal if we could fail when an insecure dependency was *added*, but I don't think there is.
