### PR TITLE
Fixes the fahrenheit_from_celsius function in the website showcase

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -144,13 +144,13 @@ showcase_section:
     - id: functions
       label: Functions
       prql: |
-        func fahrenheit_of_celsius temp -> temp * 3 + 32
+        func fahrenheit_from_celsius temp -> temp * 9/5 + 32
 
         from weather
-        select temp_f = (fahrenheit_of_celsius temp_c)
+        select temp_f = (fahrenheit_from_celsius temp_c)
       sql: |
         SELECT
-          temp_c * 3 + 32 AS temp_f
+          temp_c * 9/5 + 32 AS temp_f
         FROM
           weather
 


### PR DESCRIPTION
Hi,

A small PR to fix the fahrenheit_from_celsius function in the Showcase section of the website.

I think the Showcase section is really nice and it's one of the first things I was drawn to when reviewing the new website just now. Having an incorrect formula in there just kinda irks me and I also thought naming the function `fahrenheit_from_celsius` rather than `fahrenheit_of_celsius` is a little bit nicer.