### PR TITLE
Add 'pipelined' to tag line

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 
 **P**ipelined **R**elational **Q**uery **L**anguage, pronounced "Prequel".
 
-PRQL is a modern language for transforming data — a simpler and more powerful
-SQL. Like SQL, it's readable, explicit and declarative. Unlike SQL, it forms a
+PRQL is a modern language for transforming data — a simple, powerful, pipelined
+SQL replacement. Like SQL, it's readable, explicit and declarative. Unlike SQL, it forms a
 logical pipeline of transformations, and supports abstractions such as variables
 and functions. It can be used with any database that uses SQL, since it
 transpiles to SQL.

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,13 +1,13 @@
 [book]
 authors = ["aljazerzen"]
-description = "Modern language for transforming data — a simpler and more powerful SQL"
+description = "Modern language for transforming data — a simple, powerful, pipelined SQL replacement"
 language = "en"
 multilingual = false
 src = "src"
 title = "PRQL Language Book"
 
 [output.html]
-additional-css = ["comparison-table.css", "././mdbook-admonish.css"]
+additional-css = ["comparison-table.css", "mdbook-admonish.css"]
 additional-js = ["highlight-prql.js"]
 git-repository-url = "https://github.com/prql/prql"
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,9 +1,10 @@
 # Introduction
 
-PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement. Like SQL, it's readable, explicit and declarative. Unlike SQL, it forms a
-logical pipeline of transformations, and supports abstractions such as variables
-and functions. It can be used with any database that uses SQL, since it
-transpiles to SQL.
+PRQL is a modern language for transforming data — a simple, powerful, pipelined
+SQL replacement. Like SQL, it's readable, explicit and declarative. Unlike SQL,
+it forms a logical pipeline of transformations, and supports abstractions such
+as variables and functions. It can be used with any database that uses SQL,
+since it transpiles to SQL.
 
 Let's get started with an example:
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,7 +1,6 @@
 # Introduction
 
-PRQL is a modern language for transforming data — a simpler and more powerful
-SQL. Like SQL, it's readable, explicit and declarative. Unlike SQL, it forms a
+PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement. Like SQL, it's readable, explicit and declarative. Unlike SQL, it forms a
 logical pipeline of transformations, and supports abstractions such as variables
 and functions. It can be used with any database that uses SQL, since it
 transpiles to SQL.

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-description = "PRQL is a modern language for transforming data — a simpler and more powerful SQL."
+description = "PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement."
 edition = "2021"
 license = "Apache-2.0"
 name = "prql-compiler"

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -7,7 +7,7 @@ title: PRQL
 hero_section:
   enable: true
   heading: "PRQL is a modern language for transforming data"
-  bottom_text: "— a simpler and more powerful SQL"
+  bottom_text: "— a simple, powerful, pipelined SQL replacement"
   button:
     enable: true
     link: https://prql-lang.org/book/


### PR DESCRIPTION
Closes https://github.com/prql/prql/issues/458

One option we discussed on the dev call was:

```diff
- PRQL is a modern language for transforming data — a simpler and more powerful SQL. 
+ PRQL is a modern language for transforming data — a simpler and more powerful pipelined SQL. 
```

One issue with this is that the comparison isn't completely correct — it's saying PRQL is simpler than a pipelined SQL.

So this gets around that. It's some Eureka creation, and very open to making more changes or closing this completely.

**PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.**