### PR TITLE
Allow backticks in idents

### DIFF
--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -1452,6 +1452,39 @@ select [
     }
 
     #[test]
+    fn test_parse_backticks() -> Result<()> {
+        let prql = "
+from `a.b`
+aggregate [max c]
+";
+        assert_yaml_snapshot!(parse(prql)?, @r###"
+        ---
+        version: ~
+        dialect: Generic
+        nodes:
+          - Pipeline:
+              nodes:
+                - FuncCall:
+                    name: from
+                    args:
+                      - Ident: "`a.b`"
+                    named_args: {}
+                - FuncCall:
+                    name: aggregate
+                    args:
+                      - List:
+                          - FuncCall:
+                              name: max
+                              args:
+                                - Ident: c
+                              named_args: {}
+                    named_args: {}
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_parse_sort() -> Result<()> {
         assert_yaml_snapshot!(parse("
         from invoices

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -28,7 +28,9 @@ table = { "table" ~ ident ~ "=" ~ nested_pipeline }
 pipe = _{ NEWLINE | "|" }
 pipeline = { WHITESPACE* ~ expr_call ~ (pipe ~ expr_call)* }
 
-ident = @{ !operator ~ !(keyword ~ WHITESPACE) ~ (ASCII_ALPHA | "$") ~ (ASCII_ALPHANUMERIC | "." | "_" | "*" )* }
+// We include backticks because some DBs use them (e.g. BigQuery) and we don't,
+// so we pass them through.
+ident = @{ !operator ~ !(keyword ~ WHITESPACE) ~ (ASCII_ALPHA | "$" | "`") ~ (ASCII_ALPHANUMERIC | "." | "_" | "*" | "`")* }
 // For sorting
 signed_ident = { ( "+" | "-" ) ~ ident }
 keyword = _{ "prql" | "table" | "func" }


### PR DESCRIPTION
These are required for dbt-prql to work with BQ queries (and for lots of
standard BQ queries).
