### PR TITLE
Bump prql-compiler version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "prql-compiler"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "prql-compiler"
 repository = "https://github.com/prql/prql"
 rust-version = "1.59.0"
-version = "0.1.1"
+version = "0.1.2"
 
 [features]
 # We previously had `cli` not compile by default, because of an issue with

--- a/prql-compiler/README.md
+++ b/prql-compiler/README.md
@@ -2,8 +2,8 @@
 
 `prql-compiler` contains the implementation of PRQL's compiler, written in rust.
 
-For more on PRQL, check out the [PRQL website](prql-lang.org) or the [PRQL
-repo](github.com/prql/prql).
+For more on PRQL, check out the [PRQL website](https://prql-lang.org) or the [PRQL
+repo](https://github.com/prql/prql).
 
 ## Installation
 
@@ -23,7 +23,7 @@ cargo install --path .
 ## Usage
 
 ```sh
-$ echo "from employees | filter has_dog" | prql-compiler compile
+$ echo "from employees | filter has_dog | select salary" | prql-compiler compile
 
 SELECT
   *

--- a/prql-compiler/README.md
+++ b/prql-compiler/README.md
@@ -1,17 +1,29 @@
-# PRQL reference compiler
+# PRQL compiler
+
+`prql-compiler` contains the implementation of PRQL's compiler, written in rust.
+
+For more on PRQL, check out the [PRQL website](prql-lang.org) or the [PRQL
+repo](github.com/prql/prql).
 
 ## Installation
 
-PRQL can be installed with `cargo`, or built from source.
+`prql-compiler` can be installed with `cargo`:
 
 ```sh
 cargo install prql-compiler
 ```
 
+...or built from source:
+
+```sh
+# from prql/prql-compiler
+cargo install --path .
+```
+
 ## Usage
 
 ```sh
-$ echo "from employees | filter has_dog" | prql compile
+$ echo "from employees | filter has_dog" | prql-compiler compile
 
 SELECT
   *

--- a/prql-compiler/src/cli.rs
+++ b/prql-compiler/src/cli.rs
@@ -63,7 +63,7 @@ impl Cli {
     pub fn execute(&mut self) -> Result<(), Error> {
         match self {
             Cli::Compile(command) => {
-                // Don't wait without a prompt when running `prql compile` —
+                // Don't wait without a prompt when running `prql-compiler compile` —
                 // it's confusing whether it's waiting for input or not. This
                 // offers the prompt.
                 if is_stdin(&command.input) && atty::is(atty::Stream::Stdin) {


### PR DESCRIPTION
I'll release 0.2.0 tomorrow but want to test we can publish to cargo; clean up the crate name etc
