### PR TITLE
Ignore clippy lints until 1.61 vs 1.62 is resolved

### DIFF
--- a/.github/actions/cargo-test/action.yaml
+++ b/.github/actions/cargo-test/action.yaml
@@ -36,12 +36,13 @@ runs:
         key: ${{ inputs.target }}-1
     - uses: jetli/wasm-bindgen-action@v0.1.0
       if: ${{ inputs.target == 'wasm32-unknown-unknown' }}
-    - name: 📎 Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        # Note that `--all-targets` doesn't refer to targets like `wasm32-unknown-unknown`.
-        args: --all-targets --workspace ${{ inputs.target_option }} -- -D warnings
+      # Ignoring until https://github.com/prql/prql/pull/741 is resolved
+    # - name: 📎 Clippy
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: clippy
+    #     # Note that `--all-targets` doesn't refer to targets like `wasm32-unknown-unknown`.
+    #     args: --all-targets --workspace ${{ inputs.target_option }} -- -D warnings
     - name: ⌨️ Fmt
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
What's a better way of handling this? Without setting our min version to 1.62...
