### PR TITLE
Remove cache key

### DIFF
--- a/.github/actions/cargo-test/action.yaml
+++ b/.github/actions/cargo-test/action.yaml
@@ -29,11 +29,7 @@ runs:
       with:
         # Without inputs.target, it seems to select linux x64 in the wasm32
         # tests, though in the docs it says it uses the target as the key?
-        #
-        # We add `-1` because the cache was getting bloated; probably it doesn't
-        # clear all old files away efficiently; ideally we could set this to
-        # clear every month or similar.
-        key: ${{ inputs.target }}-1
+        key: ${{ inputs.target }}
     - uses: jetli/wasm-bindgen-action@v0.1.0
       if: ${{ inputs.target == 'wasm32-unknown-unknown' }}
       # Ignoring until https://github.com/prql/prql/pull/741 is resolved


### PR DESCRIPTION
I realize we're busting the cache every rust release, which is sufficient
