### PR TITLE
Pass through any idents surrounded by backticks

### DIFF
--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -1454,8 +1454,10 @@ select [
     #[test]
     fn test_parse_backticks() -> Result<()> {
         let prql = "
-from `a.b`
+from `a`
 aggregate [max c]
+join `my-proj.dataset.table`
+join `my-proj`.`dataset`.`table`
 ";
         assert_yaml_snapshot!(parse(prql)?, @r###"
         ---
@@ -1467,7 +1469,7 @@ aggregate [max c]
                 - FuncCall:
                     name: from
                     args:
-                      - Ident: "`a.b`"
+                      - Ident: "`a`"
                     named_args: {}
                 - FuncCall:
                     name: aggregate
@@ -1478,6 +1480,16 @@ aggregate [max c]
                               args:
                                 - Ident: c
                               named_args: {}
+                    named_args: {}
+                - FuncCall:
+                    name: join
+                    args:
+                      - Ident: "`my-proj.dataset.table`"
+                    named_args: {}
+                - FuncCall:
+                    name: join
+                    args:
+                      - Ident: "`my-proj`.`dataset`.`table`"
                     named_args: {}
         "###);
 

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -30,7 +30,8 @@ pipeline = { WHITESPACE* ~ expr_call ~ (pipe ~ expr_call)* }
 
 // We include backticks because some DBs use them (e.g. BigQuery) and we don't,
 // so we pass anything within them directly through, including otherwise invalid
-// idents, like those with hyphens.
+// idents, like those with hyphens. Possibly we should consider applying this to
+// expressions rather than just idens — we can adjust as we see more cases.
 ident = @{ !operator ~ !(keyword ~ WHITESPACE) ~ ident_start ~ ("." ~ ident_next)* }
 // Either a normal ident (starting with a letter etc), or any string surrounded
 // by backticks.

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -29,8 +29,17 @@ pipe = _{ NEWLINE | "|" }
 pipeline = { WHITESPACE* ~ expr_call ~ (pipe ~ expr_call)* }
 
 // We include backticks because some DBs use them (e.g. BigQuery) and we don't,
-// so we pass them through.
-ident = @{ !operator ~ !(keyword ~ WHITESPACE) ~ (ASCII_ALPHA | "$" | "`") ~ (ASCII_ALPHANUMERIC | "." | "_" | "*" | "`")* }
+// so we pass anything within them directly through, including otherwise invalid
+// idents, like those with hyphens.
+ident = @{ !operator ~ !(keyword ~ WHITESPACE) ~ ident_start ~ ("." ~ ident_next)* }
+// Either a normal ident (starting with a letter etc), or any string surrounded
+// by backticks.
+ident_start = _{ ((ASCII_ALPHA | "$" ) ~ (ASCII_ALPHANUMERIC | "_" )* ) | ident_backticks+ }
+// We allow `e.*`, but not just `*`, since it might conflict with multiply in
+// some cases.
+ident_next = _{ ident_start | "*" }
+// Anything surrounded by backticks, we pass through.
+ident_backticks = _{ "`" ~ (!NEWLINE ~ !"`" ~ ANY)* ~ "`" }
 // For sorting
 signed_ident = { ( "+" | "-" ) ~ ident }
 keyword = _{ "prql" | "table" | "func" }


### PR DESCRIPTION
I want to ensure we don't invent 8 different ways of doing things, which includes escape hatches for using otherwise-invalid terms.

We have s-strings already, but for DBs like BQ which use backticks as their own escape hatch, it would be quite cumbersome to require both -- i.e. ```s'`my-table\`'```.

So this allows for idents surrounded by backticks (possibly separated by periods) to be passed straight through.

One note: I'm not sure whether this should apply to idents vs expressions, but we can evolve that with more cases if needed.
