### PR TITLE
Add default member to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+default-members = ["prql-compiler"]
 members = [
   "prql-python",
   "prql-compiler",


### PR DESCRIPTION
So `cargo run compile` works from the root
