### PR TITLE
Bump package-lock.json in playground

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../prql-js/pkg": {
       "name": "prql-js",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0"
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
I don't know what this means, but it keeps being bumped when I run `task build-all`, so I'm guessing it's updating the version. (Though I don't think we actually use this; we instead include the current version?).

CC @charlie-sanders, if you know / have a view :)
