### PR TITLE
Add prql-compiler to snapcraft

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,16 +53,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/public/
-
-  publish-snapcraft:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: snapcore/action-build@v1
-      id: build
-    - uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      with:
-        snap: ${{ steps.build.outputs.snap }}
-        release: stable

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,3 +53,16 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/public/
+
+  publish-snapcraft:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+      id: build
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,16 @@ jobs:
         with:
           command: upload
           args: --skip-existing *
+
+  publish-snapcraft:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+      id: build
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: stable

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,46 @@
+name: prql-compiler
+adopt-info: prql-compiler
+base: core20
+summary: Pipelined Relational Query Language, pronounced "Prequel"
+description: |
+  PRQL is a modern language for transforming data — a simple, powerful,
+  pipelined SQL replacement. Like SQL, it's readable, explicit and
+  declarative. Unlike SQL, it forms a logical pipeline of transformations,
+  and supports abstractions such as variables and functions. It can be
+  used with any database that uses SQL, since it transpiles to SQL. *NOTE*:
+  this snap packs only the `prql-compiler`, and not the bindings.
+license: Apache-2.0
+grade: stable
+confinement: strict
+issues: https://github.com/prql/prql/issues
+source-code: https://github.com/prql/prql.git
+website: https://prql-lang.org/
+icon: website/static/img/icon.svg
+
+apps:
+  prql-compiler:
+    command: bin/prql-compiler
+    plugs:
+      - home
+      - removable-media
+
+parts:
+  prql-compiler:
+    plugin: rust
+    source: https://github.com/prql/prql.git
+    build-packages:
+        - rust-all
+    override-build: |
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }' || echo '0.0.0')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+        cd ../src
+        git checkout "${last_committed_tag}"
+      fi
+      cargo install --locked --path prql-compiler --root /root/parts/prql-compiler/install --force
+      snapcraftctl set-version $(git -C ../src describe --tags  | sed 's/v//')


### PR DESCRIPTION
This PR is:

* A `snapcraft.yaml`: metadata for publishing on [snapcraft](https://snapcraft.io) - it uses the semver tags on branch `main` to choose latest release
* M `.github/workflows/release.yml`: job for auto-publishing to snapcraft. As per [documentation](https://github.com/snapcore/action-publish), requires a repo secret to be added. This will require coordination over the discord channel.

The snap is already published under version 0.2.0, available at https://snapcraft.io/prql-compiler 
