### PR TITLE
Fix prql-js usage example in readme

### DIFF
--- a/prql-js/README.md
+++ b/prql-js/README.md
@@ -28,7 +28,7 @@ or import it directly in a browser as an ES module, [build it using a suitable
 ```js
 import compile from "prql-js";
 
-const sql = compile(`from employees | select first_name`);
+const { sql, error } = compile(`from employees | select first_name`);
 console.log(sql);
 ```
 


### PR DESCRIPTION
`compile` returns a `CompileResult` that has `sql` and `error` keys

just console.logging the output of `compile` would result in something like
```
CompileResult { ptr: 1179656 }
```