### PR TITLE
Choose different time for cargo-audit cron

### DIFF
--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -2,7 +2,7 @@ name: Cargo audit
 
 on:
   schedule:
-    - cron: "33 6 * * *"
+    - cron: "49 6 * * *"
 
 jobs:
   audit:


### PR DESCRIPTION
We're getting rate limited at the existing time; maybe because it's a default that other people are using
