### PR TITLE
Remove `default-members`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,15 @@
 [workspace]
-default-members = ["prql-compiler"]
 members = [
   "prql-compiler",
   "prql-java",
   "prql-js",
   "prql-python",
   "book",
-  "book/mdbook-prql", # Should this be here or should we exclude?
+  "book/mdbook-prql",
 ]
+# Note we don't have a `default-members = ["prql-compiler"]`, since that causes
+# commands like `cargo test` to only run tests from the default package. And
+# `cargo insta test` doesn't have a `--workspace` flag.
 
 [profile.release.package.prql-js]
 # Tell `rustc` to optimize for small code size.

--- a/book/src/examples/employees.md
+++ b/book/src/examples/employees.md
@@ -10,6 +10,7 @@ Clone and init the database (requires a local PostgreSQL instance):
 
 Execute a PRQL query:
 
+    $ cd prql-compiler
     $ cargo run compile examples/employees/average-title-salary.prql | psql -U postgres -d employees
 
 ## Task 1


### PR DESCRIPTION
This was limiting `task build-all` & `task test-all`, and only eliminates a `cd prql-compiler` in order for `cargo run compile` to work
