### PR TITLE
Standardize test-databases crate

### DIFF
--- a/.github/actions/cargo-test/action.yaml
+++ b/.github/actions/cargo-test/action.yaml
@@ -31,7 +31,6 @@ runs:
         # tests, though in the docs it says it uses the target as the key?
         key: ${{ inputs.target }}
     - uses: jetli/wasm-bindgen-action@v0.1.0
-      if: ${{ inputs.target == 'wasm32-unknown-unknown' }}
       # Ignoring until https://github.com/prql/prql/pull/741 is resolved
     # - name: 📎 Clippy
     #   uses: actions-rs/cargo@v1
@@ -41,7 +40,6 @@ runs:
     #     args: --all-targets --workspace ${{ inputs.target_option }} -- -D warnings
     - name: ⌨️ Fmt
       uses: actions-rs/cargo@v1
-      if: ${{ inputs.target != 'wasm32-unknown-unknown' }}
       with:
         command: fmt
         args: --all --check

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,9 +30,8 @@ jobs:
         include:
           # TODO: I'm sure there's a better way of doing this, where `target_option` derives from `target`?
           - target: ""
-          # for wasm, test only prql-compiler crate
           - target: "wasm32-unknown-unknown"
-            target_option: "-p prql-compiler --target=wasm32-unknown-unknown"
+            target_option: "--target=wasm32-unknown-unknown"
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3

--- a/book/tests/snapshot.rs
+++ b/book/tests/snapshot.rs
@@ -4,11 +4,11 @@
 /// - Converts them to SQL using insta, raising an error if there's a diff.
 /// - Replaces the PRQL code block with a comparison table.
 //
-// Overall, this is sligthly overengineered — it's complicated and took a long
-// time to write. The intention is good — have a version of the SQL that's
-// committed into the repo, and join our tests with our docs. But it feels like
-// overly custom code for quite a general problem, even if our preferences are
-// slightly different from the general case.
+// Overall, this is overengineered — it's complicated and took a long time to
+// write. The intention is good — have a version of the SQL that's committed
+// into the repo, and join our tests with our docs. But it feels like overly
+// custom code for quite a general problem, even if our preferences are slightly
+// different from the general case.
 //
 // Possibly we should be using something like pandoc /
 // https://github.com/gpoore/codebraid / which would run the transformation for

--- a/test-databases/Cargo.toml
+++ b/test-databases/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
+edition = "2021"
 name = "test-databases"
 version = "0.1.0"
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-prql-compiler = {path = "../prql-compiler"}
-insta = {version = "1.14.0", features = ["colors", "glob"]}
-rusqlite = {version = "0.27.0", features = ["bundled", "csvtab"]}
 chrono = "0.4"
-duckdb = {version="0.4.0", features = ["bundled", "chrono"]}
+insta = {version = "1.14.0", features = ["colors", "glob"]}
+prql-compiler = {path = "../prql-compiler"}
 
+[target.'cfg(not(target_family="wasm"))'.dev-dependencies]
+duckdb = {version = "0.4.0", features = ["bundled", "chrono"]}
 postgres = "0.19.3"
+rusqlite = {version = "0.27.0", features = ["bundled", "csvtab"]}

--- a/test-databases/src/lib.rs
+++ b/test-databases/src/lib.rs
@@ -1,4 +1,4 @@
-fn main() {}
+#![cfg(not(target_family = "wasm"))]
 
 #[cfg(test)]
 mod tests {

--- a/test-databases/src/lib.rs
+++ b/test-databases/src/lib.rs
@@ -86,7 +86,7 @@ mod tests {
             let schema = load_schema();
             conn.execute_batch(&schema).unwrap();
             conn.execute_batch(
-                &r"
+                r"
                 COPY invoices FROM 'chinook/invoices.csv' (AUTO_DETECT TRUE);
                 COPY customers FROM 'chinook/customers.csv' (AUTO_DETECT TRUE);
                 COPY employees FROM 'chinook/employees.csv' (AUTO_DETECT TRUE);


### PR DESCRIPTION
Follow up to https://github.com/prql/prql/pull/724

So we're not special-casing things in GitHub Actions which would cause local tests to fail. One way to check that is whether `task test-all` works.

(Hope it's OK to do this @aljazerzen -- I thought easier to do it here given I'd done it before in other crates.)

BTW one option would be to make this an integration test in `prql-compiler`. I don't have much experience with the best way of organizing; but at least the promise of cargo integration tests is a separate compilation unit.

We could also try and integrate with our existing examples (and maybe those should go into an examples unit in prql-compiler...)
