### PR TITLE
Allow leading underscores for idents

### DIFF
--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -1861,4 +1861,49 @@ join `my-proj`.`dataset`.`table`
               named_args: {}
         "###)
     }
+
+    #[test]
+    fn test_parse_allowed_idents() {
+        assert_yaml_snapshot!(parse(r###"
+        from employees
+        join _salary [employee_id] # table with leading underscore
+        filter first_name == $1
+        select [_employees._underscored_column]
+        "###).unwrap(), @r###"
+        ---
+        version: ~
+        dialect: Generic
+        nodes:
+          - Pipeline:
+              nodes:
+                - FuncCall:
+                    name: from
+                    args:
+                      - Ident: employees
+                    named_args: {}
+                - FuncCall:
+                    name: join
+                    args:
+                      - Ident: _salary
+                      - List:
+                          - Ident: employee_id
+                    named_args: {}
+                - FuncCall:
+                    name: filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident: first_name
+                          op: Eq
+                          right:
+                            Ident: $1
+                    named_args: {}
+                - FuncCall:
+                    name: select
+                    args:
+                      - List:
+                          - Ident: _employees._underscored_column
+                    named_args: {}
+        "###)
+    }
 }

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -31,11 +31,11 @@ pipeline = { WHITESPACE* ~ expr_call ~ (pipe ~ expr_call)* }
 // We include backticks because some DBs use them (e.g. BigQuery) and we don't,
 // so we pass anything within them directly through, including otherwise invalid
 // idents, like those with hyphens. Possibly we should consider applying this to
-// expressions rather than just idens — we can adjust as we see more cases.
+// expressions rather than just idents — we can adjust as we see more cases.
 ident = @{ !operator ~ !(keyword ~ WHITESPACE) ~ ident_start ~ ("." ~ ident_next)* }
-// Either a normal ident (starting with a letter etc), or any string surrounded
+// Either a normal ident (starting with a letter, `$` or `_`), or any string surrounded
 // by backticks.
-ident_start = _{ ((ASCII_ALPHA | "$" ) ~ (ASCII_ALPHANUMERIC | "_" )* ) | ident_backticks+ }
+ident_start = _{ ((ASCII_ALPHA | "$" | "_") ~ (ASCII_ALPHANUMERIC | "_" )* ) | ident_backticks+ }
 // We allow `e.*`, but not just `*`, since it might conflict with multiply in
 // some cases.
 ident_next = _{ ident_start | "*" }


### PR DESCRIPTION
As briefly discussed on [discord](https://discord.com/channels/936728116712316989/945832046121607208/994914239028400148), this adds support for leading underscores in front of any idents.

In my case, this will allow us to get rid of a lot of s-strings!

This is my first rodeo both with prql's code base as well as Rust & pest – a through review is probably wise.