### PR TITLE
Fix >= (gte) and <= (lte) operators

### DIFF
--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -1906,4 +1906,71 @@ join `my-proj`.`dataset`.`table`
                     named_args: {}
         "###)
     }
+
+    #[test]
+    fn test_parse_gt_lt_gte_lte() {
+        assert_yaml_snapshot!(parse(r###"
+        from people
+        filter age >= 100
+        filter num_grandchildren <= 10
+        filter salary > 0
+        filter num_eyes < 2
+        "###).unwrap(), @r###"
+        ---
+        version: ~
+        dialect: Generic
+        nodes:
+          - Pipeline:
+              nodes:
+                - FuncCall:
+                    name: from
+                    args:
+                      - Ident: people
+                    named_args: {}
+                - FuncCall:
+                    name: filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident: age
+                          op: Gte
+                          right:
+                            Literal:
+                              Integer: 100
+                    named_args: {}
+                - FuncCall:
+                    name: filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident: num_grandchildren
+                          op: Lte
+                          right:
+                            Literal:
+                              Integer: 10
+                    named_args: {}
+                - FuncCall:
+                    name: filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident: salary
+                          op: Gt
+                          right:
+                            Literal:
+                              Integer: 0
+                    named_args: {}
+                - FuncCall:
+                    name: filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident: num_eyes
+                          op: Lt
+                          right:
+                            Literal:
+                              Integer: 2
+                    named_args: {}
+        "###)
+    }
 }

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -132,7 +132,7 @@ operator = _{ operator_unary | operator_mul | operator_add | operator_compare | 
 operator_unary = ${ "-" | "+" | "!" }
 operator_mul = ${ "*" | "/" | "%" }
 operator_add = ${ "+" | "-" }
-operator_compare = ${ "==" | "!=" | ">" | "<" | ">=" | "<=" }
+operator_compare = ${ "==" | "!=" | ">=" | "<=" | ">" | "<" }
 operator_logical = ${ ("and" | "or") ~ &WHITESPACE }
 operator_coalesce = ${ "??" }
 


### PR DESCRIPTION
Because of how pest works, `<=` was always first matching `<` and `>=` was matching `>`, and the `=` was then left just hanging there, erroring:

```
Error: during parsing
   ╭─[:3:13]
   │
 3 │ filter age >= 100
   ·             ┬  
   ·             ╰── expected expr_mul
───╯
```

For reference, here are the [relevant pest docs](https://pest.rs/book/grammars/peg.html#ordered-choice).