### PR TITLE
Use correct (bundler) build of prql-js for playground

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -14,7 +14,7 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.2.1",
         "monaco-editor": "^0.33.0",
-        "prql-js": "file:../prql-js/pkg",
+        "prql-js": "file:../prql-js",
         "react": "^18.1.0",
         "react-dom": "^18.2.0",
         "react-syntax-highlighter": "^15.5.0",
@@ -25,9 +25,8 @@
         "npm-watch": "^0.11.0"
       }
     },
-    "../prql-js/pkg": {
-      "name": "prql-js",
-      "version": "0.1.2",
+    "../prql-js": {
+      "version": "0.2.0",
       "license": "Apache-2.0"
     },
     "node_modules/@ampproject/remapping": {
@@ -12782,7 +12781,7 @@
       }
     },
     "node_modules/prql-js": {
-      "resolved": "../prql-js/pkg",
+      "resolved": "../prql-js",
       "link": true
     },
     "node_modules/prr": {
@@ -25116,7 +25115,7 @@
       }
     },
     "prql-js": {
-      "version": "file:../prql-js/pkg"
+      "version": "file:../prql-js"
     },
     "prr": {
       "version": "1.0.1",

--- a/playground/package.json
+++ b/playground/package.json
@@ -17,7 +17,7 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.2.1",
     "monaco-editor": "^0.33.0",
-    "prql-js": "file:../prql-js/pkg",
+    "prql-js": "file:../prql-js",
     "react": "^18.1.0",
     "react-dom": "^18.2.0",
     "react-syntax-highlighter": "^15.5.0",
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "preinstall": "cd ../prql-js && wasm-pack build",
+    "preinstall": "cd ../prql-js && npm run build-bundler",
     "start": "react-scripts start",
     "test": "react-scripts test"
   },

--- a/playground/src/workbench/Workbench.js
+++ b/playground/src/workbench/Workbench.js
@@ -1,7 +1,7 @@
 import "./Workbench.css";
 
 import React from "react";
-import * as prql from "prql-js";
+import * as prql from "prql-js/dist/bundler";
 
 import * as monacoTheme from "./monaco-theme.json";
 import * as monaco from "monaco-editor";

--- a/prql-js/README.md
+++ b/prql-js/README.md
@@ -26,6 +26,7 @@ const prql = require("prql-js");
 
 const { sql, error } = compile(`from employees | select first_name`);
 console.log(sql);
+// handle error as well...
 ```
 
 ### From a Browser
@@ -39,9 +40,10 @@ console.log(sql);
 
       async function run() {
         await wasm_bindgen("./node_modules/prql-js/dist/web/prql_js_bg.wasm");
-        const sql = compile("from employees | select first_name").sql;
+        const { sql, error } = compile("from employees | select first_name");
 
         console.log(sql);
+        // handle error as well...
       }
 
       run();
@@ -57,8 +59,9 @@ console.log(sql);
 ```typescript
 import compile from "prql-js/dist/bundler";
 
-const sql = compile(`from employees | select first_name`).sql;
+const { sql, error } = compile(`from employees | select first_name`);
 console.log(sql);
+// handle error as well...
 ```
 
 ## Notes

--- a/prql-js/README.md
+++ b/prql-js/README.md
@@ -22,7 +22,7 @@ function to_json(prql_string) # returns JSON string ( needs JSON.parse() to get 
 ### From NodeJS
 
 ```javascript
-const prql = require("prql-js/dist/node/prql_js.js");
+const prql = require("prql-js");
 
 const { sql, error } = compile(`from employees | select first_name`);
 console.log(sql);
@@ -55,7 +55,7 @@ console.log(sql);
 ### From a Framework or a Bundler
 
 ```typescript
-import compile from "prql-js/dist/bundler/prql_js";
+import compile from "prql-js/dist/bundler";
 
 const sql = compile(`from employees | select first_name`).sql;
 console.log(sql);
@@ -77,11 +77,10 @@ successfully in a rust-driven approach to this, RIP `prql-web`.
 Build:
 
 ```sh
-wasm-pack build
+npm run build-all
 ```
 
-This builds a node package in the `pkg` path. An example of including that as a
-dependency is in [`playground`](../playground/package.json).
+This builds Node, bundler and web packages in the `dist` path.
 
 Test:
 

--- a/prql-js/package.json
+++ b/prql-js/package.json
@@ -19,5 +19,5 @@
   ],
   "main": "dist/node/prql_js.js",
   "browser": "dist/web/prql_js.js",
-  "types": "prql_js.d.ts"
+  "types": "dist/node/prql_js.d.ts"
 }

--- a/prql-js/package.json
+++ b/prql-js/package.json
@@ -3,6 +3,12 @@
   "description": "Javascript bindings for prql-compiler",
   "version": "0.2.0",
   "license": "Apache-2.0",
+  "scripts": {
+    "build-node": "wasm-pack build --target nodejs --release --out-dir dist/node",
+    "build-bundler": "wasm-pack build --target bundler --release --out-dir dist/bundler",
+    "build-web": "wasm-pack build --target no-modules --release --out-dir dist/web",
+    "build-all": "npm run build-node && npm run build-bundler && npm run build-web"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/prql/prql"


### PR DESCRIPTION
Following https://github.com/prql/prql/pull/792, this makes the playground use the correct build of `prql-js`.