### PR TITLE
Remove version from mdbook-admonish install

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -59,7 +59,10 @@ jobs:
       - uses: actions-rs/install@v0.1
         with:
           crate: mdbook-admonish
-          version: 1.7.0
+          # This seems to not allow this to be installed from cache, which then
+          # takes 3.5min to install...
+          #
+          # version: 1.7.0
           use-tool-cache: true
       - name: 🔨 Build
         run: mdbook build


### PR DESCRIPTION
As dscribed in the comment, not worth the extra time to pin the version
