### PR TITLE
Dialects for ident escaping

### DIFF
--- a/book/src/language-features/s-strings.md
+++ b/book/src/language-features/s-strings.md
@@ -51,5 +51,5 @@ aren't otherwise valid; such as those containing a hyphen.
 
 ```prql
 from `project-foo.dataset.table`
-join `project-bar`.`dataset`.`table` [col_bax]
+join `project-bar.dataset.table` [col_bax]
 ```

--- a/book/tests/prql/language-features/s-strings-3.prql
+++ b/book/tests/prql/language-features/s-strings-3.prql
@@ -1,2 +1,2 @@
 from `project-foo.dataset.table`
-join `project-bar`.`dataset`.`table` [col_bax]
+join `project-bar.dataset.table` [col_bax]

--- a/book/tests/snapshots/snapshot__run_reference_prql@s-strings-3.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@s-strings-3.prql.snap
@@ -4,9 +4,9 @@ expression: sql
 input_file: book/tests/prql/language-features/s-strings-3.prql
 ---
 SELECT
-  `project-foo.dataset.table`.*,
-  `project-bar`.`dataset`.`table`.*,
+  "project-foo".dataset.table.*,
+  "project-bar".dataset.table.*,
   col_bax
 FROM
-  `project-foo.dataset.table`
-  JOIN `project-bar`.`dataset`.`table` USING(col_bax)
+  "project-foo.dataset.table"
+  JOIN "project-bar.dataset.table" USING(col_bax)

--- a/prql-compiler/src/ast/dialect.rs
+++ b/prql-compiler/src/ast/dialect.rs
@@ -58,8 +58,7 @@ pub trait DialectHandler {
     }
 }
 
-impl DialectHandler for GenericDialect {
-}
+impl DialectHandler for GenericDialect {}
 
 impl DialectHandler for MsSqlDialect {
     fn use_top(&self) -> bool {

--- a/prql-compiler/src/ast/dialect.rs
+++ b/prql-compiler/src/ast/dialect.rs
@@ -30,6 +30,7 @@ impl Dialect {
     pub fn handler(&self) -> Box<dyn DialectHandler> {
         match self {
             Dialect::MsSql => Box::new(MsSqlDialect),
+            Dialect::MySql => Box::new(MySqlDialect),
             _ => Box::new(GenericDialect),
         }
     }
@@ -42,20 +43,31 @@ impl Default for Dialect {
 }
 
 pub struct GenericDialect;
+pub struct MySqlDialect;
+
 pub struct MsSqlDialect;
 
 pub trait DialectHandler {
-    fn use_top(&self) -> bool;
-}
-
-impl DialectHandler for GenericDialect {
     fn use_top(&self) -> bool {
         false
     }
+
+    fn ident_quote(&self) -> char {
+        '"'
+    }
+}
+
+impl DialectHandler for GenericDialect {
 }
 
 impl DialectHandler for MsSqlDialect {
     fn use_top(&self) -> bool {
         true
+    }
+}
+
+impl DialectHandler for MySqlDialect {
+    fn ident_quote(&self) -> char {
+        '`'
     }
 }

--- a/prql-compiler/src/ast/dialect.rs
+++ b/prql-compiler/src/ast/dialect.rs
@@ -31,6 +31,7 @@ impl Dialect {
         match self {
             Dialect::MsSql => Box::new(MsSqlDialect),
             Dialect::MySql => Box::new(MySqlDialect),
+            Dialect::BigQuery => Box::new(BigQueryDialect),
             _ => Box::new(GenericDialect),
         }
     }
@@ -44,8 +45,8 @@ impl Default for Dialect {
 
 pub struct GenericDialect;
 pub struct MySqlDialect;
-
 pub struct MsSqlDialect;
+pub struct BigQueryDialect;
 
 pub trait DialectHandler {
     fn use_top(&self) -> bool {
@@ -67,6 +68,12 @@ impl DialectHandler for MsSqlDialect {
 }
 
 impl DialectHandler for MySqlDialect {
+    fn ident_quote(&self) -> char {
+        '`'
+    }
+}
+
+impl DialectHandler for BigQueryDialect {
     fn ident_quote(&self) -> char {
         '`'
     }

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -222,11 +222,10 @@ fn ast_of_parse_pair(pair: Pair<Rule>) -> Result<Option<Node>> {
         }
         Rule::ident | Rule::jinja => {
             let inner = pair.as_str();
-            let stripped = if inner.starts_with('`') && inner.ends_with('`') {
-                &inner[1..inner.len() - 1]
-            } else {
-                inner
-            };
+            let stripped = inner
+                .strip_prefix('`')
+                .and_then(|s| s.strip_suffix('`'))
+                .unwrap_or(inner);
             Item::Ident(stripped.to_string())
         }
 

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -220,7 +220,15 @@ fn ast_of_parse_pair(pair: Pair<Rule>) -> Result<Option<Node>> {
                 pipeline: Box::new(pipeline),
             })
         }
-        Rule::ident | Rule::jinja => Item::Ident(pair.as_str().to_string()),
+        Rule::ident | Rule::jinja => {
+            let inner = pair.as_str();
+            let stripped = if inner.starts_with('`') && inner.ends_with('`') {
+                &inner[1..inner.len() - 1]
+            } else {
+                inner
+            };
+            Item::Ident(stripped.to_string())
+        }
 
         Rule::number => {
             let str = pair.as_str();
@@ -1469,7 +1477,7 @@ join `my-proj`.`dataset`.`table`
                 - FuncCall:
                     name: from
                     args:
-                      - Ident: "`a`"
+                      - Ident: a
                     named_args: {}
                 - FuncCall:
                     name: aggregate
@@ -1484,12 +1492,12 @@ join `my-proj`.`dataset`.`table`
                 - FuncCall:
                     name: join
                     args:
-                      - Ident: "`my-proj.dataset.table`"
+                      - Ident: my-proj.dataset.table
                     named_args: {}
                 - FuncCall:
                     name: join
                     args:
-                      - Ident: "`my-proj`.`dataset`.`table`"
+                      - Ident: "my-proj`.`dataset`.`table"
                     named_args: {}
         "###);
 

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -134,10 +134,7 @@ fn table_to_sql_cte(table: AtomicTable, dialect: &dyn DialectHandler) -> Result<
     })
 }
 
-fn table_factor_of_table_ref(
-    table_ref: &TableRef,
-    dialect: &dyn DialectHandler,
-) -> TableFactor {
+fn table_factor_of_table_ref(table_ref: &TableRef, dialect: &dyn DialectHandler) -> TableFactor {
     TableFactor::Table {
         name: ObjectName(vec![translate_ident(table_ref.name.clone(), dialect)]),
         alias: table_ref.alias.clone().map(|a| TableAlias {
@@ -429,10 +426,7 @@ fn filter_of_pipeline(
     filter_of_filters(filters, dialect)
 }
 
-fn filter_of_filters(
-    conditions: Vec<Node>,
-    dialect: &dyn DialectHandler,
-) -> Result<Option<Expr>> {
+fn filter_of_filters(conditions: Vec<Node>, dialect: &dyn DialectHandler) -> Result<Option<Expr>> {
     let mut condition = None;
     for filter in conditions {
         if let Some(left) = condition {
@@ -716,10 +710,7 @@ fn translate_func_call(func_call: FuncCall, dialect: &dyn DialectHandler) -> Res
         distinct: false,
     })
 }
-fn translate_column_sort(
-    sort: ColumnSort,
-    dialect: &dyn DialectHandler,
-) -> Result<OrderByExpr> {
+fn translate_column_sort(sort: ColumnSort, dialect: &dyn DialectHandler) -> Result<OrderByExpr> {
     Ok(OrderByExpr {
         expr: translate_item(sort.column.item, dialect)?,
         asc: if matches!(sort.direction, SortDirection::Asc) {

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -72,6 +72,8 @@ pub fn translate_query(query: Query, context: Context) -> Result<sql_ast::Query>
         });
     }
 
+    let dialect = query.dialect.handler();
+
     // take last table
     if materialized.is_empty() {
         bail!("No tables?");
@@ -82,11 +84,11 @@ pub fn translate_query(query: Query, context: Context) -> Result<sql_ast::Query>
     // convert each of the CTEs
     let ctes: Vec<_> = ctes
         .into_iter()
-        .map(|t| table_to_sql_cte(t, &query.dialect))
+        .map(|t| table_to_sql_cte(t, &dialect))
         .try_collect()?;
 
     // convert main query
-    let mut main_query = sql_query_of_atomic_table(main_query, &query.dialect)?;
+    let mut main_query = sql_query_of_atomic_table(main_query, &dialect)?;
 
     // attach CTEs
     if !ctes.is_empty() {
@@ -120,9 +122,9 @@ fn into_tables(nodes: Vec<Node>) -> Result<Vec<Table>> {
     Ok([tables, vec![transforms.into()]].concat())
 }
 
-fn table_to_sql_cte(table: AtomicTable, dialect: &Dialect) -> Result<sql_ast::Cte> {
+fn table_to_sql_cte(table: AtomicTable, dialect: &Box<dyn DialectHandler>) -> Result<sql_ast::Cte> {
     let alias = sql_ast::TableAlias {
-        name: Item::Ident(table.name.clone().unwrap().name).try_into()?,
+        name: translate_ident(table.name.clone().unwrap().name, dialect),
         columns: vec![],
     };
     Ok(sql_ast::Cte {
@@ -132,13 +134,14 @@ fn table_to_sql_cte(table: AtomicTable, dialect: &Dialect) -> Result<sql_ast::Ct
     })
 }
 
-fn table_factor_of_table_ref(table_ref: &TableRef) -> TableFactor {
+fn table_factor_of_table_ref(
+    table_ref: &TableRef,
+    dialect: &Box<dyn DialectHandler>,
+) -> TableFactor {
     TableFactor::Table {
-        name: ObjectName(vec![Item::Ident(table_ref.name.clone())
-            .try_into()
-            .unwrap()]),
+        name: ObjectName(vec![translate_ident(table_ref.name.clone(), dialect)]),
         alias: table_ref.alias.clone().map(|a| TableAlias {
-            name: Item::Ident(a).try_into().unwrap(),
+            name: translate_ident(a, dialect),
             columns: vec![],
         }),
         args: None,
@@ -148,7 +151,10 @@ fn table_factor_of_table_ref(table_ref: &TableRef) -> TableFactor {
 
 // impl Translator for
 // fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sql_ast::Query> {
-fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sql_ast::Query> {
+fn sql_query_of_atomic_table(
+    table: AtomicTable,
+    dialect: &Box<dyn DialectHandler>,
+) -> Result<sql_ast::Query> {
     let frame = table.frame.ok_or_else(|| anyhow!("frame not provided?"))?;
 
     let transforms = table.pipeline.into_transforms()?;
@@ -157,7 +163,7 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
         .iter()
         .filter_map(|t| match t {
             Transform::From(table_ref) => Some(TableWithJoins {
-                relation: table_factor_of_table_ref(table_ref),
+                relation: table_factor_of_table_ref(table_ref, dialect),
                 joins: vec![],
             }),
             _ => None,
@@ -167,7 +173,7 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
     let joins = transforms
         .iter()
         .filter(|t| matches!(t, Transform::Join { .. }))
-        .map(Join::try_from)
+        .map(|j| translate_join(j, dialect))
         .collect::<Result<Vec<_>>>()?;
     if !joins.is_empty() {
         if let Some(from) = from.last_mut() {
@@ -185,8 +191,8 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
     let (before, after) = transforms.split_at(aggregate_position);
 
     // Find the filters that come before the aggregation.
-    let where_ = filter_of_pipeline(before)?;
-    let having = filter_of_pipeline(after)?;
+    let where_ = filter_of_pipeline(before, dialect)?;
+    let having = filter_of_pipeline(after, dialect)?;
 
     let takes = transforms
         .iter()
@@ -203,7 +209,7 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
         None
     } else {
         Some(sqlparser::ast::Offset {
-            value: Item::Literal(Literal::Integer(offset)).try_into()?,
+            value: translate_item(Item::Literal(Literal::Integer(offset)), dialect)?,
             rows: sqlparser::ast::OffsetRows::None,
         })
     };
@@ -211,7 +217,7 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
     // Use sorting from the frame
     let order_by = (frame.sort)
         .into_iter()
-        .map(OrderByExpr::try_from)
+        .map(|s| translate_column_sort(s, dialect))
         .try_collect()?;
 
     let aggregate = transforms.get(aggregate_position);
@@ -221,7 +227,6 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
         None => vec![],
         _ => unreachable!("Expected an aggregate transformation"),
     };
-    let dialect = dialect.handler();
 
     let distinct = transforms.iter().any(|t| matches!(t, Transform::Unique));
 
@@ -229,18 +234,18 @@ fn sql_query_of_atomic_table(table: AtomicTable, dialect: &Dialect) -> Result<sq
         body: SetExpr::Select(Box::new(Select {
             distinct,
             top: if dialect.use_top() {
-                limit.map(top_of_i64)
+                limit.map(|l| top_of_i64(l, dialect))
             } else {
                 None
             },
             projection: (frame.columns.into_iter())
-                .map(|n| n.item.try_into())
+                .map(|n| translate_select_item(n.item, dialect))
                 .try_collect()?,
             into: None,
             from,
             lateral_views: vec![],
             selection: where_,
-            group_by: try_into_exprs(group_bys)?,
+            group_by: try_into_exprs(group_bys, dialect)?,
             cluster_by: vec![],
             distribute_by: vec![],
             sort_by: vec![],
@@ -410,7 +415,10 @@ fn range_of_ranges(ranges: Vec<Range>) -> Result<Range<i64>> {
     Ok(current)
 }
 
-fn filter_of_pipeline(pipeline: &[Transform]) -> Result<Option<Expr>> {
+fn filter_of_pipeline(
+    pipeline: &[Transform],
+    dialect: &Box<dyn DialectHandler>,
+) -> Result<Option<Expr>> {
     let filters: Vec<Node> = pipeline
         .iter()
         .filter_map(|t| match t {
@@ -418,10 +426,13 @@ fn filter_of_pipeline(pipeline: &[Transform]) -> Result<Option<Expr>> {
             _ => None,
         })
         .collect();
-    filter_of_filters(filters)
+    filter_of_filters(filters, dialect)
 }
 
-fn filter_of_filters(conditions: Vec<Node>) -> Result<Option<Expr>> {
+fn filter_of_filters(
+    conditions: Vec<Node>,
+    dialect: &Box<dyn DialectHandler>,
+) -> Result<Option<Expr>> {
     let mut condition = None;
     for filter in conditions {
         if let Some(left) = condition {
@@ -435,7 +446,9 @@ fn filter_of_filters(conditions: Vec<Node>) -> Result<Option<Expr>> {
         }
     }
 
-    condition.map(|n| n.item.try_into()).transpose()
+    condition
+        .map(|n| translate_item(n.item, dialect))
+        .transpose()
 }
 
 fn expr_of_i64(number: i64) -> Expr {
@@ -445,200 +458,205 @@ fn expr_of_i64(number: i64) -> Expr {
     ))
 }
 
-fn top_of_i64(take: i64) -> Top {
+fn top_of_i64(take: i64, dialect: &Box<dyn DialectHandler>) -> Top {
     Top {
-        quantity: Some(Item::Literal(Literal::Integer(take)).try_into().unwrap()),
+        quantity: Some(translate_item(Item::Literal(Literal::Integer(take)), dialect).unwrap()),
         with_ties: false,
         percent: false,
     }
 }
-fn try_into_exprs(nodes: Vec<Node>) -> Result<Vec<Expr>> {
+fn try_into_exprs(nodes: Vec<Node>, dialect: &Box<dyn DialectHandler>) -> Result<Vec<Expr>> {
     nodes
         .into_iter()
         .map(|x| x.item)
-        .map(Expr::try_from)
+        .map(|item| translate_item(item, dialect))
         .try_collect()
 }
 
-impl TryFrom<Item> for SelectItem {
-    type Error = anyhow::Error;
-    fn try_from(item: Item) -> Result<Self> {
-        Ok(match item {
-            Item::Binary { .. }
-            | Item::Unary { .. }
-            | Item::SString(_)
-            | Item::FString(_)
-            | Item::Ident(_)
-            | Item::Literal(_)
-            | Item::Windowed(_) => SelectItem::UnnamedExpr(Expr::try_from(item)?),
-            Item::Assign(named) => SelectItem::ExprWithAlias {
-                alias: sql_ast::Ident::new(named.name),
-                expr: named.expr.item.try_into()?,
-            },
-            _ => bail!("Can't convert to SelectItem; {:?}", item),
-        })
-    }
+fn translate_select_item(item: Item, dialect: &Box<dyn DialectHandler>) -> Result<SelectItem> {
+    Ok(match item {
+        Item::Binary { .. }
+        | Item::Unary { .. }
+        | Item::SString(_)
+        | Item::FString(_)
+        | Item::Ident(_)
+        | Item::Literal(_)
+        | Item::Windowed(_) => SelectItem::UnnamedExpr(translate_item(item, dialect)?),
+        Item::Assign(named) => SelectItem::ExprWithAlias {
+            alias: translate_ident(named.name, dialect),
+            expr: translate_item(named.expr.item, dialect)?,
+        },
+        _ => bail!("Can't convert to SelectItem; {:?}", item),
+    })
 }
-impl TryFrom<Item> for Expr {
-    type Error = anyhow::Error;
-    fn try_from(item: Item) -> Result<Self> {
-        Ok(match item {
-            Item::Ident(_) => Expr::Identifier(item.try_into()?),
 
-            // do we need to surround operations with parentheses?
-            Item::Binary { op, left, right } => {
-                if let Some(is_null) = try_into_is_null(&op, &left, &right)? {
-                    is_null
-                } else {
-                    Expr::BinaryOp {
-                        left: Box::new(left.item.try_into()?),
-                        op: match op {
-                            BinOp::Mul => BinaryOperator::Multiply,
-                            BinOp::Div => BinaryOperator::Divide,
-                            BinOp::Mod => BinaryOperator::Modulo,
-                            BinOp::Add => BinaryOperator::Plus,
-                            BinOp::Sub => BinaryOperator::Minus,
-                            BinOp::Eq => BinaryOperator::Eq,
-                            BinOp::Ne => BinaryOperator::NotEq,
-                            BinOp::Gt => BinaryOperator::Gt,
-                            BinOp::Lt => BinaryOperator::Lt,
-                            BinOp::Gte => BinaryOperator::GtEq,
-                            BinOp::Lte => BinaryOperator::LtEq,
-                            BinOp::And => BinaryOperator::And,
-                            BinOp::Or => BinaryOperator::Or,
-                            BinOp::Coalesce => unreachable!(),
-                        },
-                        right: Box::new(right.item.try_into()?),
-                    }
-                }
-            }
+fn translate_item(item: Item, dialect: &Box<dyn DialectHandler>) -> Result<Expr> {
+    Ok(match item {
+        Item::Ident(ident) => Expr::CompoundIdentifier(
+            ident
+                .split('.')
+                .map(|part| translate_ident(part.to_string(), dialect))
+                .collect(),
+        ),
 
-            Item::Unary { op, expr: a } => Expr::UnaryOp {
-                op: match op {
-                    UnOp::Neg => UnaryOperator::Minus,
-                    UnOp::Not => UnaryOperator::Not,
-                },
-                expr: Box::new(a.item.try_into()?),
-            },
-
-            Item::Range(r) => {
-                fn assert_bound(bound: Option<Box<Node>>) -> Result<Node, Error> {
-                    bound.map(|b| *b).ok_or_else(|| {
-                        Error::new(Reason::Simple(
-                            "range requires both bounds to be used this way".to_string(),
-                        ))
-                    })
-                }
-                let start: Expr = assert_bound(r.start)?.item.try_into()?;
-                let end: Expr = assert_bound(r.end)?.item.try_into()?;
-                Expr::Identifier(sql_ast::Ident::new(format!("{} AND {}", start, end)))
-            }
-            // Fairly hacky — convert everything to a string, then concat it,
-            // then convert to Expr. We can't use the `Item::Expr` code above
-            // since we don't want to intersperse with spaces.
-            Item::SString(s_string_items) => {
-                let string = s_string_items
-                    .into_iter()
-                    .map(|s_string_item| match s_string_item {
-                        InterpolateItem::String(string) => Ok(string),
-                        InterpolateItem::Expr(node) => {
-                            Expr::try_from(node.item).map(|expr| expr.to_string())
-                        }
-                    })
-                    .collect::<Result<Vec<String>>>()?
-                    .join("");
-                Item::Ident(string).try_into()?
-            }
-            Item::FString(f_string_items) => {
-                let args = f_string_items
-                    .into_iter()
-                    .map(|item| match item {
-                        InterpolateItem::String(string) => {
-                            Ok(Expr::Value(Value::SingleQuotedString(string)))
-                        }
-                        InterpolateItem::Expr(node) => Expr::try_from(node.item),
-                    })
-                    .map(|r| r.map(|e| FunctionArg::Unnamed(FunctionArgExpr::Expr(e))))
-                    .collect::<Result<Vec<_>>>()?;
-
-                Expr::Function(Function {
-                    name: ObjectName(vec![sql_ast::Ident::new("CONCAT")]),
-                    args,
-                    distinct: false,
-                    over: None,
-                })
-            }
-            Item::Interval(interval) => {
-                let sql_parser_datetime = match interval.unit.as_str() {
-                    "years" => DateTimeField::Year,
-                    "months" => DateTimeField::Month,
-                    "days" => DateTimeField::Day,
-                    "hours" => DateTimeField::Hour,
-                    "minutes" => DateTimeField::Minute,
-                    "seconds" => DateTimeField::Second,
-                    _ => bail!("Unsupported interval unit: {}", interval.unit),
-                };
-                Expr::Value(Value::Interval {
-                    value: interval.n.to_string(),
-                    leading_field: Some(sql_parser_datetime),
-                    leading_precision: None,
-                    last_field: None,
-                    fractional_seconds_precision: None,
-                })
-            }
-            Item::Windowed(window) => {
-                let expr = Expr::try_from(window.expr.item)?;
-
-                let default_frame = if window.sort.is_empty() {
-                    (WindowKind::Rows, Range::unbounded())
-                } else {
-                    (WindowKind::Range, Range::from_ints(None, Some(0)))
-                };
-
-                let window = WindowSpec {
-                    partition_by: try_into_exprs(window.group)?,
-                    order_by: (window.sort)
-                        .into_iter()
-                        .map(OrderByExpr::try_from)
-                        .try_collect()?,
-                    window_frame: if window.window == default_frame {
-                        None
-                    } else {
-                        Some(try_into_window_frame(window.window)?)
+        // do we need to surround operations with parentheses?
+        Item::Binary { op, left, right } => {
+            if let Some(is_null) = try_into_is_null(&op, &left, &right, dialect)? {
+                is_null
+            } else {
+                Expr::BinaryOp {
+                    left: Box::new(translate_item(left.item, dialect)?),
+                    op: match op {
+                        BinOp::Mul => BinaryOperator::Multiply,
+                        BinOp::Div => BinaryOperator::Divide,
+                        BinOp::Mod => BinaryOperator::Modulo,
+                        BinOp::Add => BinaryOperator::Plus,
+                        BinOp::Sub => BinaryOperator::Minus,
+                        BinOp::Eq => BinaryOperator::Eq,
+                        BinOp::Ne => BinaryOperator::NotEq,
+                        BinOp::Gt => BinaryOperator::Gt,
+                        BinOp::Lt => BinaryOperator::Lt,
+                        BinOp::Gte => BinaryOperator::GtEq,
+                        BinOp::Lte => BinaryOperator::LtEq,
+                        BinOp::And => BinaryOperator::And,
+                        BinOp::Or => BinaryOperator::Or,
+                        BinOp::Coalesce => unreachable!(),
                     },
-                };
-
-                Item::Ident(format!("{expr} OVER ({window})")).try_into()?
+                    right: Box::new(translate_item(right.item, dialect)?),
+                }
             }
-            Item::Literal(l) => match l {
-                Literal::Null => Expr::Value(Value::Null),
-                Literal::String(s) => Expr::Value(Value::SingleQuotedString(s)),
-                Literal::Boolean(b) => Expr::Value(Value::Boolean(b)),
-                Literal::Float(f) => Expr::Value(Value::Number(format!("{f}"), false)),
-                Literal::Integer(i) => Expr::Value(Value::Number(format!("{i}"), false)),
-                Literal::Date(value) => Expr::TypedString {
-                    data_type: sql_ast::DataType::Date,
-                    value,
-                },
-                Literal::Time(value) => Expr::TypedString {
-                    data_type: sql_ast::DataType::Time,
-                    value,
-                },
-                Literal::Timestamp(value) => Expr::TypedString {
-                    data_type: sql_ast::DataType::Timestamp,
-                    value,
-                },
+        }
+
+        Item::Unary { op, expr: a } => Expr::UnaryOp {
+            op: match op {
+                UnOp::Neg => UnaryOperator::Minus,
+                UnOp::Not => UnaryOperator::Not,
             },
-            _ => bail!("Can't convert to Expr; {item:?}"),
-        })
-    }
+            expr: Box::new(translate_item(a.item, dialect)?),
+        },
+
+        Item::Range(r) => {
+            fn assert_bound(bound: Option<Box<Node>>) -> Result<Node, Error> {
+                bound.map(|b| *b).ok_or_else(|| {
+                    Error::new(Reason::Simple(
+                        "range requires both bounds to be used this way".to_string(),
+                    ))
+                })
+            }
+            let start: Expr = translate_item(assert_bound(r.start)?.item, dialect)?;
+            let end: Expr = translate_item(assert_bound(r.end)?.item, dialect)?;
+            Expr::Identifier(sql_ast::Ident::new(format!("{} AND {}", start, end)))
+        }
+        // Fairly hacky — convert everything to a string, then concat it,
+        // then convert to Expr. We can't use the `Item::Expr` code above
+        // since we don't want to intersperse with spaces.
+        Item::SString(s_string_items) => {
+            let string = s_string_items
+                .into_iter()
+                .map(|s_string_item| match s_string_item {
+                    InterpolateItem::String(string) => Ok(string),
+                    InterpolateItem::Expr(node) => {
+                        translate_item(node.item, dialect).map(|expr| expr.to_string())
+                    }
+                })
+                .collect::<Result<Vec<String>>>()?
+                .join("");
+            Expr::Identifier(sql_ast::Ident::new(string))
+        }
+        Item::FString(f_string_items) => {
+            let args = f_string_items
+                .into_iter()
+                .map(|item| match item {
+                    InterpolateItem::String(string) => {
+                        Ok(Expr::Value(Value::SingleQuotedString(string)))
+                    }
+                    InterpolateItem::Expr(node) => translate_item(node.item, dialect),
+                })
+                .map(|r| r.map(|e| FunctionArg::Unnamed(FunctionArgExpr::Expr(e))))
+                .collect::<Result<Vec<_>>>()?;
+
+            Expr::Function(Function {
+                name: ObjectName(vec![sql_ast::Ident::new("CONCAT")]),
+                args,
+                distinct: false,
+                over: None,
+            })
+        }
+        Item::Interval(interval) => {
+            let sql_parser_datetime = match interval.unit.as_str() {
+                "years" => DateTimeField::Year,
+                "months" => DateTimeField::Month,
+                "days" => DateTimeField::Day,
+                "hours" => DateTimeField::Hour,
+                "minutes" => DateTimeField::Minute,
+                "seconds" => DateTimeField::Second,
+                _ => bail!("Unsupported interval unit: {}", interval.unit),
+            };
+            Expr::Value(Value::Interval {
+                value: interval.n.to_string(),
+                leading_field: Some(sql_parser_datetime),
+                leading_precision: None,
+                last_field: None,
+                fractional_seconds_precision: None,
+            })
+        }
+        Item::Windowed(window) => {
+            let expr = translate_item(window.expr.item, dialect)?;
+
+            let default_frame = if window.sort.is_empty() {
+                (WindowKind::Rows, Range::unbounded())
+            } else {
+                (WindowKind::Range, Range::from_ints(None, Some(0)))
+            };
+
+            let window = WindowSpec {
+                partition_by: try_into_exprs(window.group, dialect)?,
+                order_by: (window.sort)
+                    .into_iter()
+                    .map(|s| translate_column_sort(s, dialect))
+                    .try_collect()?,
+                window_frame: if window.window == default_frame {
+                    None
+                } else {
+                    Some(try_into_window_frame(window.window)?)
+                },
+            };
+
+            Expr::Identifier(sql_ast::Ident::new(format!("{expr} OVER ({window})")))
+        }
+        Item::Literal(l) => match l {
+            Literal::Null => Expr::Value(Value::Null),
+            Literal::String(s) => Expr::Value(Value::SingleQuotedString(s)),
+            Literal::Boolean(b) => Expr::Value(Value::Boolean(b)),
+            Literal::Float(f) => Expr::Value(Value::Number(format!("{f}"), false)),
+            Literal::Integer(i) => Expr::Value(Value::Number(format!("{i}"), false)),
+            Literal::Date(value) => Expr::TypedString {
+                data_type: sql_ast::DataType::Date,
+                value,
+            },
+            Literal::Time(value) => Expr::TypedString {
+                data_type: sql_ast::DataType::Time,
+                value,
+            },
+            Literal::Timestamp(value) => Expr::TypedString {
+                data_type: sql_ast::DataType::Timestamp,
+                value,
+            },
+        },
+        _ => bail!("Can't convert to Expr; {item:?}"),
+    })
 }
-fn try_into_is_null(op: &BinOp, a: &Node, b: &Node) -> Result<Option<Expr>> {
+fn try_into_is_null(
+    op: &BinOp,
+    a: &Node,
+    b: &Node,
+    dialect: &Box<dyn DialectHandler>,
+) -> Result<Option<Expr>> {
     if matches!(op, BinOp::Eq) || matches!(op, BinOp::Ne) {
         let expr = if matches!(a.item, Item::Literal(Literal::Null)) {
-            Expr::try_from(b.item.clone())?
+            translate_item(b.item.clone(), dialect)?
         } else if matches!(b.item, Item::Literal(Literal::Null)) {
-            Expr::try_from(a.item.clone())?
+            translate_item(a.item.clone(), dialect)?
         } else {
             return Ok(None);
         };
@@ -680,81 +698,93 @@ fn try_into_window_frame((kind, range): (WindowKind, Range)) -> Result<sql_ast::
     })
 }
 
-impl TryFrom<FuncCall> for Function {
-    // I had an idea to for stdlib functions to have "native" keyword, which would prevent them from being
-    // resolved and materialized and would be passed to here. But that has little advantage over current approach.
-    // After some time when we know that current approach is good, this impl can be removed.
-    type Error = anyhow::Error;
-    fn try_from(func_call: FuncCall) -> Result<Self> {
-        let FuncCall { name, args, .. } = func_call;
+// I had an idea to for stdlib functions to have "native" keyword, which would prevent them from being
+// resolved and materialized and would be passed to here. But that has little advantage over current approach.
+// After some time when we know that current approach is good, this impl can be removed.
+#[allow(dead_code)]
+fn translate_func_call(func_call: FuncCall, dialect: &Box<dyn DialectHandler>) -> Result<Function> {
+    let FuncCall { name, args, .. } = func_call;
 
-        Ok(Function {
-            name: ObjectName(vec![sql_ast::Ident::new(name)]),
-            args: args
-                .into_iter()
-                .map(|a| Expr::try_from(a.item))
-                .map(|e| e.map(|a| FunctionArg::Unnamed(FunctionArgExpr::Expr(a))))
-                .collect::<Result<Vec<_>>>()?,
-            over: None,
-            distinct: false,
-        })
-    }
+    Ok(Function {
+        name: ObjectName(vec![sql_ast::Ident::new(name)]),
+        args: args
+            .into_iter()
+            .map(|a| translate_item(a.item, dialect))
+            .map(|e| e.map(|a| FunctionArg::Unnamed(FunctionArgExpr::Expr(a))))
+            .collect::<Result<Vec<_>>>()?,
+        over: None,
+        distinct: false,
+    })
 }
-impl TryFrom<ColumnSort> for OrderByExpr {
-    type Error = anyhow::Error;
-    fn try_from(sort: ColumnSort) -> Result<Self> {
-        Ok(OrderByExpr {
-            expr: sort.column.item.try_into()?,
-            asc: if matches!(sort.direction, SortDirection::Asc) {
-                None // default order is ASC, so there is no need to emit it
-            } else {
-                Some(false)
-            },
-            nulls_first: None,
-        })
-    }
+fn translate_column_sort(
+    sort: ColumnSort,
+    dialect: &Box<dyn DialectHandler>,
+) -> Result<OrderByExpr> {
+    Ok(OrderByExpr {
+        expr: translate_item(sort.column.item, dialect)?,
+        asc: if matches!(sort.direction, SortDirection::Asc) {
+            None // default order is ASC, so there is no need to emit it
+        } else {
+            Some(false)
+        },
+        nulls_first: None,
+    })
 }
-impl TryFrom<&Transform> for Join {
-    type Error = anyhow::Error;
-    fn try_from(t: &Transform) -> Result<Join> {
-        match t {
-            Transform::Join { side, with, filter } => {
-                let constraint = match filter {
-                    JoinFilter::On(nodes) => JoinConstraint::On(
-                        filter_of_filters(nodes.clone())?
-                            .unwrap_or(Expr::Value(Value::Boolean(true))),
-                    ),
-                    JoinFilter::Using(nodes) => JoinConstraint::Using(
-                        nodes
-                            .iter()
-                            .map(|x| x.item.clone().try_into())
-                            .collect::<Result<Vec<_>>>()?,
-                    ),
-                };
 
-                Ok(Join {
-                    relation: table_factor_of_table_ref(with),
-                    join_operator: match *side {
-                        JoinSide::Inner => JoinOperator::Inner(constraint),
-                        JoinSide::Left => JoinOperator::LeftOuter(constraint),
-                        JoinSide::Right => JoinOperator::RightOuter(constraint),
-                        JoinSide::Full => JoinOperator::FullOuter(constraint),
-                    },
-                })
-            }
-            _ => unreachable!(),
+fn translate_join(t: &Transform, dialect: &Box<dyn DialectHandler>) -> Result<Join> {
+    match t {
+        Transform::Join { side, with, filter } => {
+            let constraint = match filter {
+                JoinFilter::On(nodes) => JoinConstraint::On(
+                    filter_of_filters(nodes.clone(), dialect)?
+                        .unwrap_or(Expr::Value(Value::Boolean(true))),
+                ),
+                JoinFilter::Using(nodes) => JoinConstraint::Using(
+                    nodes
+                        .iter()
+                        .map(|x| Ok(translate_ident(x.item.clone().into_ident()?, dialect)))
+                        .collect::<Result<Vec<_>>>()?,
+                ),
+            };
+
+            Ok(Join {
+                relation: table_factor_of_table_ref(with, dialect),
+                join_operator: match *side {
+                    JoinSide::Inner => JoinOperator::Inner(constraint),
+                    JoinSide::Left => JoinOperator::LeftOuter(constraint),
+                    JoinSide::Right => JoinOperator::RightOuter(constraint),
+                    JoinSide::Full => JoinOperator::FullOuter(constraint),
+                },
+            })
         }
+        _ => unreachable!(),
     }
 }
-impl TryFrom<Item> for sql_ast::Ident {
-    type Error = anyhow::Error;
-    fn try_from(item: Item) -> Result<Self> {
-        Ok(match item {
-            Item::Ident(ident) => sql_ast::Ident::new(ident),
-            _ => bail!("Can't convert to Ident; {item:?}"),
-        })
+
+fn translate_ident(ident: String, dialect: &Box<dyn DialectHandler>) -> sql_ast::Ident {
+    fn starting_forbidden(c: char) -> bool {
+        !(('a'..='z').contains(&c) || matches!(c, '_' | '$'))
+    }
+
+    fn subsequent_forbidden(c: char) -> bool {
+        !(('a'..='z').contains(&c) || ('0'..='9').contains(&c) || matches!(c, '_' | '$'))
+    }
+
+    let is_jinja = ident.starts_with("{{") && ident.ends_with("}}");
+    let is_asterisk = ident == "*";
+
+    if !is_jinja
+        && !is_asterisk
+        && (ident.is_empty()
+            || ident.starts_with(starting_forbidden)
+            || (ident.len() > 1 && ident.contains(subsequent_forbidden)))
+    {
+        sql_ast::Ident::with_quote(dialect.ident_quote(), ident)
+    } else {
+        sql_ast::Ident::new(ident)
     }
 }
+
 impl From<Vec<Node>> for Table {
     fn from(functions: Vec<Node>) -> Self {
         Table {
@@ -778,9 +808,7 @@ impl From<Vec<Node>> for AtomicTable {
 mod test {
     use super::*;
     use crate::{parser::parse, resolve_and_translate, resolve_names, sql::load_std_lib};
-    use insta::{
-        assert_debug_snapshot, assert_display_snapshot, assert_snapshot, assert_yaml_snapshot,
-    };
+    use insta::{assert_display_snapshot, assert_snapshot, assert_yaml_snapshot};
     use serde_yaml::from_str;
 
     #[test]
@@ -913,6 +941,7 @@ mod test {
 
     #[test]
     fn test_try_from_s_string_to_expr() -> Result<()> {
+        let dialect = Dialect::Generic.handler();
         let ast: Node = from_str(
             r"
         SString:
@@ -922,7 +951,7 @@ mod test {
         - String: )
         ",
         )?;
-        let expr: Expr = ast.item.try_into()?;
+        let expr: Expr = translate_item(ast.item, &dialect)?;
         assert_yaml_snapshot!(
             expr, @r###"
         ---
@@ -964,32 +993,6 @@ mod test {
           employees
         "###
         );
-    }
-
-    #[test]
-    fn test_try_from_list_to_vec_expr() -> Result<()> {
-        let items = vec![
-            Item::Ident("a".to_owned()).into(),
-            Item::Ident("b".to_owned()).into(),
-        ];
-        let expr: Vec<Expr> = try_into_exprs(items)?;
-        assert_debug_snapshot!(expr, @r###"
-        [
-            Identifier(
-                Ident {
-                    value: "a",
-                    quote_style: None,
-                },
-            ),
-            Identifier(
-                Ident {
-                    value: "b",
-                    quote_style: None,
-                },
-            ),
-        ]
-        "###);
-        Ok(())
     }
 
     fn parse_and_resolve(prql: &str) -> Result<Pipeline> {
@@ -1426,16 +1429,17 @@ take 20
             r###"
         prql dialect:generic
         from Employees
-        select [FirstName]
+        select [FirstName, `last name`]
         take 3
         "###,
         )?;
 
         assert_display_snapshot!((resolve_and_translate(query)?), @r###"
         SELECT
-          FirstName
+          "FirstName",
+          "last name"
         FROM
-          Employees
+          "Employees"
         LIMIT
           3
         "###);
@@ -1445,17 +1449,80 @@ take 20
             r###"
         prql dialect:mssql
         from Employees
-        select [FirstName]
+        select [FirstName, `last name`]
         take 3
         "###,
         )?;
 
         assert_display_snapshot!((resolve_and_translate(query)?), @r###"
         SELECT
-          TOP (3) FirstName
+          TOP (3) "FirstName",
+          "last name"
         FROM
-          Employees
+          "Employees"
         "###);
+
+        // MySQL
+        let query: Query = parse(
+            r###"
+        prql dialect:mysql
+        from Employees
+        select [FirstName, `last name`]
+        take 3
+        "###,
+        )?;
+
+        assert_display_snapshot!((resolve_and_translate(query)?), @r###"
+        SELECT
+          `FirstName`,
+          `last name`
+        FROM
+          `Employees`
+        LIMIT
+          3
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ident_escaping() -> Result<()> {
+        // Generic
+        let query: Query = parse(
+            r###"
+        from `anim"ls`
+        derive [`čebela` = BeeName, medved = `bear's_name`]
+        "###,
+        )?;
+
+        assert_display_snapshot!((resolve_and_translate(query)?), @r###"
+        SELECT
+          "anim""ls".*,
+          "BeeName" AS "čebela",
+          "bear's_name" AS medved
+        FROM
+          "anim""ls"
+        "###);
+
+        // MySQL
+        let query: Query = parse(
+            r###"
+        prql dialect:mysql
+
+        from `anim"ls`
+        derive [`čebela` = BeeName, medved = `bear's_name`]
+        "###,
+        )?;
+
+        assert_display_snapshot!((resolve_and_translate(query)?), @r###"
+        SELECT
+          `anim"ls`.*,
+          `BeeName` AS `čebela`,
+          `bear's_name` AS medved
+        FROM
+          `anim"ls`
+        "###);
+
         Ok(())
     }
 


### PR DESCRIPTION
Make PRQL is case sensitive and produce correct ident escaping, depending on the dialect.

Probably conflicts with #752

I had to refactor much of `translator`, mainly converting `From<Item> for sql_ast::Expr` into functions that also take `Dialect`.

I've removed support for `` `project-bar`.`dataset`.`table` ``. It can be added back, but it would require better ident parsing with PEST and I don't think it's needed. You can think that PRQL has no nested namespaces such as tables and schemas, but has a single namespace that can contain `schema1.my_table.column` and also `schema1..column` all of which are valid names.