### PR TITLE
Use default target for book build

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -50,7 +50,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          target: wasm32-unknown-unknown
           # https://github.com/actions-rs/toolchain/issues/126
           toolchain: stable
       - name: 💰 Cache


### PR DESCRIPTION
Now we no longer have the playground, no need to use wasm to test the book
