### PR TITLE
prql-macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "prql-macros"
+version = "0.1.0"
+dependencies = [
+ "prql-compiler",
+ "syn",
+]
+
+[[package]]
 name = "prql-python"
 version = "0.2.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "prql-compiler",
+  "prql-macros",
   "prql-java",
   "prql-js",
   "prql-python",

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -1,4 +1,4 @@
-mod ast;
+pub mod ast;
 #[cfg(feature = "cli")]
 mod cli;
 mod error;
@@ -38,17 +38,6 @@ pub fn format(prql: &str) -> Result<String> {
 /// Compile a PRQL string into a JSON version of the Query.
 pub fn to_json(prql: &str) -> Result<String> {
     Ok(serde_json::to_string(&parse(prql)?)?)
-}
-
-/// Exposes some library internals.
-///
-/// They are primarily exposed for documentation. There may be issues with using
-/// the exported items without items they rely on — feel free to request
-/// associated items be made public if required.
-pub mod internals {
-    pub use crate::ast::ast_fold::AstFold;
-    pub use crate::ast::Node;
-    pub use crate::utils::{IntoOnly, Only};
 }
 
 #[cfg(test)]

--- a/prql-compiler/src/utils.rs
+++ b/prql-compiler/src/utils.rs
@@ -1,10 +1,8 @@
 use anyhow::{anyhow, Result};
 use itertools::{Itertools, Position};
 
-use crate::{
-    error::{Error, Reason},
-    internals::Node,
-};
+use crate::error::{Error, Reason};
+use crate::ast::Node;
 
 // Inspired by version in sqlparser-rs; I'm surprised there isn't a version in
 // the stdlib / Itertools.

--- a/prql-compiler/src/utils.rs
+++ b/prql-compiler/src/utils.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Result};
 use itertools::{Itertools, Position};
 
-use crate::error::{Error, Reason};
 use crate::ast::Node;
+use crate::error::{Error, Reason};
 
 // Inspired by version in sqlparser-rs; I'm surprised there isn't a version in
 // the stdlib / Itertools.

--- a/prql-macros/Cargo.toml
+++ b/prql-macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "prql-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc_macro = true
+
+[dependencies]
+syn = "1.0"
+prql-compiler = { path = "../prql-compiler" }

--- a/prql-macros/src/lib.rs
+++ b/prql-macros/src/lib.rs
@@ -1,0 +1,25 @@
+use proc_macro::{Literal, TokenStream, TokenTree};
+use prql_compiler::{compile, format_error};
+use syn::{ExprLit, Expr, Lit};
+
+#[proc_macro]
+pub fn prql(input: TokenStream) -> TokenStream {
+    let input: Expr = syn::parse(input).unwrap();
+
+    let prql_string = match input {
+        Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) => {
+            lit_str.value()
+        },
+        _ => panic!("prql! proc macro expected a string")
+    };
+
+    let sql_string = match compile(&prql_string) {
+        Ok(r) => r,
+        Err(err) => {
+            let (formatted, _) = format_error(err, "<prql_macro>", &prql_string, true);
+            panic!("{}", formatted);
+        }
+    };
+
+    TokenStream::from_iter(vec![TokenTree::Literal(Literal::string(&sql_string))].into_iter())
+}

--- a/prql-macros/src/lib.rs
+++ b/prql-macros/src/lib.rs
@@ -1,16 +1,17 @@
 use proc_macro::{Literal, TokenStream, TokenTree};
 use prql_compiler::{compile, format_error};
-use syn::{ExprLit, Expr, Lit};
+use syn::{Expr, ExprLit, Lit};
 
 #[proc_macro]
 pub fn prql(input: TokenStream) -> TokenStream {
     let input: Expr = syn::parse(input).unwrap();
 
     let prql_string = match input {
-        Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) => {
-            lit_str.value()
-        },
-        _ => panic!("prql! proc macro expected a string")
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(lit_str),
+            ..
+        }) => lit_str.value(),
+        _ => panic!("prql! proc macro expected a string"),
     };
 
     let sql_string = match compile(&prql_string) {


### PR DESCRIPTION
- make `ast` mod public
- add a new crate prql-macros, which provides `prql!` macro, which can be used as such:

```
➜  rust-sandbox git:(master) ✗ bat src/main.rs 
───────┬─────────────────────────────────────────────────────────────────────────────────────
       │ File: src/main.rs
───────┼─────────────────────────────────────────────────────────────────────────────────────
   1   │ use prql_macros::prql;
   2   │ 
   3   │ fn main() {
   4   │     println!(prql!("from employees | select [first_name, last_name]"));
   5   │ }
   6   │ 
───────┴─────────────────────────────────────────────────────────────────────────────────────
➜  rust-sandbox git:(master) ✗ cargo run
   Compiling rust-sandbox v0.1.0 (/home/aljaz/Projects/rust-sandbox)
    Finished dev [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/rust-sandbox`
SELECT
  first_name,
  last_name
FROM
  employees
```


```
➜  rust-sandbox git:(master) ✗ bat src/main.rs
───────┬─────────────────────────────────────────────────────────────────────────────────────
       │ File: src/main.rs
───────┼─────────────────────────────────────────────────────────────────────────────────────
   1   │ use prql_macros::prql;
   2   │ 
   3   │ fn main() {
   4   │     println!(prql!("from employees | select first_name | select last_name"));
   5   │ }
   6   │ 
───────┴─────────────────────────────────────────────────────────────────────────────────────
➜  rust-sandbox git:(master) ✗ cargo run      
   Compiling rust-sandbox v0.1.0 (/home/aljaz/Projects/rust-sandbox)
error: proc macro panicked
 --> src/main.rs:4:14
  |
4 |     println!(prql!("from employees | select first_name | select last_name"));
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: Error: 
             ╭─[<prql_macro>:1:45]
             │
           1 │ from employees | select first_name | select last_name
             ·                                             ────┬────  
             ·                                                 ╰────── Unknown variable `last_name`
          ───╯
          

error: could not compile `rust-sandbox` due to previous error
```

`prql!` transpiles to SQL **at compile time**, also producing errors at compile time (just as PEST does).

Closes #731

Because `prql-macros` crate needs `proc_macro` flag set, which forbids any public functions that are not `proc_macro`s, this functionality cannot part of prql-compiler.

Other crates circumvent this issue by having two inner crates (prql-core, prql-macros) and a parent crate prql-compiler that included the other two, depending on enabled features.

I would not interfere with organization too much, but we may want to do something similar. @max-sixty 