### PR TITLE
Remove incorrect link

### DIFF
--- a/website/content/faq.md
+++ b/website/content/faq.md
@@ -17,7 +17,7 @@ integrations:
   output to a dataframe.
 
 Beyond these two integrations, it's very easy to add PRQL to your own apps with
-our [bindings](../content/_index.md#Bindings), for Rust, Python & JS.
+our bindings, for Rust, Python & JS.
 
 ## Something here reminds me of another project, did you take the idea from them?
 


### PR DESCRIPTION
Removing this because it generates a 404, as per #818.

Is there a way to link to a section on the homepage? Linking to prql-lang.org/index.html#Bindings doesn't seem to work either.
