### PR TITLE
Add "copy to clipboard" button to playground for output SQL

### DIFF
--- a/playground/src/workbench/Workbench.js
+++ b/playground/src/workbench/Workbench.js
@@ -23,6 +23,7 @@ class Workbench extends React.Component {
     filename: "input.prql",
     sql: "",
     prql: "",
+    justCopied: false,
   };
 
   loadFile(filename, content) {
@@ -97,6 +98,22 @@ class Workbench extends React.Component {
     }
   }
 
+  async copyOutput() {
+    const blob = new Blob([this.state.sql], { type: "text/plain" });
+    const data = [new window.ClipboardItem({ [blob.type]: blob })];
+    try {
+      await navigator.clipboard.write(data);
+
+      this.setState({ justCopied: true });
+
+      window.setTimeout(() => {
+        this.setState({ justCopied: false });
+      }, 2000)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
   render() {
     return (
       <div className="column">
@@ -126,7 +143,13 @@ class Workbench extends React.Component {
           </div>
 
           <div className="tab">
-            <div className="tab-title">output.sql</div>
+            <div className="tab-top">
+              <div className="tab-title">output.sql</div>
+              <div className="spacer"></div>
+              <button onClick={() => this.copyOutput()}>
+                {this.state.justCopied ? "Copied!" : "Copy to clipboard"}
+              </button>
+            </div>
 
             <SyntaxHighlighter language="sql" useInlineStyles={false}>
               {this.state.sql}

--- a/playground/src/workbench/Workbench.js
+++ b/playground/src/workbench/Workbench.js
@@ -108,9 +108,9 @@ class Workbench extends React.Component {
 
       window.setTimeout(() => {
         this.setState({ justCopied: false });
-      }, 2000)
+      }, 2000);
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
   }
 


### PR DESCRIPTION
I spent **way** too much time manually copying long output SQL when debugging – I assume this tiny addition will be helpful to others as well.

Should work on non-IE browsers, tested Chrome and Safari.

![2022-07-18 22 00 55](https://user-images.githubusercontent.com/3150328/179584159-7ba471ff-20b6-43f1-ae5b-fad4145dd46f.gif)
