### PR TITLE
Add from_json to compiler

### DIFF
--- a/prql-compiler/src/ast/item.rs
+++ b/prql-compiler/src/ast/item.rs
@@ -299,7 +299,15 @@ impl Display for Item {
                     write!(f, " {name}: {}", arg.item)?;
                 }
                 for arg in &func_call.args {
-                    write!(f, " {}", arg.item)?;
+                    match arg.item {
+                        Item::FuncCall(_) => {
+                            write!(f, " ( {} )", arg.item)?;
+                        }
+
+                        _ => {
+                            write!(f, " {}", arg.item)?;
+                        }
+                    }
                 }
             }
             Item::SString(parts) => {
@@ -312,7 +320,7 @@ impl Display for Item {
                 write!(f, "{}{}", i.n, i.unit)?;
             }
             Item::Windowed(w) => {
-                write!(f, "{:?}", w.expr)?;
+                write!(f, "{}", w.expr.item)?;
             }
             Item::Type(typ) => {
                 f.write_char('<')?;
@@ -320,7 +328,7 @@ impl Display for Item {
                 f.write_char('>')?;
             }
             Item::Literal(literal) => {
-                write!(f, "{:?}", literal)?;
+                write!(f, "{}", literal)?;
             }
         }
         Ok(())

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -40,6 +40,11 @@ pub fn to_json(prql: &str) -> Result<String> {
     Ok(serde_json::to_string(&parse(prql)?)?)
 }
 
+// Convert JSON AST back to PRQL string
+pub fn from_json(json: &str) -> Result<String> {
+    Ok(display(serde_json::from_str(json)?))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -40,7 +40,7 @@ pub fn to_json(prql: &str) -> Result<String> {
     Ok(serde_json::to_string(&parse(prql)?)?)
 }
 
-// Convert JSON AST back to PRQL string
+/// Convert JSON AST back to PRQL string
 pub fn from_json(json: &str) -> Result<String> {
     Ok(display(serde_json::from_str(json)?))
 }

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -99,6 +99,12 @@ pub fn to_json(s: &str) -> Option<String> {
     return_or_throw_error(result)
 }
 
+#[wasm_bindgen]
+pub fn from_json(s: &str) -> Option<String> {
+    let result = prql_compiler::from_json(s).map_err(|e| format_error(e, "", s, false));
+    return_or_throw_error(result)
+}
+
 fn return_or_throw_error(
     result: Result<String, (String, Option<prql_compiler::SourceLocation>)>,
 ) -> Option<String> {


### PR DESCRIPTION
Sorry for a duplicate PR since #782 hasn't been updated for 10 days and our team needs this to build a query builder. From what I understand with https://github.com/prql/prql/pull/782#discussion_r917243880 and https://github.com/prql/prql/pull/782#discussion_r917291829 is that the parser can't parse a function call on an argument, so we have to wrap it in a pipeline which then will be unwrapped from the AST if it contains only 1 node. But now the AST doesn't have enough information to rebuild the original query, so in the `Display` trait I wrap all function call on an argument with a parenthesis. This should close #775 and #776.