### PR TITLE
fix some display trait bugs

### DIFF
--- a/prql-compiler/src/ast/literal.rs
+++ b/prql-compiler/src/ast/literal.rs
@@ -42,7 +42,7 @@ impl Display for Literal {
                                 loop {
                                     let stop = s
                                         .find(&"\"".repeat(min_quote))
-                                        .map(|_| s.find(&"\"".repeat(min_quote + 1)).is_some())
+                                        .map(|_| s.contains(&"\"".repeat(min_quote + 1)))
                                         .unwrap_or(true);
                                     if stop {
                                         break;

--- a/prql-compiler/src/ast/literal.rs
+++ b/prql-compiler/src/ast/literal.rs
@@ -32,9 +32,9 @@ impl Display for Literal {
             Literal::Float(i) => write!(f, "{i}")?,
 
             Literal::String(s) => {
-                match s.find("\"") {
+                match s.find('"') {
                     Some(_) => {
-                        match s.find("'") {
+                        match s.find('\'') {
                             Some(_) => {
                                 let mut min_quote = 3;
                                 // find minimum number of double quotes when string contains

--- a/prql-compiler/src/ast/literal.rs
+++ b/prql-compiler/src/ast/literal.rs
@@ -27,12 +27,39 @@ impl From<Literal> for anyhow::Error {
 impl Display for Literal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Literal::Null => {}
+            Literal::Null => write!(f, "null")?,
             Literal::Integer(i) => write!(f, "{i}")?,
             Literal::Float(i) => write!(f, "{i}")?,
 
             Literal::String(s) => {
-                write!(f, "\"{s}\"")?;
+                match s.find("\"") {
+                    Some(_) => {
+                        match s.find("'") {
+                            Some(_) => {
+                                let mut min_quote = 3;
+                                // find minimum number of double quotes when string contains
+                                // both single and double quotes
+                                loop {
+                                    let stop = s
+                                        .find(&"\"".repeat(min_quote))
+                                        .map(|_| s.find(&"\"".repeat(min_quote + 1)).is_some())
+                                        .unwrap_or(true);
+                                    if stop {
+                                        break;
+                                    } else {
+                                        min_quote += 1;
+                                    }
+                                }
+                                let quotes = "\"".repeat(min_quote);
+                                write!(f, "{quotes}{s}{quotes}")?;
+                            }
+
+                            None => write!(f, "'{s}'")?,
+                        };
+                    }
+
+                    None => write!(f, "\"{s}\"")?,
+                };
             }
 
             Literal::Boolean(b) => {


### PR DESCRIPTION
I tested this to all queries in https://github.com/prql/prql/tree/main/book/tests/prql/, the only error is missing parenthesis on a binary operator, related to #609. Also, I wrapped all identity with a backtick to prevent them from being parsed as other items, eg: `from project-foo.dataset.table `