### PR TITLE
Add release info to prql-macros crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "prql-macros"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "prql-compiler",
  "syn",

--- a/prql-macros/Cargo.toml
+++ b/prql-macros/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
-name = "prql-macros"
-version = "0.1.0"
 edition = "2021"
+name = "prql-macros"
+publish = false
+version = "0.2.2"
 
 [lib]
 proc_macro = true
 
 [dependencies]
+prql-compiler = {path = "../prql-compiler"}
 syn = "1.0"
-prql-compiler = { path = "../prql-compiler" }
+
+[package.metadata.release]
+shared-version = true
+tag-name = "{{version}}"
+tag-prefix = ""


### PR DESCRIPTION
We don't publish this separately; `cargo-release` needs this info
