### PR TITLE
cli revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 dist
 .vscode/settings.json
+.vscode/launch.json
 .idea
-
+/*.prql
+*/*.prql
 target

--- a/prql-compiler/src/main.rs
+++ b/prql-compiler/src/main.rs
@@ -8,7 +8,7 @@ fn main() -> color_eyre::eyre::Result<()> {
     color_eyre::install()?;
     let mut cli = Cli::parse();
 
-    if let Err(error) = cli.execute() {
+    if let Err(error) = cli.run() {
         eprintln!("{error}");
         exit(1)
     }


### PR DESCRIPTION
Replaces the single `compile` command and format argument with different commands:

    $ prql-compiler compile input.prql output.prql
    $ prql-compiler parse input.prql output.prql
    $ prql-compiler debug input.prql output.prql
    $ prql-compiler annotate input.prql output.prql