### PR TITLE
Fix links to stdlib.prql

### DIFF
--- a/book/src/stdlib.md
+++ b/book/src/stdlib.md
@@ -11,8 +11,8 @@ then, we'll only add functions here that are broadly supported by most DBs.
 ```
 
 Here's the source of the current [PRQL
-stdlib](https://github.com/prql/prql/blob/main/prql-compiler/src/sql/stdlib.prql):
+stdlib](https://github.com/prql/prql/blob/main/prql-compiler/src/semantic/stdlib.prql):
 
 ```prql_no_test
-{{#include ../../prql-compiler/src/sql/stdlib.prql}}
+{{#include ../../prql-compiler/src/semantic/stdlib.prql}}
 ```

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -26,7 +26,7 @@
       }
     },
     "../prql-js": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0"
     },
     "node_modules/@ampproject/remapping": {

--- a/website/content/roadmap.md
+++ b/website/content/roadmap.md
@@ -38,7 +38,7 @@ Both bug reports of unfriendliness, and code contributions to improve them are w
 ## Standard library
 
 Currently, the standard library is [quite
-limited](https://github.com/prql/prql/blob/main/prql-compiler/src/sql/stdlib.prql).
+limited](https://github.com/prql/prql/blob/main/prql-compiler/src/semantic/stdlib.prql).
 It contains only basic arithmetic functions (`AVERAGE`, `SUM`) and lacks
 functions for string manipulation, date handling and many math functions. One
 challenge here is the variety of functionalities and syntax of target DBMSs;


### PR DESCRIPTION
Weirdly the book printed an error, but passed?!
https://github.com/prql/prql/runs/7530558870?check_suite_focus=true

(this was from #1513, zero stress tbc)
