### PR TITLE
Fix copying to clipboard on firefox

### DIFF
--- a/playground/src/workbench/Workbench.js
+++ b/playground/src/workbench/Workbench.js
@@ -99,10 +99,8 @@ class Workbench extends React.Component {
   }
 
   async copyOutput() {
-    const blob = new Blob([this.state.sql], { type: "text/plain" });
-    const data = [new window.ClipboardItem({ [blob.type]: blob })];
     try {
-      await navigator.clipboard.write(data);
+      await navigator.clipboard.writeText(this.state.sql);
 
       this.setState({ justCopied: true });
 


### PR DESCRIPTION
Turns out there was a way simpler way all along, and one that's supported by Firefox.

Bug report by @max-sixty under https://github.com/prql/prql/pull/825#issuecomment-1197219408