### PR TITLE
refactor: Add `fold_query` to ASTFold

### DIFF
--- a/prql-compiler/src/ast/ast_fold.rs
+++ b/prql-compiler/src/ast/ast_fold.rs
@@ -74,6 +74,9 @@ pub trait AstFold {
     fn fold_windowed(&mut self, windowed: Windowed) -> Result<Windowed> {
         fold_windowed(self, windowed)
     }
+    fn fold_query(&mut self, query: Query) -> Result<Query> {
+        fold_query(self, query)
+    }
 }
 
 pub fn fold_item<T: ?Sized + AstFold>(fold: &mut T, item: Item) -> Result<Item> {
@@ -137,6 +140,13 @@ pub fn fold_range<F: ?Sized + AstFold>(fold: &mut F, Range { start, end }: Range
     Ok(Range {
         start: fold_optional_box(fold, start)?,
         end: fold_optional_box(fold, end)?,
+    })
+}
+
+pub fn fold_query<F: ?Sized + AstFold>(fold: &mut F, query: Query) -> Result<Query> {
+    Ok(Query {
+        nodes: fold.fold_nodes(query.nodes)?,
+        ..query
     })
 }
 

--- a/prql-compiler/src/cli.rs
+++ b/prql-compiler/src/cli.rs
@@ -79,7 +79,7 @@ impl Cli {
             Cli::Format(_) => crate::format(source)?.as_bytes().to_vec(),
             Cli::Debug(_) => {
                 let query = parse(source)?;
-                let (nodes, context) = semantic::resolve(query.nodes, None)?;
+                let (nodes, context) = semantic::resolve(query, None)?;
 
                 semantic::label_references(&nodes, &context, "".to_string(), source.to_string());
 
@@ -89,7 +89,7 @@ impl Cli {
                 let query = parse(source)?;
 
                 // resolve
-                let (nodes, context) = semantic::resolve(query.nodes, None)?;
+                let (nodes, context) = semantic::resolve(query, None)?;
 
                 let frames = semantic::collect_frames(nodes);
 
@@ -100,7 +100,7 @@ impl Cli {
             }
             Cli::Resolve(_) => {
                 let ast = parse(source)?;
-                let (ir, _) = semantic::resolve(ast.nodes, None)?;
+                let (ir, _) = semantic::resolve(ast, None)?;
 
                 serde_yaml::to_string(&ir)?.into_bytes()
             }

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -12,7 +12,6 @@ pub use anyhow::Result;
 pub use cli::Cli;
 pub use error::{format_error, SourceLocation};
 pub use parser::parse;
-pub use semantic::resolve;
 pub use sql::translate;
 
 /// Compile a PRQL string into a SQL string.
@@ -26,7 +25,8 @@ pub fn compile(prql: &str) -> Result<String> {
 }
 
 pub fn resolve_and_translate(mut query: ast::Query) -> Result<String> {
-    let (nodes, context) = semantic::resolve(query.nodes, None)?;
+    // TODO: is there a way of avoiding this clone?
+    let (nodes, context) = semantic::resolve(query.clone(), None)?;
     query.nodes = nodes;
     translate(query, context)
 }

--- a/prql-compiler/src/semantic/frame.rs
+++ b/prql-compiler/src/semantic/frame.rs
@@ -19,9 +19,9 @@ pub struct Frame {
 /// Columns we know about in a Frame. The usize value represents the table id.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum FrameColumn {
-    /// Equivalent of `foo_table.*`
+    /// Used for `foo_table.*`
     All(usize),
-    // TODO: when is this used?
+    /// Used for `derive a + b` (new column has no name)
     Unnamed(usize),
     Named(String, usize),
 }

--- a/prql-compiler/src/semantic/frame.rs
+++ b/prql-compiler/src/semantic/frame.rs
@@ -13,13 +13,15 @@ use crate::ast::{ColumnSort, Item, Node, Transform};
 pub struct Frame {
     pub columns: Vec<FrameColumn>,
     pub sort: Vec<ColumnSort<usize>>,
-
     pub tables: Vec<usize>,
 }
 
+/// Columns we know about in a Frame. The usize value represents the table id.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum FrameColumn {
+    /// Equivalent of `foo_table.*`
     All(usize),
+    // TODO: when is this used?
     Unnamed(usize),
     Named(String, usize),
 }

--- a/prql-compiler/src/semantic/mod.rs
+++ b/prql-compiler/src/semantic/mod.rs
@@ -7,7 +7,7 @@ mod reporting;
 mod scope;
 mod transforms;
 
-use crate::ast::Node;
+use crate::ast::{Node, Query};
 
 pub use self::context::Context;
 pub use self::declarations::{Declaration, Declarations};
@@ -18,10 +18,10 @@ pub use reporting::{collect_frames, label_references};
 /// Runs semantic analysis on the query, using current state.
 ///
 /// Note that this removes function declarations from AST and saves them as current context.
-pub fn resolve(nodes: Vec<Node>, context: Option<Context>) -> anyhow::Result<(Vec<Node>, Context)> {
+pub fn resolve(query: Query, context: Option<Context>) -> anyhow::Result<(Vec<Node>, Context)> {
     let context = context.unwrap_or_else(load_std_lib);
 
-    let (nodes, context) = name_resolver::resolve_names(nodes, context)?;
+    let (nodes, context) = name_resolver::resolve_names(query, context)?;
     Ok((nodes, context))
 }
 
@@ -30,6 +30,6 @@ pub fn load_std_lib() -> Context {
     let std_lib = include_str!("./stdlib.prql");
     let nodes = parse(std_lib).unwrap().nodes;
 
-    let (_, context) = name_resolver::resolve_names(nodes, Context::default()).unwrap();
+    let (_, context) = name_resolver::resolve_nodes(nodes, Context::default()).unwrap();
     context
 }

--- a/prql-compiler/src/semantic/scope.rs
+++ b/prql-compiler/src/semantic/scope.rs
@@ -6,7 +6,7 @@ pub const NS_PARAM: &str = "_param";
 pub const NS_FUNC: &str = "_func";
 
 /// Maps from accessible names in some context to their declarations.
-#[derive(Default, Serialize, Deserialize, Clone)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct Scope {
     /// Mapping from idents to their declarations. For each namespace (table), a map from column names to their definitions
     /// "_param" is namespace of current function parameters

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -277,16 +277,16 @@ fn unpack<const P: usize, const N: usize>(
 mod tests {
     use insta::assert_yaml_snapshot;
 
-    use crate::parse;
-    use crate::semantic::{load_std_lib, resolve};
+    use crate::semantic::load_std_lib;
+    use crate::{parse, semantic::resolve};
 
     #[test]
     fn test_simple_casts() {
         let query = parse(r#"filter upper country = "USA""#).unwrap();
-        assert!(resolve(query.nodes, None).is_err());
+        assert!(resolve(query, None).is_err());
 
         let query = parse(r#"take"#).unwrap();
-        assert!(resolve(query.nodes, None).is_err());
+        assert!(resolve(query, None).is_err());
     }
 
     #[test]
@@ -304,7 +304,7 @@ mod tests {
         ",
         )
         .unwrap();
-        let (result, _) = resolve(query.nodes, context.clone()).unwrap();
+        let (result, _) = resolve(query, context.clone()).unwrap();
         assert_yaml_snapshot!(result, @r###"
         ---
         - Pipeline:
@@ -344,7 +344,7 @@ mod tests {
         ",
         )
         .unwrap();
-        let result = resolve(query.nodes, context.clone());
+        let result = resolve(query, context.clone());
         assert!(result.is_err());
 
         // oops, two arguments
@@ -355,7 +355,7 @@ mod tests {
         ",
         )
         .unwrap();
-        let result = resolve(query.nodes, context.clone());
+        let result = resolve(query, context.clone());
         assert!(result.is_err());
 
         // correct function call
@@ -368,7 +368,7 @@ mod tests {
         ",
         )
         .unwrap();
-        let (result, _) = resolve(query.nodes, context).unwrap();
+        let (result, _) = resolve(query, context).unwrap();
         assert_yaml_snapshot!(result, @r###"
         ---
         - Pipeline:
@@ -410,7 +410,7 @@ mod tests {
         )
         .unwrap();
 
-        let (result, _) = resolve(query.nodes, context).unwrap();
+        let (result, _) = resolve(query, context).unwrap();
         assert_yaml_snapshot!(result, @r###"
         ---
         - Pipeline:

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -102,6 +102,7 @@ pub fn translate_query(query: Query, context: Context) -> Result<sql_ast::Query>
     Ok(main_query)
 }
 
+#[derive(Debug)]
 pub struct AtomicTable {
     name: Option<TableRef>,
     pipeline: Pipeline,
@@ -922,7 +923,7 @@ impl From<Vec<Node>> for AtomicTable {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{parser::parse, resolve};
+    use crate::{parser::parse, semantic::resolve};
     use insta::assert_yaml_snapshot;
     use serde_yaml::from_str;
 
@@ -990,7 +991,7 @@ mod test {
     }
 
     fn parse_and_resolve(prql: &str) -> Result<Pipeline> {
-        let (mut nodes, _) = resolve(parse(prql)?.nodes, None)?;
+        let (mut nodes, _) = resolve(parse(prql)?, None)?;
         let pipeline = nodes.remove(nodes.len() - 1).coerce_to_pipeline();
         Ok(pipeline)
     }


### PR DESCRIPTION
I think to fix #820 we're going to need to know "where we are" in the
folding — what tables we've seen before, what is currently visible;
which I think means we want to control how each table is parsed from a
higher method.

So this:
- Adds a `fold_query` method
- Moves some functions from taking nodes to taking a `Query` object. I'm
  not that confident this is better everywhere, so we can revert parts.
