### PR TITLE
fix(compiler): Fix scope of same column name from different table

### DIFF
--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -1464,4 +1464,49 @@ take 20
         "###
         );
     }
+
+    #[test]
+    fn test_same_column_names() -> Result<()> {
+        // #820
+        let query = r###"
+table x = (
+  from x_table
+  select only_in_x = foo
+)
+
+table y = (
+  from y_table
+  select foo
+)
+
+from x
+join y [id]
+"###;
+
+        assert_display_snapshot!(compile(query)?,
+            @r###"
+        WITH x AS (
+          SELECT
+            foo AS only_in_x
+          FROM
+            x_table
+        ),
+        y AS (
+          SELECT
+            foo
+          FROM
+            y_table
+        )
+        SELECT
+          x.*,
+          y.*,
+          id
+        FROM
+          x
+          JOIN y USING(id)
+        "###
+        );
+
+        Ok(())
+    }
 }

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -7,7 +7,7 @@ use crate::ast::*;
 use crate::error::Span;
 
 /// Context of the pipeline.
-#[derive(Default, Serialize, Deserialize, Clone)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct Context {
     /// Map of all accessible names (for each namespace)
     pub(crate) scope: Scope,
@@ -66,11 +66,5 @@ impl From<Declaration> for anyhow::Error {
     fn from(dec: Declaration) -> Self {
         // panic!("Unexpected declaration type: {dec:?}");
         anyhow::anyhow!("Unexpected declaration type: {dec:?}")
-    }
-}
-
-impl Debug for Context {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{:?}", self.declarations)
     }
 }


### PR DESCRIPTION
This is very poor quality code, but it does seem to fix the issue. I will write better quality code if it stays around beyond the rewrite of semantic. There may be other issues, in which case I'll work on those this weekend.

Thanks to @aljazerzen for the guidance.
