### PR TITLE
docs: Fix GitHub build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <!-- Dev badges on first line (language docs & chat) -->
 
-[![GitHub CI Status](https://img.shields.io/github/workflow/status/prql/prql/tests?logo=github&style=for-the-badge)](https://github.com/prql/prql/actions?query=workflow:tests)
+[![GitHub CI Status](https://img.shields.io/github/workflow/status/prql/prql/test-all/main?logo=github&style=for-the-badge)](https://github.com/prql/prql/actions?query=branch%3Amain+workflow%3Atest-all)
 [![GitHub contributors](https://img.shields.io/github/contributors/prql/prql?style=for-the-badge)](https://github.com/prql/prql/graphs/contributors)
 [![Stars](https://img.shields.io/github/stars/prql/prql?style=for-the-badge)](https://github.com/prql/prql/stargazers)
 


### PR DESCRIPTION
This was always green regardless or not of whether tests were passing!
