### PR TITLE
chore: Bump insta to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,9 +890,9 @@ checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
 
 [[package]]
 name = "insta"
-version = "1.18.0-alpha.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434f24375f151c2bf41954e0a324a7198f14cf4de3ded44c8ebc126105a7aea"
+checksum = "49de01ff8a0781c5414e674b4469b81f6693d6bda6a4d405600c2acd06ebc6d3"
 dependencies = [
  "console",
  "globset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,18 +890,18 @@ checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
 
 [[package]]
 name = "insta"
-version = "1.17.0"
+version = "1.18.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e21173d5699a654cf191b0c05b0a937bb4f7cf07ee2e32da2af07a963e31577"
+checksum = "7434f24375f151c2bf41954e0a324a7198f14cf4de3ded44c8ebc126105a7aea"
 dependencies = [
  "console",
  "globset",
+ "linked-hash-map",
  "once_cell",
  "serde",
- "serde_json",
- "serde_yaml 0.8.26",
  "similar",
  "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1663,7 +1663,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "serde_yaml 0.9.1",
+ "serde_yaml",
  "similar",
  "sqlformat",
  "sqlparser",
@@ -2009,18 +2009,6 @@ dependencies = [
  "itoa 1.0.2",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -24,7 +24,7 @@ walkdir = "2.3.2"
 
 [dev-dependencies]
 globset = "0.4.8"
-insta = {version = "1.18.0-alpha.1", features = ["colors", "glob"]}
+insta = {version = "1.18.0", features = ["colors", "glob"]}
 log = "0.4.17"
 pulldown-cmark = "0.9.1"
 pulldown-cmark-to-cmark = "10.0.1"

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.2.6"
 anyhow = "1.0.57"
 clap = {version = "3.2.3", default-features = false}
 globset = "0.4.8"
-insta = {version = "1.17.0", features = ["colors", "glob"]}
 itertools = "0.10.3"
 mdbook = {version = "0.4.18", default-features = false}
 mdbook-preprocessor-boilerplate = "0.1.1"
@@ -25,7 +24,7 @@ walkdir = "2.3.2"
 
 [dev-dependencies]
 globset = "0.4.8"
-insta = {version = "1.17.0", features = ["colors", "glob"]}
+insta = {version = "1.18.0-alpha.1", features = ["colors", "glob"]}
 log = "0.4.17"
 pulldown-cmark = "0.9.1"
 pulldown-cmark-to-cmark = "10.0.1"

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -48,7 +48,7 @@ version = "1.0.137"
 chrono = "0.4"
 criterion = "0.3.5"
 globset = "0.4.8"
-insta = {version = "1.18.0-alpha.1", features = ["colors", "glob", "yaml"]}
+insta = {version = "1.18.0", features = ["colors", "glob", "yaml"]}
 pulldown-cmark = "0.9.1"
 pulldown-cmark-to-cmark = "10.0.1"
 similar = "2.2.0"

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -48,7 +48,7 @@ version = "1.0.137"
 chrono = "0.4"
 criterion = "0.3.5"
 globset = "0.4.8"
-insta = {version = "1.17.0", features = ["colors", "glob"]}
+insta = {version = "1.18.0-alpha.1", features = ["colors", "glob", "yaml"]}
 pulldown-cmark = "0.9.1"
 pulldown-cmark-to-cmark = "10.0.1"
 similar = "2.2.0"


### PR DESCRIPTION
As discussed in https://github.com/mitsuhiko/insta/discussions/267

Not to be merged until 0.18.0 actually comes out