### PR TITLE
build: Lock toolchain

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,7 +34,8 @@ tasks:
         mdbook-toc
         wasm-bindgen-cli
         wasm-pack
-      - rustup target add wasm32-unknown-unknown
+      # We no longer need this now we set it in `rust-toolchain.toml`, can be removed in time
+      # - rustup target add wasm32-unknown-unknown
       - python3 -m pip install -U maturin
       - task: install-pre-commit
       - task: install-brew-dependencies

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,6 @@
 [toolchain]
-channel = "stable"
+channel = "1.63.0"
+components = ["rustfmt", "clippy"]
+# We want two targets: wasm32, and the default target for the platform, which we
+# don't list here. (i.e. we use each platform to test each platform)
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This will reduce the issues around clippy causing the build to fail when it upgrades; these will be deliberate
