### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,4 +1,4 @@
-# Currenly this is the default CodeQL config
+# Currently this is the default CodeQL config
 #
 name: "code-ql"
 

--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -28,5 +28,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: task setup-dev
-      # This also encompases `build-all`
+      # This also encompasses `build-all`
       - run: task test-all

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,7 +141,7 @@ tasks:
       # `parser::test_parse_pipeline_parse_tree`. Ideally we would a) retain
       # examples in the documentation (inc. tested), b) not rely on falliable
       # tests to extract them, which include compiling prql-compiler, c) not
-      # fail other compliation steps if they can't be extracted.
+      # fail other compilation steps if they can't be extracted.
       - cargo insta test --accept -- run_examples
       - task: build-all
       # Only delete unreferenced snapshots on the default target — lots are excluded under wasm.

--- a/prql-compiler/src/ast/ast_fold.rs
+++ b/prql-compiler/src/ast/ast_fold.rs
@@ -1,4 +1,4 @@
-/// A trait to "fold" a PRQL AST (similiar to a visitor), so we can transitively
+/// A trait to "fold" a PRQL AST (similar to a visitor), so we can transitively
 /// apply some logic to a whole tree by just defining how we want to handle each
 /// type.
 use super::*;

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -940,7 +940,7 @@ select `first name`
         assert_snapshot!((compile(r###"
         from x
         join y [x.id]
-        "###).unwrap_err().to_string()), @r###"Error { span: None, reason: Expected { who: Some("join"), expected: "An identifer with only one part; no `.`", found: "A multipart identifer" }, help: None }"###);
+        "###).unwrap_err().to_string()), @r###"Error { span: None, reason: Expected { who: Some("join"), expected: "An identifier with only one part; no `.`", found: "A multipart identifier" }, help: None }"###);
 
         Ok(())
     }

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -1,6 +1,6 @@
 //! This module contains the parser, which is responsible for converting a tree
 //! of pest pairs into a tree of AST Items. It has a small function to call into
-//! pest to get the parse tree / concrete syntaxt tree, and then a large
+//! pest to get the parse tree / concrete syntax tree, and then a large
 //! function for turning that into PRQL AST.
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -261,7 +261,7 @@ fn ast_of_parse_pair(pair: Pair<Rule>) -> Result<Option<Node>> {
         Rule::range => {
             let [start, end]: [Option<Box<Node>>; 2] = pair
                 .into_inner()
-                // Iterate over `start` & `end` (seperator is not a term).
+                // Iterate over `start` & `end` (separator is not a term).
                 .into_iter()
                 .map(|x| {
                     // Parse & Box each one.

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -106,7 +106,7 @@ nested_pipeline = _{ "(" ~ (WHITESPACE | NEWLINE)* ~ pipeline ~ (WHITESPACE | NE
 // we only keep the `string_inner` and discard the `string` given it contains
 // the quotes.
 //
-// TODO: I'm still a bit unclear how preceeding and trailing spaces are working
+// TODO: I'm still a bit unclear how preceding and trailing spaces are working
 // -- it seems that inner spaces are included without an atomic operator (or
 // with `ANY`), but prceeding & trailing spaces require both `ANY` _and_ an
 // atomic operator. We have some rudimentary tests for these.

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -744,10 +744,10 @@ fn translate_join(t: &Transform, dialect: &dyn DialectHandler) -> Result<Join> {
                         .map_err(|_| {
                             Error::new(Reason::Expected {
                                 who: Some("join".to_string()),
-                                expected: "An identifer with only one part; no `.`".to_string(),
+                                expected: "An identifier with only one part; no `.`".to_string(),
                                 // TODO: Add in the actual item (but I couldn't
                                 // get the error types to agree)
-                                found: "A multipart identifer".to_string(),
+                                found: "A multipart identifier".to_string(),
                             })
                         })?,
                 ),

--- a/prql-compiler/tests/integration/README.md
+++ b/prql-compiler/tests/integration/README.md
@@ -8,7 +8,7 @@ Database chinook.db was downloaded from <https://www.sqlitetutorial.net/sqlite-s
 
 Columns are renamed to snake_case, so Postgres and DuckDb don't struggle with them.
 
-For optimal accessability, portability between databases and file size, all tables are stored
+For optimal accessibility, portability between databases and file size, all tables are stored
 as CSV files. Their current size is 432kB, it could be gzip-ed to 112kB, but that would require a preprocessing step before running `cargo test`.
 
 ## SQLite


### PR DESCRIPTION
Found via `codespell -L crate -S ./book,./playground,./prql-compiler/tests/integration/data,./website`