### PR TITLE
fix: the range_of_ranges should check the Range end is smaller than its start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PRQL Changelog
 
+## [unreleased]
+
+### Fixes
+
+- `range_of_ranges` checks the Range end is smaller than its start (@shuozeli, #946)
+
 ## 0.2.6 — 2022-08-05
 
 ### Fixes

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -759,6 +759,18 @@ select `first name`
           employees OFFSET 4
         "###);
 
+        assert_display_snapshot!((compile(r###"
+        from employees
+        take 5..5
+        "###)?), @r###"
+        SELECT
+          employees.*
+        FROM
+          employees
+        LIMIT
+          1 OFFSET 4
+        "###);
+
         // should be one SELECT
         assert_display_snapshot!((compile(r###"
         from employees

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -406,7 +406,7 @@ fn range_of_ranges(ranges: Vec<Range>) -> Result<Range<i64>> {
     if current
         .start
         .zip(current.end)
-        .map(|(s, e)| e <= s)
+        .map(|(s, e)| e < s)
         .unwrap_or(false)
     {
         bail!("Range end is before its start.");
@@ -936,6 +936,7 @@ mod test {
         let range2 = Range::from_ints(Some(5), Some(6));
         let range3 = Range::from_ints(Some(5), None);
         let range4 = Range::from_ints(None, Some(8));
+        let range5 = Range::from_ints(Some(5), Some(5));
 
         assert!(range_of_ranges(vec![range1.clone()])?.end.is_some());
 
@@ -988,6 +989,12 @@ mod test {
         ---
         start: ~
         end: 8
+        "###);
+
+        assert_yaml_snapshot!(range_of_ranges(vec![range5])?, @r###"
+        ---
+        start: 5
+        end: 5
         "###);
 
         Ok(())


### PR DESCRIPTION
Fix the issue described in [issue/945](https://github.com/prql/prql/issues/945).
