### PR TITLE
build: Change minor version delta to 1

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -52,6 +52,6 @@ jobs:
         uses: actions/checkout@v3
       - uses: a-kenji/update-rust-toolchain@v1
         with:
-          minor-version-delta: 2
+          minor-version-delta: 1
           toolchain-path: "./rust-toolchain.toml"
           pr-title: "build: Update rust toolchain version"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "const-random",
  "getrandom",
  "once_cell",


### PR DESCRIPTION
This was required for the latest version of arrow and seems reasonable
