### PR TITLE
docs: Provide link to started dev env in playground Readme

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -1,10 +1,16 @@
 # PRQL Playground
 
-Uses `wasm-react-scripts` instead of `react-scripts` until <https://github.com/facebook/create-react-app/pull/8303> is merged.
+A fast-feedback compiler from PRQL to SQL, hosted at <https://prql-lang.org/playground/>
 
-Development:
+To run locally, [set up a development
+environment](../CONTRIBUTING.md#development-environment), and then run:
 
 ```sh
 npm install
 npm start
 ```
+
+## Notes
+
+This currently uses `wasm-react-scripts` instead of `react-scripts`, until
+<https://github.com/facebook/create-react-app/pull/8303> is merged.


### PR DESCRIPTION
Closes #969

We may also split up files, though I'm generally biased towards a smaller number, so let's see.
