### PR TITLE
build: Disable packages without tests from testing

### DIFF
--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -15,6 +15,9 @@ version = "0.2.7"
 cli = ["clio", "atty", "clap", "color-eyre"]
 default = ["anyhow/backtrace", "cli"]
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = "1.0.57"
 ariadne = "0.1.5"

--- a/prql-java/Cargo.toml
+++ b/prql-java/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.2.7"
 
 [lib]
 crate_type = ["cdylib"]
+doctest = false
+test = false
 
 [dependencies]
 jni = "0.19.0"

--- a/prql-js/Cargo.toml
+++ b/prql-js/Cargo.toml
@@ -9,6 +9,8 @@ version = "0.2.7"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+doctest = false
+test = false
 
 [features]
 default = ["console_error_panic_hook"]

--- a/prql-lib/Cargo.toml
+++ b/prql-lib/Cargo.toml
@@ -6,10 +6,12 @@ version = "0.2.7"
 
 [lib]
 crate_type = ["staticlib", "cdylib"]
+doctest = false
+test = false
 
 [dependencies]
-prql-compiler = { path = "../prql-compiler" }
 libc = "0.2"
+prql-compiler = {path = "../prql-compiler"}
 serde_json = "1.0"
 
 [package.metadata.release]

--- a/prql-macros/Cargo.toml
+++ b/prql-macros/Cargo.toml
@@ -5,7 +5,9 @@ publish = false
 version = "0.2.7"
 
 [lib]
+doctest = false
 proc_macro = true
+test = false
 
 [dependencies]
 prql-compiler = {path = "../prql-compiler"}


### PR DESCRIPTION
This speeds up `cargo test` without any `-p` specification significantly by about 40%. We can reenable them if they do gain tests
