### PR TITLE
feat: expose plain error line

### DIFF
--- a/prql-compiler/src/cli.rs
+++ b/prql-compiler/src/cli.rs
@@ -61,7 +61,10 @@ impl Cli {
                 self.write_output(&buf)?;
             }
             Err(e) => {
-                print!("{:}", error::format_error(e, &source_id, &source, true).0);
+                print!(
+                    "{:}",
+                    error::format_error(e, &source_id, &source, true).message
+                );
                 std::process::exit(1)
             }
         }

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -10,7 +10,7 @@ mod utils;
 pub use anyhow::Result;
 #[cfg(feature = "cli")]
 pub use cli::Cli;
-pub use error::{format_error, SourceLocation};
+pub use error::{format_error, FormattedError, SourceLocation};
 pub use parser::parse;
 pub use sql::translate;
 

--- a/prql-macros/src/lib.rs
+++ b/prql-macros/src/lib.rs
@@ -17,8 +17,8 @@ pub fn prql(input: TokenStream) -> TokenStream {
     let sql_string = match compile(&prql_string) {
         Ok(r) => r,
         Err(err) => {
-            let (formatted, _) = format_error(err, "<prql_macro>", &prql_string, true);
-            panic!("{}", formatted);
+            let err = format_error(err, "<prql_macro>", &prql_string, true);
+            panic!("{}", err.message);
         }
     };
 


### PR DESCRIPTION
Replaces output of `format_error` which was `(String, Option<SourceLocation>)` with `FormattedError`.

Maybe we should also rename `message` into `output` (or some better name), so `FormattedError` would be:

```rust
struct FormattedError {
   line: String,
   output: String,
   location: Option<SourceLocation>,
}
```