### PR TITLE
build: Specify 1.60.0 as min rust version

### DIFF
--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "prql-compiler"
 repository = "https://github.com/prql/prql"
-rust-version = "1.59.0"
+rust-version = "1.60.0"
 version = "0.2.7"
 
 [features]


### PR DESCRIPTION
I found this by running `cargo msrv`. I'll add an issue for making this a regular check