### PR TITLE
feat: relation literal & from_csv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "clio",
  "color-eyre",
  "criterion",
+ "csv",
  "duckdb",
  "enum-as-inner",
  "env_logger 0.9.3",

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -21,6 +21,7 @@ doctest = false
 [dependencies]
 anyhow = {version = "1.0.57", features = ["backtrace"]}
 ariadne = "0.1.5"
+csv = "1.1.6"
 enum-as-inner = "0.5.0"
 env_logger = {version = "0.9.1", features = ["termcolor"]}
 itertools = "0.10.3"

--- a/prql-compiler/src/ast/pl/literal.rs
+++ b/prql-compiler/src/ast/pl/literal.rs
@@ -15,6 +15,7 @@ pub enum Literal {
     Time(String),
     Timestamp(String),
     ValueAndUnit(ValueAndUnit),
+    Relation(RelationLiteral),
 }
 
 // Compound units, such as "2 days 3 hours" can be represented as `2days + 3hours`
@@ -22,6 +23,16 @@ pub enum Literal {
 pub struct ValueAndUnit {
     pub n: i64,       // Do any DBs use floats or decimals for this?
     pub unit: String, // Could be an enum IntervalType,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct RelationLiteral {
+    /// Column names
+    pub columns: Vec<String>,
+    /// Row-oriented data
+    // TODO: this should be generic, so it can contain any type (but at least
+    // numbers)
+    pub rows: Vec<Vec<String>>,
 }
 
 impl From<Literal> for anyhow::Error {
@@ -78,6 +89,10 @@ impl Display for Literal {
 
             Literal::ValueAndUnit(i) => {
                 write!(f, "{}{}", i.n, i.unit)?;
+            }
+
+            Literal::Relation(_) => {
+                write!(f, "<unimplemented relation>")?;
             }
         }
         Ok(())

--- a/prql-compiler/src/ast/rq/mod.rs
+++ b/prql-compiler/src/ast/rq/mod.rs
@@ -17,7 +17,7 @@ pub use utils::*;
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 
-use super::pl::{ColumnSort, QueryDef, Range, WindowFrame};
+use super::pl::{ColumnSort, QueryDef, Range, WindowFrame, RelationLiteral};
 use super::pl::{InterpolateItem, TableExternRef};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -78,14 +78,4 @@ pub struct TableRef {
 
     /// Name hint for relation within this pipeline (table alias)
     pub name: Option<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct RelationLiteral {
-    /// Column names
-    pub columns: Vec<String>,
-    /// Row-oriented data
-    // TODO: this should be generic, so it can contain any type (but at least
-    // numbers)
-    pub rows: Vec<Vec<String>>,
 }

--- a/prql-compiler/src/ast/rq/mod.rs
+++ b/prql-compiler/src/ast/rq/mod.rs
@@ -17,7 +17,7 @@ pub use utils::*;
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 
-use super::pl::{ColumnSort, QueryDef, Range, WindowFrame, RelationLiteral};
+use super::pl::{ColumnSort, QueryDef, Range, RelationLiteral, WindowFrame};
 use super::pl::{InterpolateItem, TableExternRef};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -168,6 +168,35 @@ impl Lowerer {
                 // return an instance of this new table
                 self.create_a_table_instance(id, None, tid)
             }
+
+            ExprKind::Literal(pl::Literal::Relation(lit)) => {
+                let id = expr.id.unwrap();
+
+                // create a new table
+                let tid = self.tid.gen();
+
+                let cols = lit
+                    .columns
+                    .iter()
+                    .map(|c| RelationColumn::Single(Some(c.clone())))
+                    .collect_vec();
+
+                let relation = rq::Relation {
+                    kind: rq::RelationKind::Literal(lit),
+                    columns: cols.clone(),
+                };
+
+                log::debug!("lowering literal relation table, columns = {:?}", cols);
+                self.table_buffer.push(TableDecl {
+                    id: tid,
+                    name: None,
+                    relation,
+                });
+
+                // return an instance of this new table
+                self.create_a_table_instance(id, None, tid)
+            }
+
             _ => {
                 return Err(Error::new(Reason::Expected {
                     who: None,

--- a/prql-compiler/src/semantic/std.prql
+++ b/prql-compiler/src/semantic/std.prql
@@ -56,3 +56,6 @@ func map<list> fn list<list> -> null
 func zip<list> a<list> b<list> -> null
 func _eq<list> a<list> -> null
 func _is_null a -> a == null
+
+# Misc
+func from_csv<table> csv<string> -> null

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -24,7 +24,7 @@ pub fn resolve_type(node: &Expr, context: &Context) -> Result<Ty> {
             Literal::Time(_) => TyLit::Time.into(),
             Literal::Timestamp(_) => TyLit::Timestamp.into(),
             Literal::ValueAndUnit(_) => Ty::Infer, // TODO
-            Literal::Relation(_) => unreachable!()
+            Literal::Relation(_) => unreachable!(),
         },
 
         ExprKind::Ident(_) | ExprKind::Pipeline(_) | ExprKind::FuncCall(_) => Ty::Infer,

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -24,6 +24,7 @@ pub fn resolve_type(node: &Expr, context: &Context) -> Result<Ty> {
             Literal::Time(_) => TyLit::Time.into(),
             Literal::Timestamp(_) => TyLit::Timestamp.into(),
             Literal::ValueAndUnit(_) => Ty::Infer, // TODO
+            Literal::Relation(_) => unreachable!()
         },
 
         ExprKind::Ident(_) | ExprKind::Pipeline(_) | ExprKind::FuncCall(_) => Ty::Infer,

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -152,6 +152,7 @@ pub(super) fn translate_expr_kind(item: ExprKind, ctx: &mut Context) -> Result<s
                     fractional_seconds_precision: None,
                 }
             }
+            Literal::Relation(_) => unreachable!(),
         },
         ExprKind::Switch(mut cases) => {
             let default = cases

--- a/prql-compiler/src/sql/gen_query.rs
+++ b/prql-compiler/src/sql/gen_query.rs
@@ -350,14 +350,8 @@ fn sql_of_sample_data(data: RelationLiteral) -> sql_ast::Query {
             from: vec![],
             projection: std::iter::zip(data.columns.clone(), row)
                 .map(|(col, value)| SelectItem::ExprWithAlias {
-                    expr: sql_ast::Expr::Identifier(sql_ast::Ident {
-                        value: value.into(),
-                        quote_style: None,
-                    }),
-                    alias: sql_ast::Ident {
-                        value: col,
-                        quote_style: None,
-                    },
+                    expr: sql_ast::Expr::Identifier(sql_ast::Ident::new(value)),
+                    alias: sql_ast::Ident::new(col),
                 })
                 .collect(),
             selection: None,


### PR DESCRIPTION
This would complete https://github.com/prql/prql/issues/286

It currently would have syntax like:

```elm
from inline:csv """
  a,b,c
  1,2,3
  4,5,6
"""
filter [a > 2]
```

The functions for parsing & translating the expression are done, but I still need to allow `from` to take more than just a table name. I could either do that here on on top of the `semantic` branch. The most general approach would be to allow a general expression in the `from` clause, which would involve lots of changes which may overlap with `semantic`.

What do folks think of the prql syntax? There are alternatives discussed in #286.