### PR TITLE
docs: Add changelog for next version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # PRQL Changelog
 
-## 0.3.0 — 2022-10-17
+## 0.2.8 — 2022-10-17
 
-0.3.0 is another modest release with some fixes, doc improvements, bindings
-improvements, and lots of internal changes. We're bumping the minor part of the
-release, because one of the fixes is a small breaking change to parameter
-ordering. More significant features are forthcoming!
+0.2.8 is another modest release with some fixes, doc improvements, bindings
+improvements, and lots of internal changes. Note that one of the fixes causes
+the behavior of `round` and `cast` to change slightly — though it's handled as a
+fix rather than a breaking change in semantic versioning.
 
 Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,48 @@
 # PRQL Changelog
 
-## 0.2.X — [unreleased]
+## 0.3.0 — 2022-10-17
 
-Features:
+0.3.0 is another modest release with some fixes, doc improvements, bindings
+improvements, and lots of internal changes. We're bumping the minor part of the
+release, because one of the fixes is a small breaking change to parameter
+ordering. More significant features are forthcoming!
 
 Fixes:
 
+- Change order of the `round` & `cast` function parameters to have the column
+  last; for example `round 2 foo_col` /
+  `cast int foo`. This is consistent with other functions, and makes piping
+  possible:
+
+  ```prql
+  derive [
+    gross_salary = (salary + payroll_tax | as int),
+    gross_salary_rounded = (gross_salary | round 0),
+  ]
+  ```
+
 Documentation:
+
+- Split `DEVELOPMENT.md` from `CONTRIBUTING.md` (@richb-hanover, #1010)
+- Make s-strings more prominent in website intro (@max-sixty, #982)
 
 Web:
 
+- Add GitHub star count to website (@max-sixty, #990)
+
 Integrations:
 
+- Expose a shortened error message, in particular for the VSCode extension
+  (@aljazerzen, #1005)
+
 Internal changes:
+
+- Specify 1.60.0 as minimum rust version (@max-sixty, #1011)
+- Remove old `wee-alloc` code (@max-sixty, #1013)
+- Upgrade clap to version 4 (@aj-bagwell, #1004)
+- Improve book-building script in Taskfile (@max-sixty, #989)
+- Publish website using an artifact rather than a long-lived branch (@max-sixty,
+  #1009)
 
 ## 0.2.7 — 2022-09-17
 


### PR DESCRIPTION
I've bumped the minor version here, to 0.3.0. This might be a bit
conservative, because I see the stdlib issue as more of a bug than a
change.

But maybe people like @mklopets are relying on that?

(I guess 0.1.0 & 0.2.0 were both big releases, and this is very small.
But they don't _have_ to be coupled)
