### PR TITLE
docs: Python is required to run `cargo build`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,8 @@ Setting up a local dev environment for PRQL is simple, thanks to the rust ecosys
   instance](https://github.dev/prql/prql).
 - Any problems: post an issue and we'll help.
 
-[^5]: For completeness: running the full tests requires a couple of additional
+[^5]:
+    For completeness: running the full tests requires a couple of additional
     components that most systems will have installed already:
 
     - A clang compiler to compile the DuckDB integration tests,

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,16 +12,20 @@ Setting up a local dev environment for PRQL is simple, thanks to the rust ecosys
   instance](https://github.dev/prql/prql).
 - Any problems: post an issue and we'll help.
 
-[^5]:
-    We'll need a clang compiler to compile the DuckDB integration tests,
-    since we use [`duckdb-rs'](https://github.com/wangfenjin/duckdb-rs). To install a compiler:
+[^5]: For completeness: running the full tests requires a couple of additional
+    components that most systems will have installed already:
 
-    - On Mac, install xcode `xcode-select --install`
-    - On Linux, `apt-get install libclang-dev`
-    - On Windows, `duckdb-rs` doesn't work anyway, so these tests are excluded
+    - A clang compiler to compile the DuckDB integration tests,
+      since we use [`duckdb-rs'](https://github.com/wangfenjin/duckdb-rs). To install a compiler:
 
-    It's also possible to develop `prql-compiler` without using the integration tests. Running
-    `cargo test --lib` should complete successfully by running only the unit tests.
+      - On Mac, install xcode `xcode-select --install`
+      - On Linux, `apt-get install libclang-dev`
+      - On Windows, `duckdb-rs` doesn't work anyway, so these tests are excluded
+
+    - Python >= 3.7 to compile `prql-python`.
+
+    It's very possible to develop `prql-compiler` without using the integration tests or `prql-python`. Running
+    `cargo test -p prql-compiler --lib` should complete successfully by running only the unit tests in the `prql-compiler` package.
 
 ## Components of PRQL
 


### PR DESCRIPTION
Closes #1049
