### PR TITLE
build: Bump rust toolchain to 1.64.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.64.0"
 components = ["rustfmt", "clippy"]
 # We want two targets: wasm32, and the default target for the platform, which we
 # don't list here. (i.e. we use each platform to test each platform)


### PR DESCRIPTION
While we generally rely on a cron workflow to bump the toolchain https://github.com/prql/prql/blob/f62908a9ce14a1e3fc59bfb93b2e9e3ee62a2a51/.github/workflows/cron.yaml#L48-L57, we need to bump this now — currently `task setup-dev` fails, because `cargo-release` has a MSRV of `1.64.0` (from https://github.com/crate-ci/cargo-release/pull/559), and cargo doesn't seem to have a way of finding the latest compatible version, or using a different toolchain for `cargo install` than it's using for the current project, so it just fails.

@epage I don't have some religious view on how fast that should be bumped, but @-ing you in case that's helpful context for your decision (thanks as ever for `cargo release`!)