### PR TITLE
revert: build: Update to 1.64 workspace & cargo-release 0.22 (#1062)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,8 @@ members = [
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
 
-[workspace.package]
-version = "0.2.9"
-
 [workspace.metadata.release]
 consolidate-commits = true
+consolidate-pushes = true
 pre-release-commit-message = "chore: Release {{version}}"
 shared-version = true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -205,8 +205,8 @@ raise an issue.
 Currently we release in a semi-automated way:
 
 - PR & merge an updated [Changelog](CHANGELOG.md).
-- Run `cargo release version patch` locally to bump the versions, then PR the
-  resulting commit.
+- Run `cargo release --no-push --no-tag --no-publish -x patch` locally to bump
+  the versions, then PR the resulting commit.
 - After merging, go to [Draft a new
   release](https://github.com/prql/prql/releases/new), copy the changelog entry
   into the release notes, select a new tag to be created, and hit the "Publish"

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -5,7 +5,7 @@ name = "mdbook-prql"
 publish = false
 repository = "https://github.com/prql/prql"
 rust-version = "1.59.0"
-version.workspace = true
+version = "0.2.9"
 
 [dependencies]
 anyhow = "1.0.57"

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "prql-compiler"
 repository = "https://github.com/prql/prql"
 rust-version = "1.60.0"
-version.workspace = true
+version = "0.2.9"
 
 [features]
 # We previously had `cli` not compile by default, because of an issue with

--- a/prql-java/Cargo.toml
+++ b/prql-java/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "prql-java"
 publish = false
-version.workspace = true
+version = "0.2.9"
 
 [lib]
 crate_type = ["cdylib"]

--- a/prql-js/Cargo.toml
+++ b/prql-js/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "prql-js"
 publish = false
 repository = "https://github.com/prql/prql"
-version.workspace = true
+version = "0.2.9"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/prql-lib/Cargo.toml
+++ b/prql-lib/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "prql-lib"
 publish = false
-version.workspace = true
+version = "0.2.9"
 
 [lib]
 crate_type = ["staticlib", "cdylib"]

--- a/prql-macros/Cargo.toml
+++ b/prql-macros/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "prql-macros"
 publish = false
-version.workspace = true
+version = "0.2.9"
 
 [lib]
 doctest = false

--- a/prql-python/Cargo.toml
+++ b/prql-python/Cargo.toml
@@ -3,7 +3,7 @@ build = "build.rs"
 edition = "2021"
 name = "prql-python"
 publish = false
-version.workspace = true
+version = "0.2.9"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
This reverts commit 051544e5eef9f547182af777b3c9493d3e2b35dc because of https://github.com/PyO3/maturin/issues/1206
