### PR TITLE
docs: Update docs for releasing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ opt-level = "s"
 
 [workspace.metadata.release]
 consolidate-commits = true
-consolidate-pushes = true
 pre-release-commit-message = "chore: Release {{version}}"
 shared-version = true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -205,8 +205,8 @@ raise an issue.
 Currently we release in a semi-automated way:
 
 - PR & merge an updated [Changelog](CHANGELOG.md).
-- Run `cargo release --no-push --no-tag --no-publish -x patch` locally to bump
-  the versions, then PR the resulting commit.
+- Run `cargo release version patch` locally to bump the versions, then PR the
+  resulting commit.
 - After merging, go to [Draft a new
   release](https://github.com/prql/prql/releases/new), copy the changelog entry
   into the release notes, select a new tag to be created, and hit the "Publish"


### PR DESCRIPTION
for cargo-release 0.22. Replaces #1062 for the moment

(But it's not exactly working how I expected, will post an issue)
