### PR TITLE
feat: Allow idents to contain `.` with backticks 

### DIFF
--- a/prql-compiler/src/ast/expr.rs
+++ b/prql-compiler/src/ast/expr.rs
@@ -66,23 +66,6 @@ pub struct Ident {
     pub namespace: Option<String>,
     pub name: String,
 }
-
-impl From<Ident> for String {
-    fn from(ident: Ident) -> Self {
-        match ident.namespace {
-            Some(namespace) => format!("{}.{}", namespace, ident.name),
-            None => ident.name,
-        }
-    }
-}
-impl From<String> for Ident {
-    fn from(ident: String) -> Self {
-        Ident {
-            namespace: None,
-            name: ident,
-        }
-    }
-}
 impl ToString for Ident {
     fn to_string(&self) -> String {
         match &self.namespace {
@@ -324,7 +307,11 @@ pub enum JoinSide {
 
 impl Expr {
     pub fn new_ident<S: ToString>(name: S, declared_at: usize) -> Expr {
-        let mut node: Expr = ExprKind::Ident(name.to_string().into()).into();
+        let mut node: Expr = ExprKind::Ident(Ident {
+            namespace: None,
+            name: name.to_string(),
+        })
+        .into();
         node.declared_at = Some(declared_at);
         node
     }

--- a/prql-compiler/src/ast/expr.rs
+++ b/prql-compiler/src/ast/expr.rs
@@ -57,9 +57,6 @@ pub enum ExprKind {
     FString(Vec<InterpolateItem>),
 }
 
-// We are moving `Ident` from being a string to containing the structure of a
-// namespace. Eventually we can remove this and just use `Ident` everywhere.
-// https://github.com/prql/prql/issues/1031
 /// A name. Generally columns, tables, functions, variables.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Ident {

--- a/prql-compiler/src/ast/expr.rs
+++ b/prql-compiler/src/ast/expr.rs
@@ -63,6 +63,16 @@ pub struct Ident {
     pub namespace: Option<String>,
     pub name: String,
 }
+
+impl From<String> for Ident {
+    fn from(name: String) -> Self {
+        Ident {
+            namespace: None,
+            name,
+        }
+    }
+}
+
 impl ToString for Ident {
     fn to_string(&self) -> String {
         match &self.namespace {

--- a/prql-compiler/src/ast/expr.rs
+++ b/prql-compiler/src/ast/expr.rs
@@ -64,11 +64,11 @@ pub struct Ident {
     pub name: String,
 }
 
-impl From<String> for Ident {
-    fn from(name: String) -> Self {
+impl Ident {
+    pub fn new_name<S: ToString>(name: S) -> Self {
         Ident {
             namespace: None,
-            name,
+            name: name.to_string(),
         }
     }
 }
@@ -314,11 +314,7 @@ pub enum JoinSide {
 
 impl Expr {
     pub fn new_ident<S: ToString>(name: S, declared_at: usize) -> Expr {
-        let mut node: Expr = ExprKind::Ident(Ident {
-            namespace: None,
-            name: name.to_string(),
-        })
-        .into();
+        let mut node: Expr = ExprKind::Ident(Ident::new_name(name)).into();
         node.declared_at = Some(declared_at);
         node
     }

--- a/prql-compiler/src/ast/frame.rs
+++ b/prql-compiler/src/ast/frame.rs
@@ -73,7 +73,7 @@ impl Frame {
             let name = expr
                 .alias
                 .clone()
-                .or_else(|| expr.kind.as_ident().cloned().map(|x| x.into()));
+                .or_else(|| expr.kind.as_ident().cloned().map(|x| x.to_string()));
 
             self.push_column(name, id);
         }

--- a/prql-compiler/src/ast/stmt.rs
+++ b/prql-compiler/src/ast/stmt.rs
@@ -37,7 +37,7 @@ pub struct QueryDef {
 /// Function definition.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct FuncDef {
-    pub name: Ident,
+    pub name: String,
     pub positional_params: Vec<FuncParam>, // ident
     pub named_params: Vec<FuncParam>,      // named expr
     pub body: Box<Expr>,

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -54,7 +54,6 @@ mod test {
     use insta::{assert_display_snapshot, assert_snapshot};
 
     #[test]
-    #[ignore]
     fn test_stdlib() {
         assert_snapshot!(compile(r###"
         from employees
@@ -86,7 +85,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_to_json() {
         let json = to_json("from employees | take 10").unwrap();
         // Since the AST is so in flux right now just test that the brackets are present
@@ -219,7 +217,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_quoting() {
         // GH-#822
         assert_display_snapshot!((compile(r###"
@@ -1070,7 +1067,6 @@ select [mng_name, managers.gender, salary_avg, salary_sd]"#;
     }
 
     #[test]
-    #[ignore]
     fn test_prql_to_sql_1() {
         let query = r#"
     from employees
@@ -1467,7 +1463,6 @@ take 20
     }
 
     #[test]
-    #[ignore]
     fn test_same_column_names() {
         // #820
         let query = r###"

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -250,7 +250,10 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
         }
         Rule::jinja => {
             let inner = pair.as_str();
-            ExprKind::Ident(inner.to_string().into())
+            ExprKind::Ident(Ident {
+                namespace: None,
+                name: inner.to_string(),
+            })
         }
         Rule::ident => {
             let inner = pair.clone().into_inner();
@@ -419,7 +422,7 @@ fn parse_typed_ident(pair: Pair<Rule>) -> Result<(String, Option<Ty>, Option<Exp
 fn parse_named(mut items: Vec<Expr>) -> (String, Expr) {
     let expr = items.remove(1);
     let alias = items.remove(0).kind.into_ident().unwrap();
-    (alias.into(), expr)
+    (alias.to_string(), expr)
 }
 
 fn ast_of_interpolate_items(pair: Pair<Rule>) -> Result<Vec<InterpolateItem>> {

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -198,13 +198,7 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
             } else {
                 let parsed = exprs_of_parse_pairs(pairs)?;
                 ExprKind::FuncCall(FuncCall {
-                    name: Box::new(
-                        ExprKind::Ident(Ident {
-                            namespace: None,
-                            name: ("coalesce".to_string()),
-                        })
-                        .into(),
-                    ),
+                    name: Box::new(ExprKind::Ident(Ident::new_name("coalesce")).into()),
                     args: vec![parsed[0].clone(), parsed[2].clone()],
                     named_args: HashMap::new(),
                 })
@@ -213,10 +207,7 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
         // This makes the previous parsing a bit easier, but is hacky;
         // ideally find a better way (but it doesn't seem that easy to
         // parse parts of a Pairs).
-        Rule::operator_coalesce => ExprKind::Ident(Ident {
-            namespace: None,
-            name: "-".to_string(),
-        }),
+        Rule::operator_coalesce => ExprKind::Ident(Ident::new_name("-")),
 
         Rule::assign_call | Rule::assign => {
             let (a, expr) = parse_named(exprs_of_parse_pairs(pair.into_inner())?);
@@ -250,10 +241,7 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
         }
         Rule::jinja => {
             let inner = pair.as_str();
-            ExprKind::Ident(Ident {
-                namespace: None,
-                name: inner.to_string(),
-            })
+            ExprKind::Ident(Ident::new_name(inner))
         }
         Rule::ident => {
             let inner = pair.clone().into_inner();

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -19,20 +19,19 @@ table_def = { "table" ~ ident ~ "=" ~ nested_pipeline ~ ( NEWLINE+ | &EOI ) }
 
 pipeline_stmt = { pipeline ~ ( NEWLINE+ | &EOI ) }
 
-// See parser.rs for why this is so complicated to parse
+// An ident is a sequence of word-like terms, separated by `.`. Where surrounded
+// by backticks, the term is taken as-is, including any periods it contains.
 ident = ${ !operator ~ !(keyword ~ WHITESPACE) ~ (ident_part_first | ident_backticks) ~ (ident_part_next | ident_backticks)* }
 // Either a normal ident (starting with a letter, `$` or `_`), or any string surrounded
 // by backticks.
 ident_part_first = { ((ASCII_ALPHA | "$" | "_") ~ (ASCII_ALPHANUMERIC | "_" )* ) }
 // We allow `e.*`, but not just `*`, since it would conflict with multiply in
 // some cases.
-ident_part_next = _{ ident_separator ~ (ident_part_first | ident_star | ident_backticks) }
-// These two are split out so we can make `ident_part_next` silent, but still
-// capture these.
-ident_separator = { "." }
+ident_part_next = _{  "."  ~ (ident_part_first | ident_star | ident_backticks) }
+// This is split out so we can make `ident_part_next` silent, but still capture
+// it.
 ident_star = { "*" }
 // Anything surrounded by backticks, we pass through.
-// ident_backticks = _{ "`" ~ (!NEWLINE ~ !"`" ~ ANY)* ~ "`" }
 ident_backticks = _{ PUSH("`") ~ (!NEWLINE ~ string_inner)* ~ POP }
 keyword = _{ "prql" | "table" | "func" }
 

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -34,7 +34,7 @@ impl Context {
         id
     }
 
-    pub fn declare_table(&mut self, name: Ident, alias: Option<String>) -> usize {
+    pub fn declare_table(&mut self, name: String, alias: Option<String>) -> usize {
         let alias = alias.unwrap_or_else(|| name.clone());
 
         let table_id = self.declare(Declaration::Table(alias.clone()), None);

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -102,7 +102,9 @@ impl Lowerer {
 
     fn lower_table_expr(&mut self, expr: Expr) -> Result<TableExpr> {
         Ok(match expr.kind {
-            ast::ExprKind::Ident(name) => TableExpr::Ref(ast::TableRef::LocalTable(name.into())),
+            ast::ExprKind::Ident(name) => {
+                TableExpr::Ref(ast::TableRef::LocalTable(name.to_string()))
+            }
             _ => TableExpr::Pipeline(self.lower_transform(expr)?),
         })
     }
@@ -242,7 +244,7 @@ impl Lowerer {
         let name = if let Some(alias) = expr_ast.alias.clone() {
             Some(alias)
         } else {
-            expr_ast.kind.as_ident().cloned().map(|x| x.into())
+            expr_ast.kind.as_ident().cloned().map(|x| x.to_string())
         };
         let id = expr_ast.declared_at;
 

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -516,7 +516,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_func_call_resolve() {
         assert_display_snapshot!(compile(r#"
         from employees

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -76,7 +76,7 @@ impl AstFold for Resolver {
         let span = node.span;
         let mut r = match node.kind {
             ExprKind::Ident(ref ident) => {
-                let id = self.lookup_name(ident.into(), node.span, &node.alias)?;
+                let id = self.lookup_name(ident.to_string().as_str(), node.span, &node.alias)?;
                 node.declared_at = Some(id);
 
                 let decl = self.context.declarations.get(id);
@@ -151,17 +151,17 @@ impl AstFold for Resolver {
                     .map_err(|_| {
                         anyhow!("you can only use column names with self-equality operator.")
                     })?
-                    .ident;
+                    .name;
 
                 node.kind = ExprKind::Binary {
-                    left: Box::new(Expr::from(ExprKind::Ident(IdentWithNamespace {
+                    left: Box::new(Expr::from(ExprKind::Ident(Ident {
                         namespace: Some(NS_FRAME.to_string()),
-                        ident: ident.clone(),
+                        name: ident.clone(),
                     }))),
                     op: BinOp::Eq,
-                    right: Box::new(Expr::from(ExprKind::Ident(IdentWithNamespace {
+                    right: Box::new(Expr::from(ExprKind::Ident(Ident {
                         namespace: Some(NS_FRAME_RIGHT.to_string()),
-                        ident,
+                        name: ident,
                     }))),
                 };
                 node.kind = fold_expr_kind(self, node.kind)?;
@@ -315,7 +315,7 @@ impl Resolver {
         &mut self,
         mut closure: Closure,
         args: Vec<Expr>,
-        named_args: HashMap<Ident, Expr>,
+        named_args: HashMap<String, Expr>,
     ) -> Result<Closure> {
         for arg in args {
             closure.args.push(arg);

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
@@ -6,13 +6,13 @@ expression: "resolve_derive(r#\"\n            func subtract a b -> a - b\n\n    
     left:
       Ident:
         namespace: ~
-        ident: gross_salary
+        name: gross_salary
       ty: Infer
     op: Sub
     right:
       Ident:
         namespace: ~
-        ident: tax
+        name: tax
       ty: Infer
   ty:
     Literal: Column

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -17,7 +17,7 @@ expression: "resolve_derive(r#\"\n            func plus_one x -> x + 1\n        
             - Expr:
                 Ident:
                   namespace: ~
-                  ident: foo
+                  name: foo
                 ty: Infer
             - String: )
           ty: Infer

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -7,7 +7,7 @@ expression: "resolve_derive(r#\"\n            from a\n            derive one = (
     - Expr:
         Ident:
           namespace: ~
-          ident: foo
+          name: foo
         ty: Infer
     - String: )
   ty:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
@@ -6,7 +6,7 @@ expression: "resolve_derive(r#\"\n            func add x to:1 -> x + to\n\n     
     left:
       Ident:
         namespace: ~
-        ident: bar
+        name: bar
       ty: Infer
     op: Add
     right:
@@ -21,7 +21,7 @@ expression: "resolve_derive(r#\"\n            func add x to:1 -> x + to\n\n     
     left:
       Ident:
         namespace: ~
-        ident: bar
+        name: bar
       ty: Infer
     op: Add
     right:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
@@ -6,13 +6,13 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
     left:
       Ident:
         namespace: ~
-        ident: salary
+        name: salary
       ty: Infer
     op: Add
     right:
       Ident:
         namespace: ~
-        ident: payroll_tax
+        name: payroll_tax
       ty: Infer
   ty:
     Literal: Column
@@ -23,13 +23,13 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
         left:
           Ident:
             namespace: ~
-            ident: salary
+            name: salary
           ty: Infer
         op: Add
         right:
           Ident:
             namespace: ~
-            ident: payroll_tax
+            name: payroll_tax
           ty: Infer
       ty:
         Literal: Column
@@ -37,7 +37,7 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
     right:
       Ident:
         namespace: ~
-        ident: benefits_cost
+        name: benefits_cost
       ty: Infer
   ty:
     Literal: Column

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -146,9 +146,9 @@ pub fn cast_transform(
 
             // TODO: having dummy already be `x` is a hack.
             // Dummy should be substituted in later.
-            let mut dummy = Expr::from(ExprKind::Ident(IdentWithNamespace {
+            let mut dummy = Expr::from(ExprKind::Ident(Ident {
                 namespace: None,
-                ident: ("_x".to_string()),
+                name: ("_x".to_string()),
             }));
             dummy.ty = tbl.ty.clone();
 

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -146,10 +146,7 @@ pub fn cast_transform(
 
             // TODO: having dummy already be `x` is a hack.
             // Dummy should be substituted in later.
-            let mut dummy = Expr::from(ExprKind::Ident(Ident {
-                namespace: None,
-                name: ("_x".to_string()),
-            }));
+            let mut dummy = Expr::from(ExprKind::Ident(Ident::new_name("_x")));
             dummy.ty = tbl.ty.clone();
 
             let pipeline = Expr::from(ExprKind::FuncCall(FuncCall {

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_query.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_query.snap
@@ -9,23 +9,23 @@ expression: "stmts_of_string(r#\"\nfrom employees\nfilter country == \"USA\"    
             name:
               Ident:
                 namespace: ~
-                ident: from
+                name: from
             args:
               - Ident:
                   namespace: ~
-                  ident: employees
+                  name: employees
             named_args: {}
         - FuncCall:
             name:
               Ident:
                 namespace: ~
-                ident: filter
+                name: filter
             args:
               - Binary:
                   left:
                     Ident:
                       namespace: ~
-                      ident: country
+                      name: country
                   op: Eq
                   right:
                     Literal:
@@ -35,43 +35,43 @@ expression: "stmts_of_string(r#\"\nfrom employees\nfilter country == \"USA\"    
             name:
               Ident:
                 namespace: ~
-                ident: derive
+                name: derive
             args:
               - List:
                   - Binary:
                       left:
                         Ident:
                           namespace: ~
-                          ident: salary
+                          name: salary
                       op: Add
                       right:
                         Ident:
                           namespace: ~
-                          ident: payroll_tax
+                          name: payroll_tax
                     alias: gross_salary
                   - Binary:
                       left:
                         Ident:
                           namespace: ~
-                          ident: gross_salary
+                          name: gross_salary
                       op: Add
                       right:
                         Ident:
                           namespace: ~
-                          ident: benefits_cost
+                          name: benefits_cost
                     alias: gross_cost
             named_args: {}
         - FuncCall:
             name:
               Ident:
                 namespace: ~
-                ident: filter
+                name: filter
             args:
               - Binary:
                   left:
                     Ident:
                       namespace: ~
-                      ident: gross_cost
+                      name: gross_cost
                   op: Gt
                   right:
                     Literal:
@@ -81,86 +81,86 @@ expression: "stmts_of_string(r#\"\nfrom employees\nfilter country == \"USA\"    
             name:
               Ident:
                 namespace: ~
-                ident: group
+                name: group
             args:
               - List:
                   - Ident:
                       namespace: ~
-                      ident: title
+                      name: title
                   - Ident:
                       namespace: ~
-                      ident: country
+                      name: country
               - FuncCall:
                   name:
                     Ident:
                       namespace: ~
-                      ident: aggregate
+                      name: aggregate
                   args:
                     - List:
                         - FuncCall:
                             name:
                               Ident:
                                 namespace: ~
-                                ident: average
+                                name: average
                             args:
                               - Ident:
                                   namespace: ~
-                                  ident: salary
+                                  name: salary
                             named_args: {}
                         - FuncCall:
                             name:
                               Ident:
                                 namespace: ~
-                                ident: sum
+                                name: sum
                             args:
                               - Ident:
                                   namespace: ~
-                                  ident: salary
+                                  name: salary
                             named_args: {}
                         - FuncCall:
                             name:
                               Ident:
                                 namespace: ~
-                                ident: average
+                                name: average
                             args:
                               - Ident:
                                   namespace: ~
-                                  ident: gross_salary
+                                  name: gross_salary
                             named_args: {}
                         - FuncCall:
                             name:
                               Ident:
                                 namespace: ~
-                                ident: sum
+                                name: sum
                             args:
                               - Ident:
                                   namespace: ~
-                                  ident: gross_salary
+                                  name: gross_salary
                             named_args: {}
                         - FuncCall:
                             name:
                               Ident:
                                 namespace: ~
-                                ident: average
+                                name: average
                             args:
                               - Ident:
                                   namespace: ~
-                                  ident: gross_cost
+                                  name: gross_cost
                             named_args: {}
                         - FuncCall:
                             name:
                               Ident:
                                 namespace: ~
-                                ident: sum
+                                name: sum
                             args:
                               - Ident:
                                   namespace: ~
-                                  ident: gross_cost
+                                  name: gross_cost
                             named_args: {}
                           alias: sum_gross_cost
                         - Ident:
                             namespace: ~
-                            ident: count
+                            name: count
                           alias: ct
                   named_args: {}
             named_args: {}
@@ -168,23 +168,23 @@ expression: "stmts_of_string(r#\"\nfrom employees\nfilter country == \"USA\"    
             name:
               Ident:
                 namespace: ~
-                ident: sort
+                name: sort
             args:
               - Ident:
                   namespace: ~
-                  ident: sum_gross_cost
+                  name: sum_gross_cost
             named_args: {}
         - FuncCall:
             name:
               Ident:
                 namespace: ~
-                ident: filter
+                name: filter
             args:
               - Binary:
                   left:
                     Ident:
                       namespace: ~
-                      ident: ct
+                      name: ct
                   op: Gt
                   right:
                     Literal:
@@ -194,7 +194,7 @@ expression: "stmts_of_string(r#\"\nfrom employees\nfilter country == \"USA\"    
             name:
               Ident:
                 namespace: ~
-                ident: take
+                name: take
             args:
               - Literal:
                   Integer: 20

--- a/prql-compiler/src/sql/anchor.rs
+++ b/prql-compiler/src/sql/anchor.rs
@@ -88,20 +88,19 @@ impl AnchorContext {
         cids.iter().map(|cid| self.materialize_expr(cid)).collect()
     }
 
-    pub fn materialize_name(&mut self, cid: &CId) -> String {
+    pub fn materialize_name(&mut self, cid: &CId) -> (Option<String>, String) {
         // TODO: figure out which columns need name and call ensure_column_name in advance
         // let col_name = self
         //     .get_column_name(cid)
         //     .expect("a column is referred by name, but it doesn't have one");
         let col_name = self.ensure_column_name(cid);
 
-        if let Some(tid) = self.columns_loc.get(cid) {
+        let table = self.columns_loc.get(cid).map(|tid| {
             let table = self.table_defs.get(tid).unwrap();
 
-            format!("{}.{}", table.name, col_name)
-        } else {
-            col_name
-        }
+            table.name.clone()
+        });
+        (table, col_name)
     }
 
     pub fn split_pipeline(

--- a/prql-compiler/src/sql/codegen.rs
+++ b/prql-compiler/src/sql/codegen.rs
@@ -21,19 +21,18 @@ use super::translator::Context;
 pub(super) fn translate_expr_kind(item: ExprKind, context: &mut Context) -> Result<sql_ast::Expr> {
     Ok(match item {
         ExprKind::ColumnRef(cid) => {
-            let name = context.anchor.materialize_name(&cid);
+            let (table, column) = context.anchor.materialize_name(&cid);
 
-            sql_ast::Expr::CompoundIdentifier(translate_column(name, context))
+            sql_ast::Expr::CompoundIdentifier(translate_ident(table, Some(column), context))
         }
         ExprKind::ExternRef { variable, table } => {
-            let name = if let Some(table_id) = table {
+            let table = table.map(|table_id| {
                 let table_def = context.anchor.table_defs.get(&table_id).unwrap();
-                format!("{}.{variable}", table_def.name)
-            } else {
-                variable
-            };
 
-            sql_ast::Expr::CompoundIdentifier(translate_column(name, context))
+                table_def.name.clone()
+            });
+
+            sql_ast::Expr::CompoundIdentifier(translate_ident(table, Some(variable), context))
         }
 
         ExprKind::Binary { op, left, right } => {
@@ -192,7 +191,7 @@ pub(super) fn table_factor_of_tid(tid: &TId, context: &Context) -> TableFactor {
     let def = context.anchor.table_defs.get(tid).unwrap();
 
     TableFactor::Table {
-        name: sql_ast::ObjectName(translate_ident(def.name.clone(), context)),
+        name: sql_ast::ObjectName(translate_ident(Some(def.name.clone()), None, context)),
         alias: None,
         args: None,
         with_hints: vec![],
@@ -349,9 +348,9 @@ pub(super) fn translate_column_sort(
     sort: &ColumnSort<CId>,
     context: &mut Context,
 ) -> Result<OrderByExpr> {
-    let column = context.anchor.materialize_name(&sort.column);
+    let (table, column) = context.anchor.materialize_name(&sort.column);
     Ok(OrderByExpr {
-        expr: sql_ast::Expr::CompoundIdentifier(translate_ident(column, context)),
+        expr: sql_ast::Expr::CompoundIdentifier(translate_ident(table, Some(column), context)),
         asc: if matches!(sort.direction, SortDirection::Asc) {
             None // default order is ASC, so there is no need to emit it
         } else {
@@ -404,62 +403,36 @@ pub(super) fn translate_join(t: &Transform, context: &mut Context) -> Result<Joi
     }
 }
 
-/// Translate a column name. We need to special-case this for BigQuery
-// Ref #852
-fn translate_column(ident: String, context: &Context) -> Vec<sql_ast::Ident> {
-    // TODO: since we have changed how idents are parsed, I think this is no
-    // longer needed; confirm when we renable tests on the semantic branch
-    match context.dialect.dialect() {
-        Dialect::BigQuery => {
-            if let Some((prefix, column)) = ident.rsplit_once('.') {
-                // If there's a table definition, pass it to `translate_ident` to
-                // be surrounded by quotes; without surrounding the table name
-                // with quotes.
-                translate_ident(prefix.to_string(), context)
-                    .into_iter()
-                    .chain(translate_ident(column.to_string(), context))
-                    .collect()
-            } else {
-                translate_ident(ident, context)
-            }
-        }
-        _ => translate_ident(ident, context),
-    }
-}
-
 /// Translate a PRQL Ident to a Vec of SQL Idents.
 // We return a vec of SQL Idents because sqlparser sometimes uses
 // [ObjectName](sql_ast::ObjectName) and sometimes uses
 // [sql_ast::Expr::CompoundIdentifier](sql_ast::Expr::CompoundIdentifier), each of which
 // contains `Vec<Ident>`.
-pub(super) fn translate_ident(ident: String, context: &Context) -> Vec<sql_ast::Ident> {
-    let is_jinja = ident.starts_with("{{") && ident.ends_with("}}");
-
-    if is_jinja {
-        return vec![sql_ast::Ident::new(ident)];
-    }
-
-    match context.dialect.dialect() {
-        // BigQuery has some unusual rules around quoting idents #852 (it includes the
-        // project, which may be a cause). I'm not 100% it's watertight, but we'll see.
-        Dialect::BigQuery => {
-            if ident.split('.').count() > 2 {
-                vec![sql_ast::Ident::with_quote(
-                    context.dialect.ident_quote(),
-                    ident,
-                )]
-            } else {
-                vec![sql_ast::Ident::new(ident)]
-            }
+pub(super) fn translate_ident(
+    relation_name: Option<String>,
+    column: Option<String>,
+    context: &Context,
+) -> Vec<sql_ast::Ident> {
+    let mut parts = Vec::with_capacity(4);
+    if let Some(relation) = relation_name {
+        // Special-case this for BigQuery, Ref #852
+        if matches!(context.dialect.dialect(), Dialect::BigQuery) {
+            parts.push(relation);
+        } else {
+            parts.extend(relation.split('.').map(|s| s.to_string()));
         }
-        _ => ident
-            .split('.')
-            .map(|x| translate_ident_part(x.to_string(), context))
-            .collect(),
     }
+    parts.extend(column);
+
+    parts
+        .into_iter()
+        .map(|x| translate_ident_part(x, context))
+        .collect()
 }
 
 pub(super) fn translate_ident_part(ident: String, context: &Context) -> sql_ast::Ident {
+    let is_jinja = ident.starts_with("{{") && ident.ends_with("}}");
+
     // TODO: can probably represent these with a single regex
     fn starting_forbidden(c: char) -> bool {
         !(('a'..='z').contains(&c) || matches!(c, '_' | '$'))
@@ -471,6 +444,7 @@ pub(super) fn translate_ident_part(ident: String, context: &Context) -> sql_ast:
     let is_asterisk = ident == "*";
 
     if !is_asterisk
+        && !is_jinja
         && (ident.is_empty()
             || ident.starts_with(starting_forbidden)
             || (ident.chars().count() > 1 && ident.contains(subsequent_forbidden)))

--- a/prql-compiler/src/sql/codegen.rs
+++ b/prql-compiler/src/sql/codegen.rs
@@ -407,6 +407,8 @@ pub(super) fn translate_join(t: &Transform, context: &mut Context) -> Result<Joi
 /// Translate a column name. We need to special-case this for BigQuery
 // Ref #852
 fn translate_column(ident: String, context: &Context) -> Vec<sql_ast::Ident> {
+    // TODO: since we have changed how idents are parsed, I think this is no
+    // longer needed; confirm when we renable tests on the semantic branch
     match context.dialect.dialect() {
         Dialect::BigQuery => {
             if let Some((prefix, column)) = ident.rsplit_once('.') {


### PR DESCRIPTION
RIP `Ident`, long live `Ident`!

I suggested `namespace` & `name` as the two fields; is that reasonable?

(We should merge this soon to prevent conflicts)