### PR TITLE
refactor: Rename Ident constructor to `from_name`

### DIFF
--- a/prql-compiler/src/ast/expr.rs
+++ b/prql-compiler/src/ast/expr.rs
@@ -76,7 +76,7 @@ pub struct Ident {
 }
 
 impl Ident {
-    pub fn new_name<S: ToString>(name: S) -> Self {
+    pub fn from_name<S: ToString>(name: S) -> Self {
         Ident {
             namespace: None,
             name: name.to_string(),
@@ -325,7 +325,7 @@ pub enum JoinSide {
 
 impl Expr {
     pub fn new_ident<S: ToString>(name: S, declared_at: usize) -> Expr {
-        let mut node: Expr = ExprKind::Ident(Ident::new_name(name)).into();
+        let mut node: Expr = ExprKind::Ident(Ident::from_name(name)).into();
         node.declared_at = Some(declared_at);
         node
     }

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -196,7 +196,7 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
             } else {
                 let parsed = exprs_of_parse_pairs(pairs)?;
                 ExprKind::FuncCall(FuncCall {
-                    name: Box::new(ExprKind::Ident(Ident::new_name("coalesce")).into()),
+                    name: Box::new(ExprKind::Ident(Ident::from_name("coalesce")).into()),
                     args: vec![parsed[0].clone(), parsed[2].clone()],
                     named_args: HashMap::new(),
                 })
@@ -205,7 +205,7 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
         // This makes the previous parsing a bit easier, but is hacky;
         // ideally find a better way (but it doesn't seem that easy to
         // parse parts of a Pairs).
-        Rule::operator_coalesce => ExprKind::Ident(Ident::new_name("-")),
+        Rule::operator_coalesce => ExprKind::Ident(Ident::from_name("-")),
 
         Rule::assign_call | Rule::assign => {
             let (a, expr) = parse_named(exprs_of_parse_pairs(pair.into_inner())?);
@@ -239,7 +239,7 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
         }
         Rule::jinja => {
             let inner = pair.as_str();
-            ExprKind::Ident(Ident::new_name(inner))
+            ExprKind::Ident(Ident::from_name(inner))
         }
         Rule::ident => {
             let inner = pair.clone().into_inner();

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -146,7 +146,7 @@ pub fn cast_transform(
 
             // TODO: having dummy already be `x` is a hack.
             // Dummy should be substituted in later.
-            let mut dummy = Expr::from(ExprKind::Ident(Ident::new_name("_x")));
+            let mut dummy = Expr::from(ExprKind::Ident(Ident::from_name("_x")));
             dummy.ty = tbl.ty.clone();
 
             let pipeline = Expr::from(ExprKind::FuncCall(FuncCall {

--- a/prql-python/src/lib.rs
+++ b/prql-python/src/lib.rs
@@ -33,7 +33,7 @@ mod test {
     fn parse_for_python() -> Result<()> {
         assert_eq!(
             to_sql("from employees | filter (age | in 20..30)")?,
-            "SELECT\n  employees.*\nFROM\n  employees\nWHERE\n  age BETWEEN 20\n  AND 30"
+            "SELECT\n  employees.*\nFROM\n  employees\nWHERE\n  employees.age BETWEEN 20\n  AND 30"
         );
 
         Ok(())


### PR DESCRIPTION
Idiomatic-ness nit https://github.com/prql/prql/pull/1079#discussion_r1004772292