### PR TITLE
docs: Add link to prqlr (R bindings for prql-compiler)

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -37,6 +37,7 @@
   - [Java](./bindings/java.md)
   - [JavaScript](./bindings/javascript.md)
   - [Python](./bindings/python.md)
+  - [R](./bindings/r.md)
   - [Rust](./bindings/rust.md)
 - [Integrations](./integrations/README.md)
 

--- a/book/src/bindings/r.md
+++ b/book/src/bindings/r.md
@@ -1,0 +1,25 @@
+# R (prqlr)
+
+JavaScript bindings for [`prql-compiler`](https://github.com/prql/prql/).
+Check out <https://eitsupi.github.io/prqlr/> for more context.
+
+## Installation
+
+`install.packages("prqlr", repos = "https://eitsupi.r-universe.dev")`
+
+## Usage
+
+```r
+library(prqlr)
+
+"
+from employees
+join salaries [emp_id]
+group [dept_id, gender] (
+  aggregate [
+    avg_salary = average salary
+  ]
+)
+" |>
+  prql_to_sql()
+```

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -347,6 +347,10 @@ bindings_section:
       label: "prql-js"
       text: "JavaScript bindings for prql-compiler."
 
+    - link: https://eitsupi.r-universe.dev/ui#package:prqlr
+      label: "prqlr"
+      text: "R bindings for prql-compiler."
+
     - link: https://crates.io/crates/prql-compiler
       label: "prql-compiler"
       text: |


### PR DESCRIPTION
I have added prqlr to the documentation as suggested on Discord.
After that, thanks to R-universe, binary installations are now available for Windows and macOS, so R users can easily install this package.

Let me know if you have any requests!

I can add if you like, for example, what I wrote in the prqlr documentation about being able to convert to a dplyr query.
https://eitsupi.github.io/prqlr/

(As a side note, the reason the name is not `prql-r` is because we can't use `-` in R package names.)