### PR TITLE
feat: prevent wildcard aliasing

### DIFF
--- a/prql-compiler/src/sql/anchor.rs
+++ b/prql-compiler/src/sql/anchor.rs
@@ -66,10 +66,17 @@ impl AnchorContext {
         let def = self.columns_defs.get_mut(cid).unwrap();
 
         if def.name.is_none() {
-            let id = self.next_col_name_id;
-            self.next_col_name_id += 1;
+            match &def.expr.kind {
+                ExprKind::ExternRef { variable, .. } if variable == "*" => {
+                    def.name = Some("*".into());
+                }
+                _ => {
+                    let id = self.next_col_name_id;
+                    self.next_col_name_id += 1;
 
-            def.name = Some(format!("_expr_{id}"));
+                    def.name = Some(format!("_expr_{id}"));
+                }
+            }
         }
 
         def.name.clone().unwrap()


### PR DESCRIPTION
This pr prevents wildcard aliasing. This is done in the `ensure_column_name` method, by checking if the considered column is a wildcard, in which case, we set its name to `"*"`.

This is pretty hacky, by also works with ctes.

Maybe a better approach would be to change `ColumnDef` to something like:

```rust
enum ColumnDef {
    Wildcard,
    Def {
        id: CId,
        name: Option<String>,
        expr: Expr,
    }
}
```

By my knowledge of the project is not yet good enough to judge all the implications.

I haven't re-enabled any tests yet, it makes more sense to do that once #1094 is merged.
