### PR TITLE
fix: Solve precedence issue in materializer

### DIFF
--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -129,7 +129,7 @@ mod test {
         select [result = c * sum_1 + sum_2]
         "###)?), @r###"
         SELECT
-          c * (a + b) + (a + b) AS result
+          c * (a + b) + a + b AS result
         FROM
           numbers
         "###);
@@ -194,11 +194,11 @@ mod test {
         SELECT
           numbers.*,
           c - (a + b),
-          c + (a - b),
-          c + (a - b),
-          c + (a + b),
-          (c + a) - b,
-          (c - d) - (a - b)
+          c + a - b,
+          c + a - b,
+          c + a + b,
+          c + a - b,
+          c - d - (a - b)
         FROM
           numbers
         "###

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -182,26 +182,27 @@ mod test {
           r###"
           from numbers
           derive x = (y - z)
-          derive [
+          select [
             c - (a + b),
             c + (a - b),
             c + a - b,
             c + a + b,
             (c + a) - b,
             ((c - d) - (a - b)),
+            ((c + d) + (a - b)),
             +x,
             -x,
           ]
           "###
           )?, @r###"
         SELECT
-          numbers.*,
           c - (a + b),
           c + a - b,
           c + a - b,
           c + a + b,
           c + a - b,
           c - d - (a - b),
+          c + d + a - b,
           y - z AS x,
           -(y - z)
         FROM

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -129,7 +129,7 @@ mod test {
         select [result = c * sum_1 + sum_2]
         "###)?), @r###"
         SELECT
-          c * (a + b) + a + b AS result
+          c * (a + b) + (a + b) AS result
         FROM
           numbers
         "###);
@@ -173,6 +173,32 @@ mod test {
         )?, @r###"
         SELECT
           a + b IS NULL
+        FROM
+          numbers
+        "###
+        );
+
+        assert_display_snapshot!(compile(
+          r###"
+          from numbers
+          derive [
+            c - (a + b),
+            c + (a - b),
+            c + a - b,
+            c + a + b,
+            (c + a) - b,
+            ((c - d) - (a - b)),
+          ]
+          "###
+          )?, @r###"
+        SELECT
+          numbers.*,
+          c - (a + b),
+          c + (a - b),
+          c + (a - b),
+          c + (a + b),
+          (c + a) - b,
+          (c - d) - (a - b)
         FROM
           numbers
         "###

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -181,6 +181,7 @@ mod test {
         assert_display_snapshot!(compile(
           r###"
           from numbers
+          derive x = (y - z)
           derive [
             c - (a + b),
             c + (a - b),
@@ -188,6 +189,8 @@ mod test {
             c + a + b,
             (c + a) - b,
             ((c - d) - (a - b)),
+            +x,
+            -x,
           ]
           "###
           )?, @r###"
@@ -198,7 +201,9 @@ mod test {
           c + a - b,
           c + a + b,
           c + a - b,
-          c - d - (a - b)
+          c - d - (a - b),
+          y - z AS x,
+          -(y - z)
         FROM
           numbers
         "###

--- a/prql-compiler/src/snapshots/prql_compiler__test__prql_to_sql_2.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__test__prql_to_sql_2.snap
@@ -9,14 +9,14 @@ SELECT
   SUM(salary),
   AVG(salary + payroll_tax),
   SUM(salary + payroll_tax),
-  AVG(salary + payroll_tax + benefits_cost),
-  SUM(salary + payroll_tax + benefits_cost) AS sum_gross_cost,
+  AVG((salary + payroll_tax) + benefits_cost),
+  SUM((salary + payroll_tax) + benefits_cost) AS sum_gross_cost,
   COUNT(*) AS ct
 FROM
   employees
 WHERE
   country = 'USA'
-  AND salary + payroll_tax + benefits_cost > 0
+  AND (salary + payroll_tax) + benefits_cost > 0
 GROUP BY
   title,
   country

--- a/prql-compiler/src/snapshots/prql_compiler__test__prql_to_sql_2.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__test__prql_to_sql_2.snap
@@ -9,14 +9,14 @@ SELECT
   SUM(salary),
   AVG(salary + payroll_tax),
   SUM(salary + payroll_tax),
-  AVG((salary + payroll_tax) + benefits_cost),
-  SUM((salary + payroll_tax) + benefits_cost) AS sum_gross_cost,
+  AVG(salary + payroll_tax + benefits_cost),
+  SUM(salary + payroll_tax + benefits_cost) AS sum_gross_cost,
   COUNT(*) AS ct
 FROM
   employees
 WHERE
   country = 'USA'
-  AND (salary + payroll_tax) + benefits_cost > 0
+  AND salary + payroll_tax + benefits_cost > 0
 GROUP BY
   title,
   country

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -535,7 +535,6 @@ fn translate_item(item: Item, dialect: &dyn DialectHandler) -> Result<Expr> {
             let op = match op {
                 UnOp::Neg => UnaryOperator::Minus,
                 UnOp::Not => UnaryOperator::Not,
-                // UnOp::Plus => UnaryOperator::Plus,
             };
             let expr = translate_operand(expr.item, op.binding_strength(), true, dialect)?;
             Expr::UnaryOp { op, expr }
@@ -672,6 +671,7 @@ fn try_into_is_null(
         };
 
         let min_strength = Expr::IsNull(Box::new(Expr::Value(Value::Null))).binding_strength();
+        // TODO: should we always be fixing the associativity here?
         let expr = translate_operand(expr, min_strength, true, dialect)?;
 
         return Ok(Some(if matches!(op, BinOp::Eq) {

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -516,7 +516,7 @@ fn translate_item(item: Item, dialect: &dyn DialectHandler) -> Result<Expr> {
                     left: translate_operand(
                         left.item,
                         op.binding_strength(),
-                        // No right-associativity in SQL,so we never need to fix
+                        // No right-associativity in SQL, so we never need to fix
                         // the left associativity.
                         false,
                         dialect,


### PR DESCRIPTION
This is not great; hopefully there is a better way  -- it creates lots of parentheses where they're not needed. One challenge is that we don't store parentheses in our AST; we use the parser for this and encode as `BinOp` in the correct order. But that facility is no longer available for us during the materialization phase.

Maybe one inelegant solution is to check whether we need parentheses and only add them if so.
