### PR TITLE
revert: chore: Remove lock of cargo-insta

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,6 @@ tasks:
       # default?!)
       - cargo install --locked
         cargo-audit
-        cargo-insta
         cargo-release
         default-target
         mdbook
@@ -55,6 +54,8 @@ tasks:
         mdbook-toc
         wasm-bindgen-cli
         wasm-pack
+        # https://github.com/mitsuhiko/insta/issues/301
+      - cargo install cargo-insta --version=1.21.0
 
   install-maturin:
     desc: Install maturin


### PR DESCRIPTION
Reverts prql/prql#1169 until I can resolve why the arg passing doesn't seem to be working:

```
❯ cargo insta test -- --target=wasm32-unknown-unknown
    Finished test [unoptimized + debuginfo] target(s) in 0.16s
     Running unittests src/main.rs (target/debug/deps/mdbook_prql-1b98900596ae00f7)
error: Unrecognized option: 'target'
     Running tests/snapshot.rs (target/debug/deps/snapshot-610ac3b37a4750ff)
error: Unrecognized option: 'target'
     Running unittests src/lib.rs (target/debug/deps/prql_compiler-bb28a9cd9d5e2c10)
error: Unrecognized option: 'target'
     Running unittests src/main.rs (target/debug/deps/prql_compiler-49d0107c77853836)
error: Unrecognized option: 'target'
     Running tests/integration/main.rs (target/debug/deps/integration-25b5c22e67643858)
error: Unrecognized option: 'target'
     Running unittests src/lib.rs (target/debug/deps/prql_python-f72459eddfcb7416)
error: Unrecognized option: 'target'
```