### PR TITLE
ci: Don't run gh-pages workflow on forks

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -9,7 +9,9 @@ on:
 jobs:
   publish-gh-pages:
     runs-on: ubuntu-latest
-    # Docs at https://github.com/actions/deploy-pages
+
+    # Skip running workflow on forks
+    if: github.repository_owner == 'prql'
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:


### PR DESCRIPTION
This causes an unnecessary error notification for those running on a fork*

*(which maybe should be all of us, including me?!)
