### PR TITLE
test: check that prql.to_json returns a pipeline

### DIFF
--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -56,8 +56,7 @@ describe("prql-js", () => {
   describe("to_json", () => {
     it("should return valid json from valid prql", () => {
       const js = JSON.parse(prql.to_json(employee_prql));
-      // TODO: fix, ref #1194
-      // assert.equal(js.nodes.length, 1);
+      assert.equal(js.length, 1);
     });
 
     it("should throw an error on invalid prql", () => {

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -1,7 +1,6 @@
 const assert = require("assert");
 const expect = require("chai").expect;
 const prql = require("../dist/node");
-const print = console.log;
 const employee_prql = `from employees
 join salaries [==emp_no]
 group [emp_no, gender] (
@@ -55,8 +54,8 @@ describe("prql-js", () => {
 
   describe("to_json", () => {
     it("should return valid json from valid prql", () => {
-      const js = JSON.parse(prql.to_json(employee_prql));
-      assert.equal(js.length, 1);
+      const json = JSON.parse(prql.to_json(employee_prql));
+      assert.equal(json.length, 1);
     });
 
     it("should throw an error on invalid prql", () => {


### PR DESCRIPTION
Closes #1210

There was a change in output for `to_json` due to the intermediary format changing, so there was no longer a `.nodes` inside this JSON to access.