### PR TITLE
docs: integrate book and playground into main website

### DIFF
--- a/website/config.yml
+++ b/website/config.yml
@@ -12,11 +12,11 @@ menu:
     # TODO: Can we use the info from pages directly? https://gohugo.io/templates/menu-templates/#menu-entries-from-the-pages-front-matter
     - identifier: Book
       name: Book
-      url: "https://prql-lang.org/book/"
+      url: /book_integrated/
       weight: 1
     - identifier: Playground
       name: Playground
-      url: "https://prql-lang.org/playground/"
+      url: /playground_integrated/
       weight: 2
     - identifier: Roadmap
       name: Roadmap

--- a/website/content/book_integrated.html
+++ b/website/content/book_integrated.html
@@ -1,0 +1,6 @@
+---
+title: "Book"
+layout: big_iframe
+---
+
+<iframe src="https://prql-lang.org/book/"></iframe>

--- a/website/content/playground_integrated.html
+++ b/website/content/playground_integrated.html
@@ -1,0 +1,6 @@
+---
+title: "Playground"
+layout: big_iframe
+---
+
+<iframe src="https://prql-lang.org/playground/"></iframe>

--- a/website/themes/prql-theme/layouts/_default/baseof.html
+++ b/website/themes/prql-theme/layouts/_default/baseof.html
@@ -10,7 +10,9 @@
     <div class="d-flex flex-column flex-grow-1 overflow-scroll">
       {{- block "main" . }}{{- end }}
 
-      {{ partial "footer.html" . }}
+      {{- block "footer" . }}
+        {{ partial "footer.html" . }}
+      {{- end }}
     </div>
 
     <a

--- a/website/themes/prql-theme/layouts/_default/big_iframe.html
+++ b/website/themes/prql-theme/layouts/_default/big_iframe.html
@@ -1,5 +1,5 @@
 {{ define "footer" }}
-<!--no footer here-->
+  <!--no footer here-->
 {{ end }}
 {{ define "main" }}
   <main id="main" class="big-iframe">

--- a/website/themes/prql-theme/layouts/_default/big_iframe.html
+++ b/website/themes/prql-theme/layouts/_default/big_iframe.html
@@ -1,0 +1,8 @@
+{{ define "footer" }}
+<!--no footer here-->
+{{ end }}
+{{ define "main" }}
+  <main id="main" class="big-iframe">
+    {{ .Content }}
+  </main>
+{{ end }}

--- a/website/themes/prql-theme/static/style.css
+++ b/website/themes/prql-theme/static/style.css
@@ -730,3 +730,16 @@ details.faq[open] summary h2:before {
 .list .post-item > a {
   font-family: var(--title-font);
 }
+
+/*--------------------------------------------------------------
+# "Full screen" iframe views for book, playground etc
+--------------------------------------------------------------*/
+.big-iframe {
+  padding-top: 80px; /* This is for the header */
+}
+.big-iframe iframe {
+  height: calc(100vh - 80px); /* This is for the header */
+  width: 100vw;
+  display: block;
+  border: none;
+}

--- a/website/themes/prql-theme/static/style.css
+++ b/website/themes/prql-theme/static/style.css
@@ -735,10 +735,10 @@ details.faq[open] summary h2:before {
 # "Full screen" iframe views for book, playground etc
 --------------------------------------------------------------*/
 .big-iframe {
-  padding-top: 80px; /* This is for the header */
+  flex-grow: 1;
 }
 .big-iframe iframe {
-  height: calc(100vh - 80px); /* This is for the header */
+  height: 100%;
   width: 100vw;
   display: block;
   border: none;


### PR DESCRIPTION
Closes #632 

Two notes:
- new ugly URLs – this keeps the book & playground's full-screen versions at /book and /playground, and creates new routes (see GIF) that the main menu now links to. Suggestions welcome!
- the styles of the overall website, the book & the playground are fairly different – not ideal, but I think this change still moves the site in the right direction (we could open a followup issue to theme the playground similarly to the book & code samples)

![2022-12-03 18 28 57](https://user-images.githubusercontent.com/3150328/205451461-ade29af1-f217-48a1-a888-592397c90348.gif)