### PR TITLE
build: Use standard hugo install on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ RUN apt install -y nodejs
 RUN task install-npm-dependencies
 
 # ========= Install hugo =========
-RUN curl -L https://github.com/gohugoio/hugo/releases/download/v0.91.2/hugo_0.91.2_Linux-64bit.deb -o hugo.deb \
-  && apt install ./hugo.deb \
-  && rm hugo.deb
+RUN apt install -y hugo
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Getting an error with the previous version locally (maybe M1?)