### PR TITLE
feat: hide intermadiate named from RQ

### DIFF
--- a/book/tests/snapshots/snapshot__run_reference_prql@examples__employees-0.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@examples__employees-0.prql.snap
@@ -5,7 +5,7 @@ input_file: book/tests/prql/examples/employees-0.prql
 ---
 WITH table_1 AS (
   SELECT
-    AVG(salary) AS emp_salary,
+    AVG(salary) AS _expr_0,
     emp_no
   FROM
     salaries
@@ -15,7 +15,7 @@ WITH table_1 AS (
 table_2 AS (
   SELECT
     t.title,
-    AVG(table_1.emp_salary) AS avg_salary,
+    AVG(table_1._expr_0) AS avg_salary,
     dept_emp.dept_no
   FROM
     table_1

--- a/book/tests/snapshots/snapshot__run_reference_prql@examples__employees-1.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@examples__employees-1.prql.snap
@@ -6,7 +6,7 @@ input_file: book/tests/prql/examples/employees-1.prql
 WITH table_1 AS (
   SELECT
     e.gender,
-    AVG(salaries.salary) AS emp_salary,
+    AVG(salaries.salary) AS _expr_0,
     e.emp_no
   FROM
     employees AS e
@@ -18,8 +18,8 @@ WITH table_1 AS (
 table_2 AS (
   SELECT
     table_1.gender,
-    AVG(table_1.emp_salary) AS salary_avg,
-    STDDEV(table_1.emp_salary) AS salary_sd,
+    AVG(table_1._expr_0) AS salary_avg,
+    STDDEV(table_1._expr_0) AS salary_sd,
     de.dept_no
   FROM
     table_1

--- a/book/tests/snapshots/snapshot__run_reference_prql@examples__employees-2.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@examples__employees-2.prql.snap
@@ -6,7 +6,7 @@ input_file: book/tests/prql/examples/employees-2.prql
 WITH table_1 AS (
   SELECT
     e.gender,
-    AVG(salaries.salary) AS emp_salary,
+    AVG(salaries.salary) AS _expr_0,
     e.emp_no
   FROM
     employees AS e
@@ -17,8 +17,8 @@ WITH table_1 AS (
 ),
 table_2 AS (
   SELECT
-    AVG(table_1.emp_salary) AS salary_avg,
-    STDDEV(table_1.emp_salary) AS salary_sd,
+    AVG(table_1._expr_0) AS salary_avg,
+    STDDEV(table_1._expr_0) AS salary_sd,
     dm.emp_no
   FROM
     table_1

--- a/book/tests/snapshots/snapshot__run_reference_prql@examples__variables-0.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@examples__variables-0.prql.snap
@@ -7,8 +7,8 @@ WITH table_1 AS (
   SELECT
     title,
     country,
-    salary + payroll_tax + benefits_cost AS gross_cost,
-    salary + payroll_tax AS gross_salary,
+    salary + payroll_tax + benefits_cost AS _expr_0,
+    salary + payroll_tax AS _expr_1,
     salary
   FROM
     employees
@@ -19,16 +19,16 @@ SELECT
   title,
   country,
   AVG(salary),
-  AVG(gross_salary),
+  AVG(_expr_1),
   SUM(salary),
-  SUM(gross_salary),
-  AVG(gross_cost),
-  SUM(gross_cost) AS sum_gross_cost,
+  SUM(_expr_1),
+  AVG(_expr_0),
+  SUM(_expr_0) AS sum_gross_cost,
   COUNT(*) AS ct
 FROM
   table_1
 WHERE
-  gross_cost > 0
+  _expr_0 > 0
 GROUP BY
   title,
   country

--- a/book/tests/snapshots/snapshot__run_reference_prql@examples__variables-1.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@examples__variables-1.prql.snap
@@ -5,7 +5,7 @@ input_file: book/tests/prql/examples/variables-1.prql
 ---
 WITH table_1 AS (
   SELECT
-    AVG(salary) AS emp_salary,
+    AVG(salary) AS _expr_0,
     emp_no
   FROM
     employees
@@ -13,8 +13,8 @@ WITH table_1 AS (
     emp_no
 )
 SELECT
-  AVG(table_1.emp_salary) / 1000 AS salary_k,
-  AVG(table_1.emp_salary) / 1000 * 1000 AS salary
+  AVG(table_1._expr_0) / 1000 AS salary_k,
+  AVG(table_1._expr_0) / 1000 * 1000 AS salary
 FROM
   table_1
   JOIN titles ON table_1.emp_no = titles.emp_no

--- a/book/tests/snapshots/snapshot__run_reference_prql@introduction-0.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@introduction-0.prql.snap
@@ -7,8 +7,8 @@ WITH table_1 AS (
   SELECT
     title,
     country,
-    salary + COALESCE(tax, 0) + benefits_cost AS gross_cost,
-    salary + COALESCE(tax, 0) AS gross_salary
+    salary + COALESCE(tax, 0) + benefits_cost AS _expr_0,
+    salary + COALESCE(tax, 0) AS _expr_1
   FROM
     employees
   WHERE
@@ -17,19 +17,19 @@ WITH table_1 AS (
 SELECT
   title,
   country,
-  AVG(gross_salary),
-  SUM(gross_cost) AS sum_gross_cost,
+  AVG(_expr_1),
+  SUM(_expr_0) AS sum_gross_cost,
   CONCAT(title, '_', country) AS id,
   LEFT(country, 2) AS country_code
 FROM
   table_1
 WHERE
-  gross_cost > 0
+  _expr_0 > 0
 GROUP BY
   title,
   country
 HAVING
-  SUM(gross_cost) > 100000
+  SUM(_expr_0) > 100000
 ORDER BY
   sum_gross_cost,
   country DESC

--- a/prql-compiler/src/ast/pl/frame.rs
+++ b/prql-compiler/src/ast/pl/frame.rs
@@ -61,9 +61,20 @@ impl Default for SortDirection {
 }
 
 impl Frame {
-    pub fn push_column(&mut self, name: Option<String>, id: usize) {
+    pub fn push_column(&mut self, col_name: Option<String>, id: usize) {
+        // remove names from columns with the same name
+        if col_name.is_some() {
+            for c in &mut self.columns {
+                if let FrameColumn::Single { name, .. } = c {
+                    if name.as_ref().map(|i| &i.name) == col_name.as_ref() {
+                        *name = None;
+                    }
+                }
+            }
+        }
+
         self.columns.push(FrameColumn::Single {
-            name: name.map(Ident::from_name),
+            name: col_name.map(Ident::from_name),
             expr_id: id,
         });
     }

--- a/prql-compiler/src/ast/rq/mod.rs
+++ b/prql-compiler/src/ast/rq/mod.rs
@@ -30,7 +30,7 @@ pub struct Query {
 pub struct Relation {
     pub kind: RelationKind,
 
-    pub columns: Vec<RelationColumn>
+    pub columns: Vec<RelationColumn>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, EnumAsInner)]
@@ -41,11 +41,10 @@ pub enum RelationKind {
     SString(Vec<InterpolateItem<Expr>>),
 }
 
-
 #[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
 pub enum RelationColumn {
     Wildcard,
-    Single(Option<String>)
+    Single(Option<String>),
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -58,7 +57,7 @@ pub struct TableDecl {
     pub relation: Relation,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct TableRef {
     // referenced table
     pub source: TId,

--- a/prql-compiler/src/ast/rq/mod.rs
+++ b/prql-compiler/src/ast/rq/mod.rs
@@ -26,12 +26,26 @@ pub struct Query {
     pub relation: Relation,
 }
 
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct Relation {
+    pub kind: RelationKind,
+
+    pub columns: Vec<RelationColumn>
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, EnumAsInner)]
-pub enum Relation {
-    ExternRef(TableExternRef, Vec<ColumnDecl>),
+pub enum RelationKind {
+    ExternRef(TableExternRef),
     Pipeline(Vec<Transform>),
-    Literal(RelationLiteral, Vec<ColumnDecl>),
-    SString(Vec<InterpolateItem<Expr>>, Vec<ColumnDecl>),
+    Literal(RelationLiteral),
+    SString(Vec<InterpolateItem<Expr>>),
+}
+
+
+#[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
+pub enum RelationColumn {
+    Wildcard,
+    Single(Option<String>)
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -51,7 +65,7 @@ pub struct TableRef {
 
     // new column definitions are required because there may be multiple instances
     // of this table in the same query
-    pub columns: Vec<ColumnDecl>,
+    pub columns: Vec<(RelationColumn, CId)>,
 
     /// Given name of this table (table alias)
     pub name: Option<String>,

--- a/prql-compiler/src/ast/rq/transform.rs
+++ b/prql-compiler/src/ast/rq/transform.rs
@@ -10,7 +10,7 @@ use super::*;
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, strum::AsRefStr, EnumAsInner)]
 pub enum Transform {
     From(TableRef),
-    Compute(ColumnDecl),
+    Compute(Compute),
     Select(Vec<CId>),
     Filter(Expr),
     Aggregate {
@@ -34,19 +34,10 @@ pub struct Take {
     pub sort: Vec<ColumnSort<CId>>,
 }
 
-/// Transformation of a table.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Default)]
-pub struct Window {
-    pub frame: WindowFrame<Expr>,
-    pub partition: Vec<CId>,
-    pub sort: Vec<ColumnSort<CId>>,
-}
-
-/// Column declaration.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ColumnDecl {
+pub struct Compute {
     pub id: CId,
-    pub kind: ColumnDeclKind,
+    pub expr: Expr,
 
     /// Paramaters for window functions (or expressions).
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -57,27 +48,12 @@ pub struct ColumnDecl {
     pub is_aggregation: bool,
 }
 
-/// Column declaration kind.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, strum::AsRefStr, EnumAsInner)]
-pub enum ColumnDeclKind {
-    /// A column that is out of scope of this query, referenced by name.
-    /// Can only be used in [Relation::ExternRef].
-    ExternRef(String),
-    /// All columns of the relation.
-    /// Can only be used in [Relation::ExternRef].
-    Wildcard,
-    /// A column computed using an expression.
-    /// Can only be used in [Transform::Compute].
-    Expr { name: Option<String>, expr: Expr },
-}
-
-impl ColumnDecl {
-    pub fn get_name(&self) -> Option<&String> {
-        match &self.kind {
-            ColumnDeclKind::Expr { name, .. } => name.as_ref(),
-            _ => None,
-        }
-    }
+/// Transformation of a table.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Default)]
+pub struct Window {
+    pub frame: WindowFrame<Expr>,
+    pub partition: Vec<CId>,
+    pub sort: Vec<ColumnSort<CId>>,
 }
 
 fn is_false(b: &bool) -> bool {

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -350,11 +350,11 @@ select `first name`
         WITH table_1 AS (
           SELECT
             'something' AS renamed,
-            'something' AS somefield
+            'something' AS _expr_0
           FROM
             x
           ORDER BY
-            somefield
+            _expr_0
         )
         SELECT
           renamed
@@ -1327,7 +1327,7 @@ take 20
           SELECT
             title,
             country,
-            AVG(salary) AS salary
+            AVG(salary) AS _expr_0
           FROM
             table_1
           WHERE
@@ -1339,7 +1339,7 @@ take 20
         SELECT
           title,
           country,
-          AVG(salary) AS sum_gross_cost
+          AVG(_expr_0) AS sum_gross_cost
         FROM
           table_2
         GROUP BY

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -1922,7 +1922,7 @@ join y [foo == only_in_x]
           table_1.*
         FROM
           table_2 AS table_0
-          JOIN table_3 AS table_1 ON table_0.* = table_1.*
+          JOIN table_3 AS table_1 ON table_0.id = table_1.id
         "###
         );
     }
@@ -1944,5 +1944,42 @@ join y [foo == only_in_x]
         "###,
         )
         .unwrap_err();
+    }
+
+    #[test]
+    fn test_name_shadowing() {
+        assert_display_snapshot!(compile(
+            r###"
+        from x
+        select [a, a, a = a + 1]
+        "###).unwrap(),
+            @r###"
+        SELECT
+          a,
+          a,
+          a + 1 AS a
+        FROM
+          x
+        "###
+        );
+
+        assert_display_snapshot!(compile(
+            r###"
+        from x
+        select a
+        derive a
+        derive a = a + 1
+        derive a = a + 2
+        "###).unwrap(),
+            @r###"
+        SELECT
+          a,
+          a,
+          a + 1,
+          a + 1 + 2 AS a
+        FROM
+          x
+        "###
+        );
     }
 }

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -210,10 +210,15 @@ impl Lowerer {
         // create instance columns from table columns
         let table = self.table_buffer.iter().find(|t| t.id == tid).unwrap();
 
-        let mut columns = Vec::new();
-        for col in &table.relation.columns {
-            columns.push((col.clone(), self.cid.gen()));
-        }
+        let inferred_cols = self.context.inferred_columns.get(&id);
+
+        let columns = (table.relation.columns.iter())
+            .cloned()
+            .chain(inferred_cols.cloned().unwrap_or_default())
+            .unique()
+            .map(|col| (col, self.cid.gen()))
+            .collect_vec();
+
         log::debug!("... columns = {:?}", columns);
 
         let input_cids: HashMap<_, _> = columns
@@ -563,8 +568,7 @@ impl Lowerer {
                 if let Some((cid, _)) = input_columns.get(&name) {
                     *cid
                 } else {
-                    input_columns.get(&RelationColumn::Wildcard).unwrap().0
-                    // panic!("cannot find cid by id={id} and name={name:?}");
+                    panic!("cannot find cid by id={id} and name={name:?}");
                 }
             }
             None => panic!("cannot find cid by id={id}"),

--- a/prql-compiler/src/semantic/mod.rs
+++ b/prql-compiler/src/semantic/mod.rs
@@ -126,20 +126,24 @@ mod test {
           - id: 0
             name: employees
             relation:
-              ExternRef:
-                - LocalTable: employees
-                - - id: 0
-                    kind: Wildcard
+              kind:
+                ExternRef:
+                  LocalTable: employees
+              columns:
+                - Wildcard
         relation:
-          Pipeline:
-            - From:
-                source: 0
-                columns:
-                  - id: 1
-                    kind: Wildcard
-                name: employees
-            - Select:
-                - 1
+          kind:
+            Pipeline:
+              - From:
+                  source: 0
+                  columns:
+                    - - Wildcard
+                      - 0
+                  name: employees
+              - Select:
+                  - 0
+          columns:
+            - Wildcard
         "### );
 
         assert!(parse_and_resolve(

--- a/prql-compiler/src/semantic/mod.rs
+++ b/prql-compiler/src/semantic/mod.rs
@@ -93,20 +93,24 @@ mod test {
           - id: 0
             name: employees
             relation:
-              ExternRef:
-                - LocalTable: employees
-                - - id: 0
-                    kind: Wildcard
+              kind:
+                ExternRef:
+                  LocalTable: employees
+              columns:
+                - Wildcard
         relation:
-          Pipeline:
-            - From:
-                source: 0
-                columns:
-                  - id: 1
-                    kind: Wildcard
-                name: employees
-            - Select:
-                - 1
+          kind:
+            Pipeline:
+              - From:
+                  source: 0
+                  columns:
+                    - - Wildcard
+                      - 0
+                  name: employees
+              - Select:
+                  - 0
+          columns:
+            - Wildcard
         "### );
 
         assert_yaml_snapshot!(parse_and_resolve(r###"

--- a/prql-compiler/src/semantic/module.rs
+++ b/prql-compiler/src/semantic/module.rs
@@ -225,7 +225,10 @@ impl Module {
                             };
                             sub_ns.names.insert(NS_SELF.to_string(), self_decl);
                         }
-                        let sub_ns = Decl::from(DeclKind::Module(sub_ns));
+                        let sub_ns = Decl {
+                            declared_at: Some(input.id),
+                            kind: DeclKind::Module(sub_ns),
+                        };
 
                         namespace.names.entry(input_name.clone()).or_insert(sub_ns)
                     }
@@ -240,8 +243,10 @@ impl Module {
                 FrameColumn::Wildcard { input_name } => {
                     let input = frame.inputs.iter().find(|i| &i.name == input_name).unwrap();
 
-                    let entry = DeclKind::Wildcard(Box::new(DeclKind::Column(input.id)));
-                    ns.names.insert("*".to_string(), entry.into());
+                    let kind = DeclKind::Wildcard(Box::new(DeclKind::Column(input.id)));
+                    let declared_at = Some(input.id);
+                    let entry = Decl { kind, declared_at };
+                    ns.names.insert("*".to_string(), entry);
                 }
                 FrameColumn::Single {
                     name: Some(name),

--- a/prql-compiler/src/semantic/module.rs
+++ b/prql-compiler/src/semantic/module.rs
@@ -5,8 +5,9 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::ast::pl::{Expr, Ident};
+use crate::ast::rq::RelationColumn;
 
-use super::context::{Decl, DeclKind, TableColumn, TableDecl, TableFrame};
+use super::context::{Decl, DeclKind, TableDecl};
 use super::{Frame, FrameColumn};
 
 pub const NS_STD: &str = "std";
@@ -47,9 +48,7 @@ impl Module {
                             "*".to_string(),
                             Decl::from(DeclKind::Wildcard(Box::new(DeclKind::TableDecl(
                                 TableDecl {
-                                    frame: TableFrame {
-                                        columns: vec![TableColumn::Wildcard],
-                                    },
+                                    columns: vec![RelationColumn::Wildcard],
                                     expr: None,
                                 },
                             )))),

--- a/prql-compiler/src/semantic/reporting.rs
+++ b/prql-compiler/src/semantic/reporting.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 use anyhow::{Ok, Result};
 use ariadne::{Color, Label, Report, ReportBuilder, ReportKind, Source};
 
-use super::context::{DeclKind, TableDecl};
+use super::context::{DeclKind, RelationColumns, TableDecl};
 use super::module::NS_DEFAULT_DB;
 use super::{Context, Frame};
 use crate::ast::pl::{fold::*, *};
@@ -102,7 +102,9 @@ impl<'a> AstFold for Labeler<'a> {
                         .unwrap_or_default();
 
                     let decl = match &decl.kind {
-                        DeclKind::TableDecl(TableDecl { frame, .. }) => format!("table {frame}"),
+                        DeclKind::TableDecl(TableDecl { columns, .. }) => {
+                            format!("table {}", RelationColumns(columns))
+                        }
                         _ => decl.to_string(),
                     };
 

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -5,11 +5,12 @@ use anyhow::{anyhow, bail, Result};
 use itertools::{Itertools, Position};
 
 use crate::ast::pl::{fold::*, *};
+use crate::ast::rq::RelationColumn;
 use crate::error::{Error, Reason, Span};
 use crate::semantic::context::TableDecl;
 use crate::utils::IdGenerator;
 
-use super::context::{Context, Decl, DeclKind, TableColumn};
+use super::context::{Context, Decl, DeclKind};
 use super::module::{Module, NS_FRAME, NS_FRAME_RIGHT, NS_PARAM};
 use super::reporting::debug_call_tree;
 use super::transforms::Flattener;
@@ -138,7 +139,7 @@ impl AstFold for Resolver {
                         ..node
                     },
 
-                    DeclKind::TableDecl(TableDecl { frame, .. }) => {
+                    DeclKind::TableDecl(TableDecl { columns, .. }) => {
                         let alias = node.alias.unwrap_or_else(|| ident.name.clone());
 
                         let instance_frame = Frame {
@@ -147,14 +148,13 @@ impl AstFold for Resolver {
                                 name: alias.clone(),
                                 table: Some(fq_ident.clone()),
                             }],
-                            columns: frame
-                                .columns
+                            columns: columns
                                 .iter()
                                 .map(|col| match col {
-                                    TableColumn::Wildcard => FrameColumn::Wildcard {
+                                    RelationColumn::Wildcard => FrameColumn::Wildcard {
                                         input_name: alias.clone(),
                                     },
-                                    TableColumn::Single(name) => FrameColumn::Single {
+                                    RelationColumn::Single(name) => FrameColumn::Single {
                                         name: name.clone().map(|name| Ident {
                                             name,
                                             path: vec![alias.clone()],

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -127,6 +127,11 @@ impl AstFold for Resolver {
                         }
                     }
 
+                    DeclKind::Wildcard(_) => Expr {
+                        kind: ExprKind::Ident(fq_ident),
+                        target_id: entry.declared_at,
+                        ..node
+                    },
                     DeclKind::Column(target_id) => Expr {
                         kind: ExprKind::Ident(fq_ident),
                         target_id: Some(*target_id),

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -496,44 +496,40 @@ mod tests {
           - id: 0
             name: c_invoice
             relation:
-              ExternRef:
-                - LocalTable: c_invoice
-                - - id: 0
-                    kind: Wildcard
-                  - id: 1
-                    kind:
-                      ExternRef: invoice_no
+              kind:
+                ExternRef:
+                  LocalTable: c_invoice
+              columns:
+                - Single: invoice_no
+                - Wildcard
         relation:
-          Pipeline:
-            - From:
-                source: 0
-                columns:
-                  - id: 2
-                    kind: Wildcard
-                  - id: 3
-                    kind:
-                      Expr:
-                        name: invoice_no
-                        expr:
-                          kind:
-                            ColumnRef: 1
-                          span: ~
-                name: c_invoice
-            - Select:
-                - 3
-            - Take:
-                range:
-                  start: ~
-                  end:
-                    kind:
-                      Literal:
-                        Integer: 1
-                    span: ~
-                partition:
-                  - 3
-                sort: []
-            - Select:
-                - 3
+          kind:
+            Pipeline:
+              - From:
+                  source: 0
+                  columns:
+                    - - Single: invoice_no
+                      - 0
+                    - - Wildcard
+                      - 1
+                  name: c_invoice
+              - Select:
+                  - 0
+              - Take:
+                  range:
+                    start: ~
+                    end:
+                      kind:
+                        Literal:
+                          Integer: 1
+                      span: ~
+                  partition:
+                    - 0
+                  sort: []
+              - Select:
+                  - 0
+          columns:
+            - Single: invoice_no
         "###);
 
         // oops, two arguments #339
@@ -658,72 +654,58 @@ mod tests {
           - id: 0
             name: invoices
             relation:
-              ExternRef:
-                - LocalTable: invoices
-                - - id: 0
-                    kind: Wildcard
-                  - id: 1
-                    kind:
-                      ExternRef: issued_at
-                  - id: 2
-                    kind:
-                      ExternRef: amount
-                  - id: 3
-                    kind:
-                      ExternRef: num_of_articles
+              kind:
+                ExternRef:
+                  LocalTable: invoices
+              columns:
+                - Single: issued_at
+                - Single: amount
+                - Single: num_of_articles
+                - Wildcard
         relation:
-          Pipeline:
-            - From:
-                source: 0
-                columns:
-                  - id: 4
-                    kind: Wildcard
-                  - id: 5
-                    kind:
-                      Expr:
-                        name: issued_at
-                        expr:
-                          kind:
-                            ColumnRef: 1
-                          span: ~
-                  - id: 6
-                    kind:
-                      Expr:
-                        name: amount
-                        expr:
-                          kind:
-                            ColumnRef: 2
-                          span: ~
-                  - id: 7
-                    kind:
-                      Expr:
-                        name: num_of_articles
-                        expr:
-                          kind:
-                            ColumnRef: 3
-                          span: ~
-                name: invoices
-            - Sort:
-                - direction: Asc
-                  column: 5
-                - direction: Desc
-                  column: 6
-                - direction: Asc
-                  column: 7
-            - Sort:
-                - direction: Asc
-                  column: 5
-            - Sort:
-                - direction: Desc
-                  column: 5
-            - Sort:
-                - direction: Asc
-                  column: 5
-            - Sort:
-                - direction: Desc
-                  column: 5
-            - Select:
-                - 4
+          kind:
+            Pipeline:
+              - From:
+                  source: 0
+                  columns:
+                    - - Single: issued_at
+                      - 0
+                    - - Single: amount
+                      - 1
+                    - - Single: num_of_articles
+                      - 2
+                    - - Wildcard
+                      - 3
+                  name: invoices
+              - Sort:
+                  - direction: Asc
+                    column: 0
+                  - direction: Desc
+                    column: 1
+                  - direction: Asc
+                    column: 2
+              - Sort:
+                  - direction: Asc
+                    column: 0
+              - Sort:
+                  - direction: Desc
+                    column: 0
+              - Sort:
+                  - direction: Asc
+                    column: 0
+              - Sort:
+                  - direction: Desc
+                    column: 0
+              - Select:
+                  - 0
+                  - 1
+                  - 2
+                  - 3
+          columns:
+            - Single: issued_at
+            - Single: amount
+            - Single: num_of_articles
+            - Wildcard
         "###);
     }
 }

--- a/prql-compiler/src/snapshots/prql_compiler__test__prql_to_sql_2.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__test__prql_to_sql_2.snap
@@ -6,8 +6,8 @@ WITH table_1 AS (
   SELECT
     title,
     country,
-    salary + payroll_tax + benefits_cost AS gross_cost,
-    salary + payroll_tax AS gross_salary,
+    salary + payroll_tax + benefits_cost AS _expr_0,
+    salary + payroll_tax AS _expr_1,
     salary
   FROM
     employees
@@ -19,15 +19,15 @@ SELECT
   country,
   AVG(salary),
   SUM(salary),
-  AVG(gross_salary),
-  SUM(gross_salary),
-  AVG(gross_cost),
-  SUM(gross_cost) AS sum_gross_cost,
+  AVG(_expr_1),
+  SUM(_expr_1),
+  AVG(_expr_0),
+  SUM(_expr_0) AS sum_gross_cost,
   COUNT(*) AS ct
 FROM
   table_1
 WHERE
-  gross_cost > 0
+  _expr_0 > 0
 GROUP BY
   title,
   country

--- a/prql-compiler/src/sql/anchor.rs
+++ b/prql-compiler/src/sql/anchor.rs
@@ -50,11 +50,6 @@ pub fn split_off_back(
             Transform::Compute(compute) => {
                 if can_materialize(compute, &inputs_required) {
                     log::debug!("materializing {:?}", compute.id);
-
-                    // materialize
-                    // let col_def = ctx.columns_decls.get_mut(&decl.id).unwrap();
-                    // col_def.kind = decl.kind.clone();
-
                     inputs_avail.insert(compute.id);
                 } else {
                     pipeline.push(transform);

--- a/prql-compiler/src/sql/anchor.rs
+++ b/prql-compiler/src/sql/anchor.rs
@@ -482,9 +482,7 @@ impl<'a> IrFold for CidRedirector<'a> {
         match transform {
             Transform::Compute(compute) => {
                 let compute = self.fold_compute(compute)?;
-                self.ctx
-                    .column_decls
-                    .insert(compute.id, ColumnDecl::Compute(compute.clone()));
+                self.ctx.register_compute(compute.clone());
                 Ok(Transform::Compute(compute))
             }
             _ => fold_transform(self, transform),

--- a/prql-compiler/src/sql/anchor.rs
+++ b/prql-compiler/src/sql/anchor.rs
@@ -48,7 +48,7 @@ pub fn split_off_back(
 
         match &transform {
             Transform::Compute(compute) => {
-                if can_materialize(&compute, &inputs_required) {
+                if can_materialize(compute, &inputs_required) {
                     log::debug!("materializing {:?}", compute.id);
 
                     // materialize
@@ -212,13 +212,13 @@ pub fn anchor_split(
         let old_def = ctx.column_decls.get(old_cid).unwrap();
 
         let col = match old_def {
-            ColumnDecl::RelationColumn(_, _, col) => {
-                match col {
-                    RelationColumn::Wildcard | RelationColumn::Single(Some(_)) => col.clone(),
-                    RelationColumn::Single(None) => RelationColumn::Single(Some(ctx.col_name.gen()))
-                }
+            ColumnDecl::RelationColumn(_, _, col) => match col {
+                RelationColumn::Wildcard | RelationColumn::Single(Some(_)) => col.clone(),
+                RelationColumn::Single(None) => RelationColumn::Single(Some(ctx.col_name.gen())),
             },
-            ColumnDecl::Compute(_) => RelationColumn::Single(ctx.get_column_name(*old_cid).cloned()),
+            ColumnDecl::Compute(_) => {
+                RelationColumn::Single(ctx.get_column_name(*old_cid).cloned())
+            }
         };
         let new_cid = ctx.cid.gen();
 

--- a/prql-compiler/src/sql/codegen.rs
+++ b/prql-compiler/src/sql/codegen.rs
@@ -20,6 +20,7 @@ use crate::ast::pl::{
 };
 use crate::ast::rq::*;
 use crate::error::{Error, Reason};
+use crate::sql::context::ColumnDecl;
 use crate::utils::OrMap;
 
 use super::translator::Context;
@@ -150,12 +151,12 @@ pub(super) fn translate_expr_kind(item: ExprKind, ctx: &mut Context) -> Result<s
 fn translate_cid(cid: CId, ctx: &mut Context) -> Result<sql_ast::Expr> {
     if ctx.pre_projection {
         log::debug!("translating {cid:?}");
-        let decl = ctx.anchor.columns_decls.get(&cid).expect("bad RQ ids");
+        let decl = ctx.anchor.column_decls.get(&cid).expect("bad RQ ids");
 
-        if let ColumnDeclKind::Expr { expr, .. } = &decl.kind {
-            let window = decl.window.clone();
+        if let ColumnDecl::Compute(compute) = decl {
+            let window = compute.window.clone();
 
-            let expr = translate_expr_kind(expr.kind.clone(), ctx)?;
+            let expr = translate_expr_kind(compute.expr.kind.clone(), ctx)?;
 
             return if let Some(window) = window {
                 translate_windowed(expr, window, ctx)
@@ -166,17 +167,26 @@ fn translate_cid(cid: CId, ctx: &mut Context) -> Result<sql_ast::Expr> {
     }
 
     // translate into ident
-    let (table, column) = ctx.anchor.materialize_name(&cid);
+    let ident = match &ctx.anchor.column_decls[&cid] {
+        ColumnDecl::Compute(_) => {
+            let name = ctx.anchor.get_column_name(cid).unwrap().clone();
+            translate_ident(None, Some(name), ctx)
+        }
+        ColumnDecl::RelationColumn(tiid, _, col) => {
+            let col = match col {
+                RelationColumn::Wildcard => "*".to_string(),
+                RelationColumn::Single(name) => name.clone().unwrap(),
+            };
+            let t = &ctx.anchor.table_instances[&*tiid];
+
+            translate_ident(Some(t.name.clone().unwrap()), Some(col), ctx)
+        }
+    };
 
     let proj = if ctx.pre_projection { "pre" } else { "post" };
-    log::debug!(
-        "translating {cid:?} {} projection: {:?}.{}",
-        proj,
-        table,
-        column
-    );
+    log::debug!("translating {cid:?} {proj} projection: {ident:?}");
 
-    let ident = sql_ast::Expr::CompoundIdentifier(translate_ident(table, Some(column), ctx));
+    let ident = sql_ast::Expr::CompoundIdentifier(ident);
     Ok(ident)
 }
 
@@ -324,10 +334,10 @@ pub(super) fn translate_select_item(cid: CId, ctx: &mut Context) -> Result<Selec
         _ => None,
     };
 
-    if let Some(alias) = ctx.anchor.get_column_name(&cid) {
-        if Some(&alias) != inferred_name {
+    if let Some(alias) = ctx.anchor.get_column_name(cid) {
+        if Some(alias) != inferred_name {
             return Ok(SelectItem::ExprWithAlias {
-                alias: translate_ident_part(alias, ctx),
+                alias: translate_ident_part(alias.clone(), ctx),
                 expr,
             });
         }

--- a/prql-compiler/src/sql/codegen.rs
+++ b/prql-compiler/src/sql/codegen.rs
@@ -177,7 +177,7 @@ fn translate_cid(cid: CId, ctx: &mut Context) -> Result<sql_ast::Expr> {
                 RelationColumn::Wildcard => "*".to_string(),
                 RelationColumn::Single(name) => name.clone().unwrap(),
             };
-            let t = &ctx.anchor.table_instances[&*tiid];
+            let t = &ctx.anchor.table_instances[tiid];
 
             translate_ident(Some(t.name.clone().unwrap()), Some(col), ctx)
         }

--- a/prql-compiler/src/sql/context.rs
+++ b/prql-compiler/src/sql/context.rs
@@ -86,9 +86,7 @@ impl AnchorContext {
     }
 
     pub(crate) fn get_column_name(&mut self, cid: CId) -> Option<&String> {
-        if self.column_decls[&cid].as_compute().is_none() {
-            return None;
-        }
+        self.column_decls[&cid].as_compute()?;
 
         let name = self.column_names.entry(cid);
         let col_name_gen = &mut self.col_name;

--- a/prql-compiler/src/sql/context.rs
+++ b/prql-compiler/src/sql/context.rs
@@ -93,7 +93,7 @@ impl AnchorContext {
         let name = self.column_names.entry(cid);
         let col_name_gen = &mut self.col_name;
 
-        let name = name.or_insert_with(|| Some(format!("_expr_{}", col_name_gen.gen())));
+        let name = name.or_insert_with(|| Some(col_name_gen.gen()));
 
         name.as_ref()
     }

--- a/prql-compiler/src/sql/context.rs
+++ b/prql-compiler/src/sql/context.rs
@@ -103,11 +103,11 @@ impl AnchorContext {
     }
 
     pub fn determine_select_columns(&self, pipeline: &[Transform]) -> Vec<CId> {
-        if let Some((last, remaning)) = pipeline.split_last() {
+        if let Some((last, remaining)) = pipeline.split_last() {
             match last {
                 Transform::From(table) => table.columns.iter().map(|(_, cid)| *cid).collect(),
                 Transform::Join { with: table, .. } => [
-                    self.determine_select_columns(remaning),
+                    self.determine_select_columns(remaining),
                     table.columns.iter().map(|(_, cid)| *cid).collect_vec(),
                 ]
                 .concat(),
@@ -115,7 +115,7 @@ impl AnchorContext {
                 Transform::Aggregate { partition, compute } => {
                     [partition.clone(), compute.clone()].concat()
                 }
-                _ => self.determine_select_columns(remaning),
+                _ => self.determine_select_columns(remaining),
             }
         } else {
             Vec::new()

--- a/prql-compiler/src/sql/preprocess.rs
+++ b/prql-compiler/src/sql/preprocess.rs
@@ -6,7 +6,7 @@ use crate::ast::pl::{BinOp, ColumnSort, InterpolateItem, Literal, Range, WindowF
 use crate::ast::rq::{CId, Compute, Expr, ExprKind, IrFold, Take, Transform, Window};
 
 use super::anchor::{infer_complexity, Complexity};
-use super::context::{AnchorContext, ColumnDecl};
+use super::context::AnchorContext;
 use super::translator::Context;
 
 pub(super) fn preprocess_distinct(
@@ -117,9 +117,7 @@ impl<'a> TakeConverter<'a> {
             is_aggregation: false,
         };
 
-        self.context
-            .column_decls
-            .insert(compute.id, ColumnDecl::Compute(compute.clone()));
+        self.context.register_compute(compute.clone());
 
         let col_ref = Box::new(Expr {
             kind: ExprKind::ColumnRef(compute.id),

--- a/prql-compiler/src/sql/snapshots/prql_compiler__sql__translator__test__variable_after_aggregate.snap
+++ b/prql-compiler/src/sql/snapshots/prql_compiler__sql__translator__test__variable_after_aggregate.snap
@@ -5,7 +5,7 @@ expression: sql_ast
 WITH table_1 AS (
   SELECT
     title,
-    AVG(salary) AS emp_salary
+    AVG(salary) AS _expr_0
   FROM
     employees
   GROUP BY
@@ -14,7 +14,7 @@ WITH table_1 AS (
 )
 SELECT
   title,
-  AVG(emp_salary) AS avg_salary
+  AVG(_expr_0) AS avg_salary
 FROM
   table_1
 GROUP BY

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -92,6 +92,8 @@ pub fn translate_query(query: Query) -> Result<sql_ast::Query> {
         }
     }
 
+    dbg!(&atomics);
+
     // take last table
     let main_query = atomics.remove(atomics.len() - 1);
     let ctes = atomics;

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -92,8 +92,6 @@ pub fn translate_query(query: Query) -> Result<sql_ast::Query> {
         }
     }
 
-    dbg!(&atomics);
-
     // take last table
     let main_query = atomics.remove(atomics.len() - 1);
     let ctes = atomics;

--- a/prql-compiler/src/utils/id_gen.rs
+++ b/prql-compiler/src/utils/id_gen.rs
@@ -1,11 +1,10 @@
 use std::marker::PhantomData;
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
 
 use crate::ast::rq::{fold_table, CId, IrFold, Query, TId, TableDecl};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IdGenerator<T: From<usize>> {
     next_id: usize,
     phantom: PhantomData<T>,
@@ -63,5 +62,24 @@ impl IrFold for IdLoader {
         self.tid.skip(table.id.get());
 
         fold_table(self, table)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NameGenerator {
+    prefix: &'static str,
+    id: IdGenerator<usize>,
+}
+
+impl NameGenerator {
+    pub fn new(prefix: &'static str) -> Self {
+        NameGenerator {
+            prefix,
+            id: IdGenerator::new(),
+        }
+    }
+
+    pub fn gen(&mut self) -> String {
+        format!("{}{}", self.prefix, self.id.gen())
     }
 }

--- a/prql-compiler/src/utils/id_gen.rs
+++ b/prql-compiler/src/utils/id_gen.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::ast::rq::{fold_table, CId, ColumnDecl, IrFold, Query, TId, TableDecl};
+use crate::ast::rq::{fold_table, CId, IrFold, Query, TId, TableDecl};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdGenerator<T: From<usize>> {
@@ -53,10 +53,10 @@ struct IdLoader {
 }
 
 impl IrFold for IdLoader {
-    fn fold_column_decl(&mut self, cd: ColumnDecl) -> Result<ColumnDecl> {
-        self.cid.skip(cd.id.get());
+    fn fold_cid(&mut self, cid: CId) -> Result<CId> {
+        self.cid.skip(cid.get());
 
-        Ok(cd)
+        Ok(cid)
     }
 
     fn fold_table(&mut self, table: TableDecl) -> Result<TableDecl> {

--- a/prql-compiler/src/utils/mod.rs
+++ b/prql-compiler/src/utils/mod.rs
@@ -3,7 +3,7 @@ mod only;
 mod table_counter;
 mod toposort;
 
-pub use id_gen::IdGenerator;
+pub use id_gen::{IdGenerator, NameGenerator};
 pub use only::*;
 pub use table_counter::TableCounter;
 pub use toposort::toposort;


### PR DESCRIPTION
This removes names from column definitions in RQ. Reason behind this is that we don't want to depend on names, because they can cause collisions, but instead used `CId`s.

Instead of names directly on column defs, we do define names of *columns on the table*.

The end result is that:
- CId is used to reference column within a table (in a pipeline)
- RelationColumn (basically a column name) is used to reference a column from outside the table. For example when instantiating the table in some pipeline downstream.

This way, RQ:
- contains column names for each exposed table,
- does not contain column names for intermediate columns.

Practical effect is this:

```diff
  from x
  # declare a column
  derive [intermediate = a + 1]
  
  # trigger a pipeline split
  take 10
  filter a > 0

  # don't expose the intermediate
  select [final = intermediate +2]

  WITH table_1 AS (
    SELECT
-     a + 1 AS intermediate,
+     a + 1 AS _expr_0,
      a
    FROM
      x
    LIMIT
      10
  )
  SELECT
-   intermediate + 2 AS final
+   _expr_0 + 2 AS final
  FROM
    table_1
  WHERE
    a > 0% 
```

----

This commit also fixes some ambiguities on name shadowing in scenarios like this:
```
from x
select [a, a = b, a = b + 1]
```
The behavior that I implemented resolves this table to have this frame: 
```
[<unnamed>, <unnamed>, a]
```