### PR TITLE
feat: switch

### DIFF
--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -59,6 +59,7 @@ pub enum ExprKind {
     TransformCall(TransformCall),
     SString(Vec<InterpolateItem>),
     FString(Vec<InterpolateItem>),
+    Switch(Vec<SwitchCase>),
 }
 
 impl ExprKind {
@@ -69,8 +70,6 @@ impl ExprKind {
         }
     }
 }
-
-mod modname {}
 
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, strum::Display, strum::EnumString,
@@ -221,6 +220,12 @@ impl Range {
             false
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct SwitchCase<T = Expr> {
+    pub condition: T,
+    pub value: T,
 }
 
 /// FuncCall with better typing. Returns the modified table.
@@ -458,7 +463,7 @@ impl Display for Expr {
                     write!(f, "[{}]", nodes[0])?;
                 } else {
                     f.write_str("[\n")?;
-                    for li in nodes.iter() {
+                    for li in nodes {
                         writeln!(f, "  {},", li)?;
                     }
                     f.write_str("]")?;
@@ -529,6 +534,13 @@ impl Display for Expr {
             }
             ExprKind::Literal(literal) => {
                 write!(f, "{}", literal)?;
+            }
+            ExprKind::Switch(cases) => {
+                f.write_str("[\n")?;
+                for case in cases {
+                    writeln!(f, "  {} => {}", case.condition, case.value)?;
+                }
+                f.write_str("]")?;
             }
         }
 

--- a/prql-compiler/src/ast/rq/expr.rs
+++ b/prql-compiler/src/ast/rq/expr.rs
@@ -1,7 +1,7 @@
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 
-use super::super::pl::{BinOp, InterpolateItem, Literal, Range};
+use super::super::pl::{BinOp, InterpolateItem, Literal, Range, SwitchCase};
 use super::CId;
 use crate::error::Span;
 
@@ -28,6 +28,7 @@ pub enum ExprKind {
     },
     SString(Vec<InterpolateItem<Expr>>),
     FString(Vec<InterpolateItem<Expr>>),
+    Switch(Vec<SwitchCase<Expr>>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -2192,4 +2192,48 @@ join y [foo == only_in_x]
         "###
         );
     }
+
+    #[test]
+    fn test_switch() {
+        assert_display_snapshot!(compile(
+            r###"
+        from employees
+        derive display_name = switch [
+            nickname != null -> nickname,
+            true -> f'{first_name} {last_name}'
+        ]
+            "###).unwrap(),
+            @r###"
+        SELECT
+          *,
+          CASE
+            WHEN nickname IS NOT NULL THEN nickname
+            ELSE CONCAT(first_name, ' ', last_name)
+          END AS display_name
+        FROM
+          employees
+        "###
+        );
+
+        assert_display_snapshot!(compile(
+            r###"
+        from employees
+        derive display_name = switch [
+            nickname != null -> nickname,
+            first_name != null -> f'{first_name} {last_name}'
+        ]
+            "###).unwrap(),
+            @r###"
+        SELECT
+          *,
+          CASE
+            WHEN nickname IS NOT NULL THEN nickname
+            WHEN first_name IS NOT NULL THEN CONCAT(first_name, ' ', last_name)
+            ELSE NULL
+          END AS display_name
+        FROM
+          employees
+        "###
+        );
+    }
 }

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -330,6 +330,23 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
             })
         }
 
+        Rule::switch => {
+            let cases = pair
+                .into_inner()
+                .map(|pair| -> Result<_> {
+                    let [condition, value]: [Expr; 2] = pair
+                        .into_inner()
+                        .map(expr_of_parse_pair)
+                        .collect::<Result<Vec<_>>>()?
+                        .try_into()
+                        .unwrap();
+                    Ok(SwitchCase { condition, value })
+                })
+                .try_collect()?;
+
+            ExprKind::Switch(cases)
+        }
+
         _ => unreachable!("{pair}"),
     };
     Ok(Expr {

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -58,7 +58,7 @@ expr_compare = { expr_add ~ (operator_compare ~ expr_add)? }
 expr_add = { expr_mul ~ (operator_add ~ expr_add)? }
 expr_mul = { term ~ (operator_mul ~ expr_mul)? }
 
-term = _{ ( s_string | f_string | range | literal | ident | nested_pipeline | expr_unary | list | jinja ) }
+term = _{ ( switch | s_string | f_string | range | literal | ident | nested_pipeline | expr_unary | list | jinja ) }
 expr_unary = { ( operator_unary ~ ( nested_pipeline | ident )) }
 literal = _{ value_and_unit | number | boolean | null | string | timestamp | date | time }
 list = { "[" ~ (NEWLINE* ~ (assign_call | expr_call) ~ ("," ~ NEWLINE* ~ (assign_call | expr_call) )* ~ ","?)? ~ NEWLINE* ~ "]" }
@@ -139,3 +139,6 @@ end_expr = _{ WHITESPACE | "," | ")" | "]" | EOI | NEWLINE | ".." }
 
 // We pass text between `{{` and `}}` through, so dbt can use Jinja.
 jinja = { ("{{" ~ (!"}}" ~ ANY)* ~ "}}") }
+
+switch = { "switch" ~ "[" ~ (NEWLINE* ~ switch_case ~ ("," ~ NEWLINE* ~ switch_case )* ~ ","?)? ~ NEWLINE* ~ "]" }
+switch_case = { expr_call ~ "->" ~ expr_call }

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -7,8 +7,8 @@ use itertools::Itertools;
 
 use crate::ast::pl::fold::AstFold;
 use crate::ast::pl::{
-    self, Expr, ExprKind, FrameColumn, Ident, InterpolateItem, Range, TableExternRef, Ty,
-    WindowFrame,
+    self, Expr, ExprKind, FrameColumn, Ident, InterpolateItem, Range, SwitchCase, TableExternRef,
+    Ty, WindowFrame,
 };
 use crate::ast::rq::{self, CId, Query, RelationColumn, TId, TableDecl, Transform};
 use crate::error::{Error, Reason};
@@ -521,6 +521,17 @@ impl Lowerer {
             pl::ExprKind::FString(items) => {
                 rq::ExprKind::FString(self.lower_interpolations(items)?)
             }
+            pl::ExprKind::Switch(cases) => rq::ExprKind::Switch(
+                cases
+                    .into_iter()
+                    .map(|case| -> Result<_> {
+                        Ok(SwitchCase {
+                            condition: self.lower_expr(case.condition)?,
+                            value: self.lower_expr(case.value)?,
+                        })
+                    })
+                    .try_collect()?,
+            ),
             pl::ExprKind::FuncCall(_)
             | pl::ExprKind::Closure(_)
             | pl::ExprKind::List(_)

--- a/prql-compiler/src/sql/anchor.rs
+++ b/prql-compiler/src/sql/anchor.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::rq::{
-    self, fold_transform, CId, Compute, Expr, IrFold, Relation, RelationColumn, RelationKind,
+    self, fold_transform, CId, Compute, Expr, Relation, RelationColumn, RelationKind, RqFold,
     TableDecl, TableRef, Transform,
 };
 
@@ -451,7 +451,7 @@ impl CidCollector {
     }
 }
 
-impl IrFold for CidCollector {
+impl RqFold for CidCollector {
     fn fold_cid(&mut self, cid: CId) -> Result<CId> {
         self.cids.insert(cid);
         Ok(cid)
@@ -463,7 +463,7 @@ struct CidRedirector<'a> {
     cid_redirects: HashMap<CId, CId>,
 }
 
-impl<'a> IrFold for CidRedirector<'a> {
+impl<'a> RqFold for CidRedirector<'a> {
     fn fold_cid(&mut self, cid: CId) -> Result<CId> {
         Ok(self.cid_redirects.get(&cid).cloned().unwrap_or(cid))
     }

--- a/prql-compiler/src/sql/context.rs
+++ b/prql-compiler/src/sql/context.rs
@@ -9,7 +9,7 @@ use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 
 use crate::ast::rq::{
-    fold_table, CId, Compute, IrFold, Query, RelationColumn, TId, TableDecl, TableRef, Transform,
+    fold_table, CId, Compute, Query, RelationColumn, RqFold, TId, TableDecl, TableRef, Transform,
 };
 use crate::utils::{IdGenerator, NameGenerator};
 
@@ -173,7 +173,7 @@ impl QueryLoader {
     }
 }
 
-impl IrFold for QueryLoader {
+impl RqFold for QueryLoader {
     fn fold_table(&mut self, table: TableDecl) -> Result<TableDecl> {
         let mut table = fold_table(self, table)?;
 

--- a/prql-compiler/src/sql/preprocess.rs
+++ b/prql-compiler/src/sql/preprocess.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use anyhow::Result;
 
 use crate::ast::pl::{BinOp, ColumnSort, InterpolateItem, Literal, Range, WindowFrame, WindowKind};
-use crate::ast::rq::{CId, Compute, Expr, ExprKind, IrFold, Take, Transform, Window};
+use crate::ast::rq::{CId, Compute, Expr, ExprKind, RqFold, Take, Transform, Window};
 
 use super::anchor::{infer_complexity, Complexity};
 use super::context::AnchorContext;
@@ -23,7 +23,7 @@ struct TakeConverter<'a> {
     context: &'a mut AnchorContext,
 }
 
-impl<'a> IrFold for TakeConverter<'a> {
+impl<'a> RqFold for TakeConverter<'a> {
     fn fold_transforms(&mut self, transforms: Vec<Transform>) -> Result<Vec<Transform>> {
         let mut res = Vec::new();
 

--- a/prql-compiler/src/sql/translator.rs
+++ b/prql-compiler/src/sql/translator.rs
@@ -11,7 +11,7 @@ use sqlparser::ast::{self as sql_ast, Select, SelectItem, SetExpr, TableWithJoin
 
 use crate::ast::pl::{BinOp, DialectHandler, Literal};
 use crate::ast::rq::{
-    CId, Expr, ExprKind, IrFold, Query, Relation, RelationColumn, RelationKind, TableDecl,
+    CId, Expr, ExprKind, Query, Relation, RelationColumn, RelationKind, RqFold, TableDecl,
     Transform,
 };
 use crate::sql::context::ColumnDecl;

--- a/prql-compiler/src/utils/id_gen.rs
+++ b/prql-compiler/src/utils/id_gen.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use anyhow::Result;
 
-use crate::ast::rq::{fold_table, CId, IrFold, Query, TId, TableDecl};
+use crate::ast::rq::{fold_table, CId, Query, RqFold, TId, TableDecl};
 
 #[derive(Debug, Clone)]
 pub struct IdGenerator<T: From<usize>> {
@@ -51,7 +51,7 @@ struct IdLoader {
     tid: IdGenerator<TId>,
 }
 
-impl IrFold for IdLoader {
+impl RqFold for IdLoader {
     fn fold_cid(&mut self, cid: CId) -> Result<CId> {
         self.cid.skip(cid.get());
 

--- a/prql-compiler/src/utils/table_counter.rs
+++ b/prql-compiler/src/utils/table_counter.rs
@@ -1,4 +1,4 @@
-use crate::ast::rq::{IrFold, Transform};
+use crate::ast::rq::{RqFold, Transform};
 
 /// Folder that counts the number of table referenced in a PRQL query.
 #[derive(Debug, Default)]
@@ -12,7 +12,7 @@ impl TableCounter {
     }
 }
 
-impl IrFold for TableCounter {
+impl RqFold for TableCounter {
     fn fold_transforms(&mut self, transforms: Vec<Transform>) -> anyhow::Result<Vec<Transform>> {
         for transform in &transforms {
             if let Transform::Join { .. } | Transform::From(_) = transform {


### PR DESCRIPTION
First stab at #504

```elm
from employees
derive display_name = switch [
    nickname != null -> nickname,
    true -> f'{first_name} {last_name}'
]
```

Note that:
- default case can be set by using `true` condition.
- if there is no `true` condition, default is NULL (unlike in SQL where an exception is the default).