### PR TITLE
docs: Add docs clarifying how aliases flow

### DIFF
--- a/book/src/transforms/derive.md
+++ b/book/src/transforms/derive.md
@@ -3,7 +3,11 @@
 Computes one or more new columns.
 
 ```prql_no_test
-derive [{new_name} = {expression}]
+derive [
+  {new_name} = {expression},
+  # or
+  {expression}
+]
 ```
 
 ## Examples

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -41,8 +41,7 @@ e.first_name`, such that the table / namespace is lost. So this would not work:
 ```prql_no_test
 from e=employees
 select e.first_name
-# Can't find `e.first_name`
-derive fn = e.first_name
+select fn = e.first_name # Error: cannot find `e.first_name`
 ```
 
 ...and would instead need to be:

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -41,7 +41,7 @@ e.first_name`, such that the table / namespace is lost. So this would not work:
 ```prql_no_test
 from e=employees
 select e.first_name
-select fn = e.first_name # Error: cannot find `e.first_name`
+select fn = e.first_name  # Error: cannot find `e.first_name`
 ```
 
 ...and would instead need to be:

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -47,7 +47,7 @@ derive fn = e.first_name
 
 ...and would instead need to be:
 
-```prql_no_test
+```prql
 from e=employees
 select e.first_name
 derive fn = first_name  # No `e.` here

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -3,20 +3,14 @@
 Picks and computes columns.
 
 ```prql_no_test
-select [{assign_expression}]
+select [
+  {new_name} = {expression},
+  # or
+  {expression}
+]
 ```
 
 ## Examples
-
-```prql
-from employees
-select first_name
-```
-
-```prql
-from employees
-select [first_name, last_name]
-```
 
 ```prql
 from employees
@@ -29,4 +23,32 @@ select [
   name = f"{first_name} {last_name}",
   age_eoy = dob - @2022-12-31,
 ]
+```
+
+```prql
+from employees
+select first_name
+```
+
+```prql
+from e=employees
+select [e.first_name, e.last_name]
+```
+
+Note that currently `select e.first_name` is an alias for `select first_name =
+e.first_name`, such that the table / namespace is lost. So this would not work:
+
+```prql_no_test
+from e=employees
+select e.first_name
+# Can't find `e.first_name`
+derive fn = e.first_name
+```
+
+...and would instead need to be:
+
+```prql_no_test
+from e=employees
+select e.first_name
+derive fn = first_name  # No `e.` here
 ```

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -36,7 +36,7 @@ select [e.first_name, e.last_name]
 ```
 
 Note that currently `select e.first_name` is an alias for `select first_name =
-e.first_name`, such that the table / namespace is lost. So this would not work:
+e.first_name`, such that the table / namespace is not retained. So this would not work:
 
 ```prql_no_test
 from e=employees

--- a/book/tests/prql/transforms/select-0.prql
+++ b/book/tests/prql/transforms/select-0.prql
@@ -1,2 +1,2 @@
 from employees
-select first_name
+select name = f"{first_name} {last_name}"

--- a/book/tests/prql/transforms/select-1.prql
+++ b/book/tests/prql/transforms/select-1.prql
@@ -1,2 +1,5 @@
 from employees
-select [first_name, last_name]
+select [
+  name = f"{first_name} {last_name}",
+  age_eoy = dob - @2022-12-31,
+]

--- a/book/tests/prql/transforms/select-2.prql
+++ b/book/tests/prql/transforms/select-2.prql
@@ -1,2 +1,2 @@
 from employees
-select name = f"{first_name} {last_name}"
+select first_name

--- a/book/tests/prql/transforms/select-3.prql
+++ b/book/tests/prql/transforms/select-3.prql
@@ -1,5 +1,2 @@
-from employees
-select [
-  name = f"{first_name} {last_name}",
-  age_eoy = dob - @2022-12-31,
-]
+from e=employees
+select [e.first_name, e.last_name]

--- a/book/tests/prql/transforms/select-4.prql
+++ b/book/tests/prql/transforms/select-4.prql
@@ -1,0 +1,3 @@
+from e=employees
+select e.first_name
+derive fn = first_name  # No `e.` here

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-0.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-0.prql.snap
@@ -4,7 +4,7 @@ expression: Statements(parse(&prql).unwrap())
 input_file: book/tests/prql/transforms/select-0.prql
 ---
 from employees
-select first_name
+select name = f"{first_name} {last_name}"
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-1.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-1.prql.snap
@@ -5,8 +5,8 @@ input_file: book/tests/prql/transforms/select-1.prql
 ---
 from employees
 select [
-  first_name,
-  last_name,
+  name = f"{first_name} {last_name}",
+  age_eoy = dob - @2022-12-31,
 ]
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-2.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-2.prql.snap
@@ -4,7 +4,7 @@ expression: Statements(parse(&prql).unwrap())
 input_file: book/tests/prql/transforms/select-2.prql
 ---
 from employees
-select name = f"{first_name} {last_name}"
+select first_name
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-3.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-3.prql.snap
@@ -3,10 +3,10 @@ source: book/tests/snapshot.rs
 expression: Statements(parse(&prql).unwrap())
 input_file: book/tests/prql/transforms/select-3.prql
 ---
-from employees
+from e = employees
 select [
-  name = f"{first_name} {last_name}",
-  age_eoy = dob - @2022-12-31,
+  e.first_name,
+  e.last_name,
 ]
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-4.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-4.prql.snap
@@ -1,0 +1,11 @@
+---
+source: book/tests/snapshot.rs
+expression: Statements(parse(&prql).unwrap())
+input_file: book/tests/prql/transforms/select-4.prql
+---
+from e = employees
+select e.first_name
+derive fn = first_name
+
+
+

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-0.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-0.prql.snap
@@ -4,6 +4,6 @@ expression: sql
 input_file: book/tests/prql/transforms/select-0.prql
 ---
 SELECT
-  first_name
+  CONCAT(first_name, ' ', last_name) AS name
 FROM
   employees

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-1.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-1.prql.snap
@@ -4,7 +4,7 @@ expression: sql
 input_file: book/tests/prql/transforms/select-1.prql
 ---
 SELECT
-  first_name,
-  last_name
+  CONCAT(first_name, ' ', last_name) AS name,
+  dob - DATE '2022-12-31' AS age_eoy
 FROM
   employees

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-2.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-2.prql.snap
@@ -4,6 +4,6 @@ expression: sql
 input_file: book/tests/prql/transforms/select-2.prql
 ---
 SELECT
-  CONCAT(first_name, ' ', last_name) AS name
+  first_name
 FROM
   employees

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-3.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-3.prql.snap
@@ -4,7 +4,7 @@ expression: sql
 input_file: book/tests/prql/transforms/select-3.prql
 ---
 SELECT
-  CONCAT(first_name, ' ', last_name) AS name,
-  dob - DATE '2022-12-31' AS age_eoy
+  first_name,
+  last_name
 FROM
-  employees
+  employees AS e

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-4.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-4.prql.snap
@@ -1,0 +1,10 @@
+---
+source: book/tests/snapshot.rs
+expression: sql
+input_file: book/tests/prql/transforms/select-4.prql
+---
+SELECT
+  first_name,
+  first_name AS fn
+FROM
+  employees AS e


### PR DESCRIPTION
Based on https://github.com/prql/prql/issues/1253

If I'm thinking about this correctly, our implementation is different to SQL, which carries the table / namespace through the query.

I don't think it's necessarily bad, and we can have a nice error message saying "Did you mean `first_name`?" if we see a `e.first_name` column
