### PR TITLE
docs: Tweak select wording

### DIFF
--- a/book/src/transforms/derive.md
+++ b/book/src/transforms/derive.md
@@ -3,7 +3,11 @@
 Computes one or more new columns.
 
 ```prql_no_test
-derive [{new_name} = {expression}]
+derive [
+  {new_name} = {expression},
+  # or
+  {expression}
+]
 ```
 
 ## Examples

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -35,20 +35,21 @@ from e=employees
 select [e.first_name, e.last_name]
 ```
 
-Note that currently `select e.first_name` is an alias for `select first_name =
-e.first_name`, such that the table / namespace is lost. So this would not work:
+_Note:_ In the example above, the `e` representing the table / namespace
+is no longer available after the `select` statement.
+So the `filter` statement below would give a "Can't find" error:
 
 ```prql_no_test
 from e=employees
 select e.first_name
-# Can't find `e.first_name`
-derive fn = e.first_name
+filter e.first_name == "Fred" # Can't find `e.first_name`
 ```
 
-...and would instead need to be:
+To refer to the `e.first_name` column in subsequent processing,
+assign it a name in the `select` statement:
 
 ```prql
 from e=employees
-select e.first_name
-derive fn = first_name  # No `e.` here
+select first_name = e.first_name
+filter first_name == "Fred" 
 ```

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -37,7 +37,7 @@ select [e.first_name, e.last_name]
 
 _Note:_ In the example above, the `e` representing the table / namespace
 is no longer available after the `select` statement.
-So the `filter` statement after it would give a "Can't find" error:
+So the `filter` statement after it displays a "Can't find" error:
 
 ```prql_no_test
 from e=employees

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -51,5 +51,5 @@ assign it a name in the `select` statement:
 ```prql
 from e=employees
 select fname = e.first_name
-filter fname == "Fred" 
+filter fname == "Fred"
 ```

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -47,7 +47,7 @@ derive fn = e.first_name
 
 ...and would instead need to be:
 
-```prql_no_test
+```prql
 from e=employees
 select e.first_name
 derive fn = first_name  # No `e.` here

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -37,7 +37,7 @@ select [e.first_name, e.last_name]
 
 _Note:_ In the example above, the `e` representing the table / namespace
 is no longer available after the `select` statement.
-So the `filter` statement below would give a "Can't find" error:
+So the `filter` statement after it would give a "Can't find" error:
 
 ```prql_no_test
 from e=employees
@@ -50,6 +50,6 @@ assign it a name in the `select` statement:
 
 ```prql
 from e=employees
-select first_name = e.first_name
-filter first_name == "Fred" 
+select fname = e.first_name
+filter fname == "Fred" 
 ```

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -3,20 +3,14 @@
 Picks and computes columns.
 
 ```prql_no_test
-select [{assign_expression}]
+select [
+  {new_name} = {expression},
+  # or
+  {expression}
+]
 ```
 
 ## Examples
-
-```prql
-from employees
-select first_name
-```
-
-```prql
-from employees
-select [first_name, last_name]
-```
 
 ```prql
 from employees
@@ -29,4 +23,32 @@ select [
   name = f"{first_name} {last_name}",
   age_eoy = dob - @2022-12-31,
 ]
+```
+
+```prql
+from employees
+select first_name
+```
+
+```prql
+from e=employees
+select [e.first_name, e.last_name]
+```
+
+Note that currently `select e.first_name` is an alias for `select first_name =
+e.first_name`, such that the table / namespace is lost. So this would not work:
+
+```prql_no_test
+from e=employees
+select e.first_name
+# Can't find `e.first_name`
+derive fn = e.first_name
+```
+
+...and would instead need to be:
+
+```prql_no_test
+from e=employees
+select e.first_name
+derive fn = first_name  # No `e.` here
 ```

--- a/book/src/transforms/select.md
+++ b/book/src/transforms/select.md
@@ -37,7 +37,7 @@ select [e.first_name, e.last_name]
 
 _Note:_ In the example above, the `e` representing the table / namespace
 is no longer available after the `select` statement.
-So the `filter` statement after it displays a "Can't find" error:
+So the `filter` statement that follows it displays a "Can't find" error:
 
 ```prql_no_test
 from e=employees

--- a/book/tests/prql/transforms/select-0.prql
+++ b/book/tests/prql/transforms/select-0.prql
@@ -1,2 +1,2 @@
 from employees
-select first_name
+select name = f"{first_name} {last_name}"

--- a/book/tests/prql/transforms/select-1.prql
+++ b/book/tests/prql/transforms/select-1.prql
@@ -1,2 +1,5 @@
 from employees
-select [first_name, last_name]
+select [
+  name = f"{first_name} {last_name}",
+  age_eoy = dob - @2022-12-31,
+]

--- a/book/tests/prql/transforms/select-2.prql
+++ b/book/tests/prql/transforms/select-2.prql
@@ -1,2 +1,2 @@
 from employees
-select name = f"{first_name} {last_name}"
+select first_name

--- a/book/tests/prql/transforms/select-3.prql
+++ b/book/tests/prql/transforms/select-3.prql
@@ -1,5 +1,2 @@
-from employees
-select [
-  name = f"{first_name} {last_name}",
-  age_eoy = dob - @2022-12-31,
-]
+from e=employees
+select [e.first_name, e.last_name]

--- a/book/tests/prql/transforms/select-4.prql
+++ b/book/tests/prql/transforms/select-4.prql
@@ -1,0 +1,3 @@
+from e=employees
+select e.first_name
+derive fn = first_name  # No `e.` here

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-0.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-0.prql.snap
@@ -4,7 +4,7 @@ expression: Statements(parse(&prql).unwrap())
 input_file: book/tests/prql/transforms/select-0.prql
 ---
 from employees
-select first_name
+select name = f"{first_name} {last_name}"
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-1.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-1.prql.snap
@@ -5,8 +5,8 @@ input_file: book/tests/prql/transforms/select-1.prql
 ---
 from employees
 select [
-  first_name,
-  last_name,
+  name = f"{first_name} {last_name}",
+  age_eoy = dob - @2022-12-31,
 ]
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-2.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-2.prql.snap
@@ -4,7 +4,7 @@ expression: Statements(parse(&prql).unwrap())
 input_file: book/tests/prql/transforms/select-2.prql
 ---
 from employees
-select name = f"{first_name} {last_name}"
+select first_name
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-3.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-3.prql.snap
@@ -3,10 +3,10 @@ source: book/tests/snapshot.rs
 expression: Statements(parse(&prql).unwrap())
 input_file: book/tests/prql/transforms/select-3.prql
 ---
-from employees
+from e = employees
 select [
-  name = f"{first_name} {last_name}",
-  age_eoy = dob - @2022-12-31,
+  e.first_name,
+  e.last_name,
 ]
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-4.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@transforms__select-4.prql.snap
@@ -1,0 +1,11 @@
+---
+source: book/tests/snapshot.rs
+expression: Statements(parse(&prql).unwrap())
+input_file: book/tests/prql/transforms/select-4.prql
+---
+from e = employees
+select e.first_name
+derive fn = first_name
+
+
+

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-0.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-0.prql.snap
@@ -4,6 +4,6 @@ expression: sql
 input_file: book/tests/prql/transforms/select-0.prql
 ---
 SELECT
-  first_name
+  CONCAT(first_name, ' ', last_name) AS name
 FROM
   employees

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-1.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-1.prql.snap
@@ -4,7 +4,7 @@ expression: sql
 input_file: book/tests/prql/transforms/select-1.prql
 ---
 SELECT
-  first_name,
-  last_name
+  CONCAT(first_name, ' ', last_name) AS name,
+  dob - DATE '2022-12-31' AS age_eoy
 FROM
   employees

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-2.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-2.prql.snap
@@ -4,6 +4,6 @@ expression: sql
 input_file: book/tests/prql/transforms/select-2.prql
 ---
 SELECT
-  CONCAT(first_name, ' ', last_name) AS name
+  first_name
 FROM
   employees

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-3.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-3.prql.snap
@@ -4,7 +4,7 @@ expression: sql
 input_file: book/tests/prql/transforms/select-3.prql
 ---
 SELECT
-  CONCAT(first_name, ' ', last_name) AS name,
-  dob - DATE '2022-12-31' AS age_eoy
+  first_name,
+  last_name
 FROM
-  employees
+  employees AS e

--- a/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-4.prql.snap
+++ b/book/tests/snapshots/snapshot__run_reference_prql@transforms__select-4.prql.snap
@@ -1,0 +1,10 @@
+---
+source: book/tests/snapshot.rs
+expression: sql
+input_file: book/tests/prql/transforms/select-4.prql
+---
+SELECT
+  first_name,
+  first_name AS fn
+FROM
+  employees AS e


### PR DESCRIPTION
This responds to https://github.com/prql/prql/pull/1290 with updated wording about `select` and the loss of the table/namespace alias.