### PR TITLE
ci: Skip attempting to deploy on PR forks

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -39,7 +39,6 @@ jobs:
           crate: mdbook-admonish
           version: "1.7.0"
 
-      # Playground setup
       - uses: ./.github/actions/build-prql-js
 
       - uses: arduino/setup-task@v1
@@ -52,5 +51,8 @@ jobs:
           path: website/public/
 
       - name: Deploy to GitHub Pages
+        # Even if called by another workflow, don't try and actually publish if
+        # on a fork (it'll fail the workflow even if it otherwise builds successfully)
+        if: github.event.pull_request.head.repo.fork
         id: deployment
         uses: actions/deploy-pages@v1.2.3


### PR DESCRIPTION
This made for a less clear CI report in https://github.com/prql/prql/pull/1302
