### PR TITLE
refactor: public API

### DIFF
--- a/book/tests/snapshot.rs
+++ b/book/tests/snapshot.rs
@@ -142,6 +142,6 @@ fn run_display_reference_prql() {
             return;
         }
 
-        assert_display_snapshot!(pl_of_prql(&prql).and_then(prql_of_pl).unwrap());
+        assert_display_snapshot!(prql_to_pl(&prql).and_then(pl_to_prql).unwrap());
     });
 }

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__dialect_and_version-2.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__dialect_and_version-2.prql.snap
@@ -1,6 +1,6 @@
 ---
 source: book/tests/snapshot.rs
-expression: pl_of_prql(&prql).and_then(prql_of_pl).unwrap()
+expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/dialect_and_version-2.prql
 ---
 prql version:^0.3

--- a/prql-compiler/src/cli.rs
+++ b/prql-compiler/src/cli.rs
@@ -12,7 +12,7 @@ use crate::error::{downcast, Span};
 use crate::parser;
 use crate::semantic::{self, reporting::*};
 use crate::sql;
-use crate::{ast::pl::Frame, prql_of_pl};
+use crate::{ast::pl::Frame, pl_to_prql};
 
 #[derive(Parser)]
 #[clap(name = env!("CARGO_PKG_NAME"), about, version)]
@@ -76,7 +76,7 @@ impl Cli {
                 serde_yaml::to_string(&ast)?.into_bytes()
             }
             Cli::Format(_) => parser::parse(source)
-                .and_then(|x| prql_of_pl(x).map_err(|x| anyhow!(x)))?
+                .and_then(|x| pl_to_prql(x).map_err(|x| anyhow!(x)))?
                 .as_bytes()
                 .to_vec(),
             Cli::Debug(_) => {

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -10,21 +10,21 @@
 //!    (parse) │ ▲
 //! prql_to_pl │ │ pl_to_prql
 //!            │ │
-//!            ▼ │      json::to_pl
+//!            ▼ │      json::from_pl
 //!                   ────────►
 //!           PL AST            PL JSON
 //!                   ◄────────
-//!            │        json::from_pl
+//!            │        json::to_pl
 //!            │
 //!  (resolve) │
 //!   pl_to_rq │
 //!            │
 //!            │
-//!            ▼        json::to_rq
+//!            ▼        json::from_rq
 //!                   ────────►
 //!           RQ AST            RQ JSON
 //!                   ◄────────
-//!            │        json::from_rq
+//!            │        json::to_rq
 //!            │
 //!  rq_to_sql │
 //!            ▼

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -104,7 +104,7 @@ pub fn pl_to_prql(pl: Vec<ast::pl::Stmt>) -> Result<String, ErrorMessages> {
 pub mod json {
     use super::*;
 
-    /// JSON serialization    
+    /// JSON serialization
     pub fn from_pl(pl: Vec<ast::pl::Stmt>) -> Result<String, ErrorMessages> {
         serde_json::to_string(&pl).map_err(|e| error::downcast(anyhow::anyhow!(e)))
     }

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -8,25 +8,25 @@
 //!            PRQL
 //!
 //!    (parse) │ ▲
-//! pl_of_prql │ │ prql_of_pl
+//! prql_to_pl │ │ pl_to_prql
 //!            │ │
-//!            ▼ │      pl_of_json
+//!            ▼ │      json::to_pl
 //!                   ────────►
 //!           PL AST            PL JSON
 //!                   ◄────────
-//!            │        json_of_pl
+//!            │        json::from_pl
 //!            │
 //!  (resolve) │
-//!   rq_of_pl │
+//!   pl_to_rq │
 //!            │
 //!            │
-//!            ▼        rq_of_json
+//!            ▼        json::to_rq
 //!                   ────────►
 //!           RQ AST            RQ JSON
 //!                   ◄────────
-//!            │        json_of_rq
+//!            │        json::from_rq
 //!            │
-//!  sql_of_rq │
+//!  rq_to_sql │
 //!            ▼
 //!
 //!            SQL
@@ -36,7 +36,7 @@
 // is exactly the default warning level. Given we're not that performance
 // sensitive, it's fine to ignore this at the moment (and not worth having a
 // clippy config file for a single setting). We can consider adjusting it as a
-// yak-shaving execise in the future.
+// yak-shaving exercise in the future.
 #![allow(clippy::result_large_err)]
 
 pub mod ast;
@@ -64,9 +64,9 @@ static PRQL_VERSION: Lazy<Version> =
 /// Compile a PRQL string into a SQL string.
 ///
 /// This is a wrapper for:
-/// - [pl_of_prql] — Build PL AST from a PRQL string
-/// - [rq_of_pl] — Finds variable references, validates functions calls, determines frames and converts PL to RQ.
-/// - [sql_of_rq] — Convert RQ AST into an SQL string.
+/// - [prql_to_pl] — Build PL AST from a PRQL string
+/// - [pl_to_rq] — Finds variable references, validates functions calls, determines frames and converts PL to RQ.
+/// - [rq_to_sql] — Convert RQ AST into an SQL string.
 pub fn compile(prql: &str) -> Result<String, ErrorMessages> {
     parser::parse(prql)
         .and_then(semantic::resolve)
@@ -76,19 +76,19 @@ pub fn compile(prql: &str) -> Result<String, ErrorMessages> {
 }
 
 /// Parse PRQL into a PL AST
-pub fn pl_of_prql(prql: &str) -> Result<Vec<ast::pl::Stmt>, ErrorMessages> {
+pub fn prql_to_pl(prql: &str) -> Result<Vec<ast::pl::Stmt>, ErrorMessages> {
     parser::parse(prql)
         .map_err(error::downcast)
         .map_err(|e| e.composed("", prql, false))
 }
 
 /// Perform semantic analysis and convert PL to RQ.
-pub fn rq_of_pl(pl: Vec<ast::pl::Stmt>) -> Result<ast::rq::Query, ErrorMessages> {
+pub fn pl_to_rq(pl: Vec<ast::pl::Stmt>) -> Result<ast::rq::Query, ErrorMessages> {
     semantic::resolve(pl).map_err(error::downcast)
 }
 
 /// Generate SQL from RQ.
-pub fn sql_of_rq(
+pub fn rq_to_sql(
     rq: ast::rq::Query,
     options: Option<sql::Options>,
 ) -> Result<String, ErrorMessages> {
@@ -96,26 +96,31 @@ pub fn sql_of_rq(
 }
 
 /// Generate PRQL code from PL AST
-pub fn prql_of_pl(pl: Vec<ast::pl::Stmt>) -> Result<String, ErrorMessages> {
+pub fn pl_to_prql(pl: Vec<ast::pl::Stmt>) -> Result<String, ErrorMessages> {
     Ok(format!("{}", ast::pl::Statements(pl)))
 }
 
-/// JSON serialization
-pub fn json_of_pl(pl: Vec<ast::pl::Stmt>) -> Result<String, ErrorMessages> {
-    serde_json::to_string(&pl).map_err(|e| error::downcast(anyhow::anyhow!(e)))
-}
+/// JSON serialization and deserialization functions
+pub mod json {
+    use super::*;
 
-/// JSON deserialization
-pub fn pl_of_json(json: &str) -> Result<Vec<ast::pl::Stmt>, ErrorMessages> {
-    serde_json::from_str(json).map_err(|e| error::downcast(anyhow::anyhow!(e)))
-}
+    /// JSON serialization    
+    pub fn from_pl(pl: Vec<ast::pl::Stmt>) -> Result<String, ErrorMessages> {
+        serde_json::to_string(&pl).map_err(|e| error::downcast(anyhow::anyhow!(e)))
+    }
 
-/// JSON deserialization
-pub fn rq_of_json(json: &str) -> Result<ast::rq::Query, ErrorMessages> {
-    serde_json::from_str(json).map_err(|e| error::downcast(anyhow::anyhow!(e)))
-}
+    /// JSON deserialization
+    pub fn to_pl(json: &str) -> Result<Vec<ast::pl::Stmt>, ErrorMessages> {
+        serde_json::from_str(json).map_err(|e| error::downcast(anyhow::anyhow!(e)))
+    }
 
-/// JSON serialization
-pub fn json_of_rq(rq: ast::rq::Query) -> Result<String, ErrorMessages> {
-    serde_json::to_string(&rq).map_err(|e| error::downcast(anyhow::anyhow!(e)))
+    /// JSON serialization
+    pub fn from_rq(rq: ast::rq::Query) -> Result<String, ErrorMessages> {
+        serde_json::to_string(&rq).map_err(|e| error::downcast(anyhow::anyhow!(e)))
+    }
+
+    /// JSON deserialization
+    pub fn to_rq(json: &str) -> Result<ast::rq::Query, ErrorMessages> {
+        serde_json::from_str(json).map_err(|e| error::downcast(anyhow::anyhow!(e)))
+    }
 }

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -36,8 +36,8 @@ fn test_stdlib() {
 
 #[test]
 fn json_of_test() {
-    let json = pl_of_prql("from employees | take 10")
-        .and_then(json_of_pl)
+    let json = prql_to_pl("from employees | take 10")
+        .and_then(json::from_pl)
         .unwrap();
     // Since the AST is so in flux right now just test that the brackets are present
     assert_eq!(json.chars().next().unwrap(), '[');
@@ -1140,11 +1140,11 @@ select [mng_name, managers.gender, salary_avg, salary_sd]"#;
         .and_then(|rq| sql::compile(rq, None))
         .unwrap();
 
-    let sql_from_json = pl_of_prql(original_prql)
-        .and_then(json_of_pl)
-        .and_then(|json| pl_of_json(&json))
-        .and_then(rq_of_pl)
-        .and_then(|rq| sql_of_rq(rq, None))
+    let sql_from_json = prql_to_pl(original_prql)
+        .and_then(json::from_pl)
+        .and_then(|json| json::to_pl(&json))
+        .and_then(pl_to_rq)
+        .and_then(|rq| rq_to_sql(rq, None))
         .unwrap();
 
     assert_eq!(sql_from_prql, sql_from_json);

--- a/prql-java/src/lib.rs
+++ b/prql-java/src/lib.rs
@@ -1,7 +1,7 @@
 use jni::objects::{JClass, JString};
 use jni::sys::jstring;
 use jni::JNIEnv;
-use prql_compiler::{json_of_pl, pl_of_prql};
+use prql_compiler::{json, prql_to_pl};
 
 #[no_mangle]
 #[allow(non_snake_case)]
@@ -33,7 +33,7 @@ pub extern "system" fn Java_org_prql_prql4j_PrqlCompiler_toJson(
         .expect("Couldn't get java string!")
         .into();
     let rs_json_str: String =
-        { pl_of_prql(&prql_query).and_then(json_of_pl) }.expect("Couldn't get prql json of query!");
+        { prql_to_pl(&prql_query).and_then(json::from_pl) }.expect("Couldn't get prql json of query!");
     env.new_string(rs_json_str)
         .expect("Couldn't create java string!")
         .into_raw()

--- a/prql-java/src/lib.rs
+++ b/prql-java/src/lib.rs
@@ -33,7 +33,7 @@ pub extern "system" fn Java_org_prql_prql4j_PrqlCompiler_toJson(
         .expect("Couldn't get java string!")
         .into();
     let rs_json_str: String = { prql_to_pl(&prql_query).and_then(json::from_pl) }
-        .expect("Couldn't get prql json of query!");
+        .expect("Couldn't get json from prql query!");
     env.new_string(rs_json_str)
         .expect("Couldn't create java string!")
         .into_raw()

--- a/prql-java/src/lib.rs
+++ b/prql-java/src/lib.rs
@@ -32,8 +32,8 @@ pub extern "system" fn Java_org_prql_prql4j_PrqlCompiler_toJson(
         .get_string(query)
         .expect("Couldn't get java string!")
         .into();
-    let rs_json_str: String =
-        { prql_to_pl(&prql_query).and_then(json::from_pl) }.expect("Couldn't get prql json of query!");
+    let rs_json_str: String = { prql_to_pl(&prql_query).and_then(json::from_pl) }
+        .expect("Couldn't get prql json of query!");
     env.new_string(rs_json_str)
         .expect("Couldn't create java string!")
         .into_raw()

--- a/prql-js/README.md
+++ b/prql-js/README.md
@@ -15,11 +15,11 @@ Currently these functions are exposed
 ```javascript
 function compile(prql_query: string, options?: CompileOptions): string;
 
-function pl_of_prql(prql_query: string): string;
+function prql_to_pl(prql_query: string): string;
 
-function rq_of_pl(pl_json: string): string;
+function pl_to_rq(pl_json: string): string;
 
-function sql_of_rq(rq_json: string): string;
+function rq_to_sql(rq_json: string): string;
 ```
 
 ### From NodeJS

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -8,40 +8,40 @@ use wasm_bindgen::prelude::*;
 pub fn compile(prql_query: &str, options: Option<CompileOptions>) -> Option<String> {
     return_or_throw(
         Ok(prql_query)
-            .and_then(prql_compiler::pl_of_prql)
-            .and_then(prql_compiler::rq_of_pl)
+            .and_then(prql_compiler::prql_to_pl)
+            .and_then(prql_compiler::pl_to_rq)
             .and_then(|rq| {
-                prql_compiler::sql_of_rq(rq, options.map(prql_compiler::sql::Options::from))
+                prql_compiler::rq_to_sql(rq, options.map(prql_compiler::sql::Options::from))
             })
             .map_err(|e| e.composed("", prql_query, false)),
     )
 }
 
 #[wasm_bindgen]
-pub fn pl_of_prql(prql_query: &str) -> Option<String> {
+pub fn prql_to_pl(prql_query: &str) -> Option<String> {
     return_or_throw(
         Ok(prql_query)
-            .and_then(prql_compiler::pl_of_prql)
-            .and_then(prql_compiler::json_of_pl),
+            .and_then(prql_compiler::prql_to_pl)
+            .and_then(prql_compiler::json::from_pl),
     )
 }
 
 #[wasm_bindgen]
-pub fn rq_of_pl(pl_json: &str) -> Option<String> {
+pub fn pl_to_rq(pl_json: &str) -> Option<String> {
     return_or_throw(
         Ok(pl_json)
-            .and_then(prql_compiler::pl_of_json)
-            .and_then(prql_compiler::rq_of_pl)
-            .and_then(prql_compiler::json_of_rq),
+            .and_then(prql_compiler::json::to_pl)
+            .and_then(prql_compiler::pl_to_rq)
+            .and_then(prql_compiler::json::from_rq),
     )
 }
 
 #[wasm_bindgen]
-pub fn sql_of_rq(rq_json: &str) -> Option<String> {
+pub fn rq_to_sql(rq_json: &str) -> Option<String> {
     return_or_throw(
         Ok(rq_json)
-            .and_then(prql_compiler::rq_of_json)
-            .and_then(|x| prql_compiler::sql_of_rq(x, None)),
+            .and_then(prql_compiler::json::to_rq)
+            .and_then(|x| prql_compiler::rq_to_sql(x, None)),
     )
 }
 

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -40,14 +40,14 @@ describe("prql-js", () => {
     });
   });
 
-  describe("pl_of_prql", () => {
+  describe("prql_to_pl", () => {
     it("should return valid json from valid prql", () => {
-      const json = JSON.parse(prql.pl_of_prql(employee_prql));
+      const json = JSON.parse(prql.prql_to_pl(employee_prql));
       assert.equal(json.length, 1);
     });
 
     it("should throw an error on invalid prql", () => {
-      expect(() => prql.pl_of_prql("Answer: T-H-A-T!")).to.throw("Error");
+      expect(() => prql.prql_to_pl("Answer: T-H-A-T!")).to.throw("Error");
     });
   });
 });

--- a/prql-lib/src/lib.rs
+++ b/prql-lib/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate libc;
 
 use libc::{c_char, c_int};
-use prql_compiler::{json_of_pl, pl_of_prql};
+use prql_compiler::{json, prql_to_pl};
 use std::ffi::CStr;
 use std::ffi::CString;
 
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn to_sql(query: *const c_char, out: *mut c_char) -> c_int
 pub unsafe extern "C" fn to_json(query: *const c_char, out: *mut c_char) -> c_int {
     let prql_query: String = CStr::from_ptr(query).to_string_lossy().into_owned();
 
-    let (isErr, sql_result) = match pl_of_prql(&prql_query).and_then(json_of_pl) {
+    let (isErr, sql_result) = match prql_to_pl(&prql_query).and_then(json::from_pl) {
         Ok(sql_str) => (false, sql_str),
         Err(err) => {
             //let err_str = format!("{}", err);

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -11,13 +11,13 @@ def test_all():
     prql_query = "from employee"
 
     # Since the AST is so in flux, let's just take these dont throw exceptions
-    res = prql.pl_of_prql(prql_query)
+    res = prql.prql_to_pl(prql_query)
     assert res is not None
 
-    res = prql.rq_of_pl(res)
+    res = prql.pl_to_rq(res)
     assert res is not None
 
-    res = prql.sql_of_rq(res)
+    res = prql.rq_to_sql(res)
     assert res is not None
 
     assert prql.__version__ is not None


### PR DESCRIPTION
Re #1280

Given
- rust naming conventions, 
- research described in #1280, 
- the fact that we often use the following chaining pattern,
  ```
  Ok(prql).and_then(prql_to_pl).and_then(pl_to_rq)
  ```
- and my personal preference

... I'm changing public API to use `{input}_to_{output}` naming convention.

Additionally, I future proofed serialization and moved it into `json` module.