### PR TITLE
refactor: Rename items in parser for coherency

### DIFF
--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -201,7 +201,7 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
         // parse parts of a Pairs).
         Rule::operator_coalesce => ExprKind::Ident(Ident::from_name("-")),
 
-        Rule::assign_call | Rule::assign => {
+        Rule::assign | Rule::alias => {
             let (a, expr) = parse_named(pair.into_inner())?;
             alias = Some(a);
             expr.kind
@@ -1101,7 +1101,7 @@ Canada
         assert_yaml_snapshot!(
             expr_of_string(
                 "gross_salary = (salary + payroll_tax) * (1 + tax_rate)",
-                Rule::assign,
+                Rule::alias,
             )?,
             @r###"
         ---

--- a/prql-compiler/src/prql.pest
+++ b/prql-compiler/src/prql.pest
@@ -41,19 +41,16 @@ keyword = _{ "prql" | "table" | "func" }
 pipe = _{ NEWLINE+ | "|" }
 pipeline = { WHITESPACE* ~ expr_call ~ (pipe ~ expr_call)* }
 
-// Whitespace is required to prevent matching s"string". Forbid `operator` so `a
-// - b` can't parse as `a` & `-b`.
-//
-// Note that this needs to use `assign` rather than `assign_call`, so that
-//
-//   join s=salaries [==id]`
-//
-// isn't parsed as `s=` & `salaries [==id]`
-func_call = ${ ident ~ WHITESPACE+ ~ (!operator ~ (named_arg | assign | expr) ~ WHITESPACE*)+ }
+// Whitespace is required to prevent matching s"string". And we forbid
+// `operator` so `a - b` doesn't parse as `a` & `-b`.
+func_call = ${ ident ~ WHITESPACE+ ~ (!operator ~ (named_arg | alias | expr) ~ WHITESPACE*)+ }
 
 named_arg   = !{ ident_part ~ ":" ~ !":" ~ expr }
-assign      = !{ ident_part ~ "=" ~ !"=" ~ expr }
-assign_call = !{ ident_part ~ "=" ~ !"=" ~ expr_call }
+// alias needs to be distinct from assign, so that in `join s=salaries [==id]`,
+// `s=salaries` is parsed separately from `[==id]`, since aliases allow for an
+// expr as an rvalue, but not a function call.
+alias = !{ ident_part ~ "=" ~ !"=" ~ expr }
+assign = !{ ident_part ~ "=" ~ !"=" ~ expr_call }
 
 expr_call = _{ (func_call | expr) }
 
@@ -66,8 +63,8 @@ expr_mul = { term ~ (operator_mul ~ expr_mul)? }
 term = _{ ( switch | s_string | f_string | range | literal | ident | nested_pipeline | expr_unary | list | jinja ) }
 expr_unary = { ( operator_unary ~ ( nested_pipeline | ident )) }
 literal = _{ value_and_unit | number | boolean | null | string | timestamp | date | time }
-// TODO: is there some abstraction of `assign_call | expr_call` that would work here?
-list = { "[" ~ (NEWLINE* ~ (assign_call | expr_call) ~ ("," ~ NEWLINE* ~ (assign_call | expr_call) )* ~ ","?)? ~ NEWLINE* ~ "]" }
+// TODO: is there some abstraction of `assign | expr_call` that would work here?
+list = { "[" ~ (NEWLINE* ~ (assign |  expr_call) ~ ("," ~ NEWLINE* ~ (assign | expr_call) )* ~ ","?)? ~ NEWLINE* ~ "]" }
 nested_pipeline = { "(" ~ (WHITESPACE | NEWLINE)* ~ pipeline? ~ (WHITESPACE | NEWLINE)* ~ ")" }
 
 // We haven't implemented escapes — I think we can mostly pass those through to

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-6.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_into_parse_tree-6.snap
@@ -12,7 +12,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
         },
         inner: [
             Pair {
-                rule: assign_call,
+                rule: assign,
                 span: Span {
                     str: "gross_salary = salary + payroll_tax",
                     start: 4,
@@ -158,7 +158,7 @@ expression: "parse_tree_of_str(r#\"[\n  gross_salary = salary + payroll_tax,\n  
                 ],
             },
             Pair {
-                rule: assign_call,
+                rule: assign,
                 span: Span {
                     str: "gross_cost   = gross_salary + benefits_cost",
                     start: 43,

--- a/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_pipeline_parse_tree.snap
+++ b/prql-compiler/src/snapshots/prql_compiler__parser__test__parse_pipeline_parse_tree.snap
@@ -331,7 +331,7 @@ expression: "parse_tree_of_str(&include_str!(\"../../book/tests/prql/examples/va
                                                                 },
                                                                 inner: [
                                                                     Pair {
-                                                                        rule: assign_call,
+                                                                        rule: assign,
                                                                         span: Span {
                                                                             str: "gross_salary = salary + payroll_tax",
                                                                             start: 185,
@@ -477,7 +477,7 @@ expression: "parse_tree_of_str(&include_str!(\"../../book/tests/prql/examples/va
                                                                         ],
                                                                     },
                                                                     Pair {
-                                                                        rule: assign_call,
+                                                                        rule: assign,
                                                                         span: Span {
                                                                             str: "gross_cost = gross_salary + benefits_cost  # Variables can use other variables.",
                                                                             start: 224,
@@ -1619,7 +1619,7 @@ expression: "parse_tree_of_str(&include_str!(\"../../book/tests/prql/examples/va
                                                                                                                                         ],
                                                                                                                                     },
                                                                                                                                     Pair {
-                                                                                                                                        rule: assign_call,
+                                                                                                                                        rule: assign,
                                                                                                                                         span: Span {
                                                                                                                                             str: "sum_gross_cost = sum gross_cost",
                                                                                                                                             start: 608,
@@ -1746,7 +1746,7 @@ expression: "parse_tree_of_str(&include_str!(\"../../book/tests/prql/examples/va
                                                                                                                                         ],
                                                                                                                                     },
                                                                                                                                     Pair {
-                                                                                                                                        rule: assign_call,
+                                                                                                                                        rule: assign,
                                                                                                                                         span: Span {
                                                                                                                                             str: "ct = count",
                                                                                                                                             start: 645,


### PR DESCRIPTION
While working on #1318 I found the names confusing. Added some explanations too