### PR TITLE
feat: builtin functions

### DIFF
--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -60,6 +60,10 @@ pub enum ExprKind {
     SString(Vec<InterpolateItem>),
     FString(Vec<InterpolateItem>),
     Switch(Vec<SwitchCase>),
+    BuiltInFunction {
+        name: String,
+        args: Vec<Expr>,
+    },
 }
 
 impl ExprKind {
@@ -541,6 +545,9 @@ impl Display for Expr {
                     writeln!(f, "  {} => {}", case.condition, case.value)?;
                 }
                 f.write_str("]")?;
+            }
+            ExprKind::BuiltInFunction { .. } => {
+                f.write_str("<built-in>")?;
             }
         }
 

--- a/prql-compiler/src/ast/pl/fold.rs
+++ b/prql-compiler/src/ast/pl/fold.rs
@@ -107,6 +107,10 @@ pub fn fold_expr_kind<T: ?Sized + AstFold>(fold: &mut T, expr_kind: ExprKind) ->
         Closure(closure) => Closure(Box::new(fold.fold_closure(*closure)?)),
 
         TransformCall(transform) => TransformCall(fold.fold_transform_call(transform)?),
+        BuiltInFunction { name, args } => BuiltInFunction {
+            name,
+            args: fold.fold_exprs(args)?,
+        },
 
         // None of these capture variables, so we don't need to fold them.
         Literal(_) => expr_kind,

--- a/prql-compiler/src/ast/rq/expr.rs
+++ b/prql-compiler/src/ast/rq/expr.rs
@@ -29,6 +29,10 @@ pub enum ExprKind {
     SString(Vec<InterpolateItem<Expr>>),
     FString(Vec<InterpolateItem<Expr>>),
     Switch(Vec<SwitchCase<Expr>>),
+    BuiltInFunction {
+        name: String,
+        args: Vec<Expr>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/prql-compiler/src/ast/rq/fold.rs
+++ b/prql-compiler/src/ast/rq/fold.rs
@@ -233,6 +233,10 @@ pub fn fold_expr_kind<F: ?Sized + RqFold>(fold: &mut F, kind: ExprKind) -> Resul
                 .map(|c| fold_switch_case(fold, c))
                 .try_collect()?,
         ),
+        ExprKind::BuiltInFunction { name, args } => ExprKind::BuiltInFunction {
+            name,
+            args: args.into_iter().map(|a| fold.fold_expr(a)).try_collect()?,
+        },
 
         ExprKind::Literal(_) => kind,
     })

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -532,9 +532,16 @@ impl Lowerer {
                     })
                     .try_collect()?,
             ),
+            pl::ExprKind::BuiltInFunction { name, args } => {
+                // built-in function
+                let args = args.into_iter().map(|x| self.lower_expr(x)).try_collect()?;
+
+                rq::ExprKind::BuiltInFunction { name, args }
+            }
+
             pl::ExprKind::FuncCall(_)
-            | pl::ExprKind::Closure(_)
             | pl::ExprKind::List(_)
+            | pl::ExprKind::Closure(_)
             | pl::ExprKind::Pipeline(_)
             | pl::ExprKind::TransformCall(_) => bail!("Cannot lower to IR expr: `{ast:?}`"),
         };

--- a/prql-compiler/src/semantic/mod.rs
+++ b/prql-compiler/src/semantic/mod.rs
@@ -10,11 +10,11 @@ mod transforms;
 mod type_resolver;
 
 pub use self::context::Context;
+pub use self::module::Module;
 
 use crate::ast::pl::frame::{Frame, FrameColumn};
 use crate::ast::pl::Stmt;
 use crate::ast::rq::Query;
-use crate::semantic::module::Module;
 use crate::PRQL_VERSION;
 
 use anyhow::{bail, Result};
@@ -47,7 +47,7 @@ pub fn resolve_only(
 
 pub fn load_std_lib() -> Context {
     use crate::parser::parse;
-    let std_lib = include_str!("./stdlib.prql");
+    let std_lib = include_str!("./std.prql");
     let statements = parse(std_lib).unwrap();
 
     let context = Context {

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
@@ -15,7 +15,7 @@ Table:
     - Single:
         name:
           - emp_salary
-        expr_id: 28
+        expr_id: 25
   inputs:
     - id: 4
       name: e

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -2,35 +2,34 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            func plus_one x -> x + 1\n            func plus x y -> x + y\n\n            from a\n            derive [b = (sum foo | plus_one | plus 2)]\n            \"#).unwrap()"
 ---
-- id: 25
+- id: 23
   Binary:
     left:
-      id: 19
+      id: 17
       Literal:
         Integer: 2
       ty:
         Literal: Integer
     op: Add
     right:
-      id: 22
+      id: 20
       Binary:
         left:
-          id: 14
-          SString:
-            - String: SUM(
-            - Expr:
-                id: 13
+          id: 11
+          BuiltInFunction:
+            name: std.sum
+            args:
+              - id: 13
                 Ident:
                   - _frame
                   - a
                   - foo
                 target_id: 6
                 ty: Infer
-            - String: )
           ty: Infer
         op: Add
         right:
-          id: 24
+          id: 22
           Literal:
             Integer: 1
           ty:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -2,18 +2,17 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            from a\n            derive one = (foo | sum)\n            \"#).unwrap()"
 ---
-- id: 12
-  SString:
-    - String: SUM(
-    - Expr:
-        id: 9
+- id: 10
+  BuiltInFunction:
+    name: std.sum
+    args:
+      - id: 9
         Ident:
           - _frame
           - a
           - foo
         target_id: 4
         ty: Infer
-    - String: )
   ty:
     Literal: Column
   alias: one

--- a/prql-compiler/src/semantic/std.prql
+++ b/prql-compiler/src/semantic/std.prql
@@ -1,0 +1,44 @@
+# Aggregate Functions
+func min <scalar|column> column -> null
+func max <scalar|column> column -> null
+func sum <scalar|column> column -> null
+func avg <scalar|column> column -> null
+func stddev <scalar|column> column -> null
+func average <scalar|column> column -> null
+func count <scalar|column> non_null:s"*" -> null
+# TODO: Possibly make this into `count distinct:true` (or like `distinct:` as an
+# abbreviation of that?)
+func count_distinct <scalar|column> column -> null
+
+# Window functions
+func lag<column> offset column -> null
+func lead<column> offset column -> null
+func first<column> offset column -> null
+func last<column> offset column -> null
+func rank<column> -> null
+func rank_dense<column> -> null
+func row_number<column> -> null
+
+# Other functions
+func round<scalar> n_digits column -> null
+func as<scalar> `noresolve.type` column -> null
+# TODO: Introduce a notation for getting start and end out of a ranges
+# could be range.0? or range.start? But to make this happen, we need to make
+# changes to how variables are resolved.
+func in<bool> range value -> null
+
+# Transform type definitions
+func from<table> `default_db.source`<table> -> null
+func select<table> columns<column> tbl<table> -> null
+func filter<table> condition<bool> tbl<table> -> null
+func derive<table> columns<column> tbl<table> -> null
+func aggregate<table> a<column> tbl<table> -> null
+func sort<table> by tbl<table> -> null
+func take<table> expr tbl<table> -> null
+func join<table> `default_db.with`<table> filter `noresolve.side`:inner tbl<table> -> null
+func concat<table> `default_db.bottom`<table> top<table> -> null
+func union<table> `default_db.bottom`<table> top<table> -> (
+    top | concat _param.bottom | group [`*`] (take 1)
+)
+func group<table> by pipeline tbl<table> -> null
+func window<table> rows:0..0 range:0..0 expanding:false rolling:0 pipeline tbl<table> -> null

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -652,18 +652,17 @@ mod tests {
               kind:
                 Aggregate:
                   assigns:
-                    - id: 18
-                      SString:
-                        - String: AVG(
-                        - Expr:
-                            id: 17
+                    - id: 15
+                      BuiltInFunction:
+                        name: std.average
+                        args:
+                          - id: 17
                             Ident:
                               - _frame
                               - c_invoice
                               - amount
                             target_id: 4
                             ty: Infer
-                        - String: )
                       ty:
                         Literal: Column
               partition:
@@ -683,7 +682,7 @@ mod tests {
                       expr_id: 8
                   - Single:
                       name: ~
-                      expr_id: 18
+                      expr_id: 15
                 inputs:
                   - id: 4
                     name: c_invoice

--- a/prql-compiler/src/sql/codegen.rs
+++ b/prql-compiler/src/sql/codegen.rs
@@ -200,6 +200,9 @@ pub(super) fn translate_expr_kind(item: ExprKind, ctx: &mut Context) -> Result<s
                 else_result,
             }
         }
+        ExprKind::BuiltInFunction { name, args } => {
+            super::std::translate_built_in(name, args, ctx)?
+        }
     })
 }
 

--- a/prql-compiler/src/sql/mod.rs
+++ b/prql-compiler/src/sql/mod.rs
@@ -5,6 +5,7 @@ mod codegen;
 mod context;
 mod dialect;
 mod preprocess;
+mod std;
 mod translator;
 
 pub use dialect::Dialect;

--- a/prql-compiler/src/sql/std.rs
+++ b/prql-compiler/src/sql/std.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+use std::iter::zip;
+
+use anyhow::Result;
+use once_cell::sync::Lazy;
+use sqlparser::ast::{self as sql_ast};
+
+use super::codegen;
+use super::translator::Context;
+use crate::ast::{pl, rq};
+use crate::semantic;
+
+static STD: Lazy<semantic::Module> = Lazy::new(load_std_impl);
+
+fn load_std_impl() -> semantic::Module {
+    use crate::parser::parse;
+    let std_lib = include_str!("./std_impl.prql");
+    let statements = parse(std_lib).unwrap();
+
+    let context = semantic::Context {
+        root_mod: semantic::Module::new(),
+        ..semantic::Context::default()
+    };
+
+    let (_, context) = semantic::resolve_only(statements, Some(context)).unwrap();
+    let std = context.root_mod.get(&pl::Ident::from_name("std")).unwrap();
+
+    std.kind.clone().into_module().unwrap()
+}
+
+pub(super) fn translate_built_in(
+    name: String,
+    args: Vec<rq::Expr>,
+    ctx: &mut Context,
+) -> Result<sql_ast::Expr> {
+    let name = name.strip_prefix("std.").unwrap();
+
+    let entry = STD.get(&pl::Ident::from_name(name)).unwrap();
+    let func_def = entry.kind.as_func_def().unwrap();
+
+    let params = func_def
+        .named_params
+        .iter()
+        .chain(func_def.positional_params.iter())
+        .map(|x| x.name.split('.').last().unwrap_or(x.name.as_str()));
+
+    let mut args: HashMap<&str, _> = zip(params, args.into_iter()).collect();
+
+    // body can only be an s-string
+    let body = &func_def.body.kind.as_s_string().unwrap();
+    let body = body
+        .iter()
+        .map(|item| {
+            match item {
+                pl::InterpolateItem::Expr(expr) => {
+                    // s-string exprs can only contain idents
+                    let ident = expr.kind.as_ident();
+                    let ident = ident.as_ref().unwrap();
+
+                    // lookup args
+                    let arg = args.remove(ident.name.as_str());
+                    pl::InterpolateItem::<rq::Expr>::Expr(Box::new(arg.unwrap()))
+                }
+                pl::InterpolateItem::String(s) => pl::InterpolateItem::String(s.clone()),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let s_string = codegen::translate_sstring(body, ctx)?;
+
+    Ok(sql_ast::Expr::Identifier(sql_ast::Ident::new(s_string)))
+}

--- a/prql-compiler/src/sql/std_impl.prql
+++ b/prql-compiler/src/sql/std_impl.prql
@@ -1,4 +1,3 @@
-# Aggregate Functions
 func min <scalar|column> column ->  s"MIN({column})"
 func max <scalar|column> column ->  s"MAX({column})"
 func sum <scalar|column> column ->  s"SUM({column})"
@@ -26,23 +25,3 @@ func as<scalar> `noresolve.type` column ->  s"CAST({column} AS {type})"
 # could be range.0? or range.start? But to make this happen, we need to make
 # changes to how variables are resolved.
 func in<bool> range value ->  s"{value} BETWEEN {range}"
-
-# Logical functions
-# TODO: should we remove in favor of `??` to reduce ambiguity?
-func coalesce value default -> s"COALESCE({value}, {default})"
-
-# Transform type definitions
-func from<table> `default_db.source`<table> -> null
-func select<table> columns<column> tbl<table> -> null
-func filter<table> condition<bool> tbl<table> -> null
-func derive<table> columns<column> tbl<table> -> null
-func aggregate<table> a<column> tbl<table> -> null
-func sort<table> by tbl<table> -> null
-func take<table> expr tbl<table> -> null
-func join<table> `default_db.with`<table> filter `noresolve.side`:inner tbl<table> -> null
-func concat<table> `default_db.bottom`<table> top<table> -> null
-func union<table> `default_db.bottom`<table> top<table> -> (
-    top | concat _param.bottom | group [`*`] (take 1)
-)
-func group<table> by pipeline tbl<table> -> null
-func window<table> rows:0..0 range:0..0 expanding:false rolling:0 pipeline tbl<table> -> null


### PR DESCRIPTION
Removes usage of s-string for representation of built-in functions is RQ.

Why? Because we eventually want to use PRQL with backends other than SQL - maybe have database take RQ directly. Using s-strings defeats that purpose. Also, SQL backend needs to know which SQL function is it translating in some cases #1247.

Why now? Because this is tangential to implementing `in` operator needed for #1286