### PR TITLE
style: Add md config

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,10 @@
+config:
+  # We use prettier for line length & wrapping
+  MD013: false
+# markdownItPlugins:
+#
+# Doesn't seem to help with some issues — if someone wants to help resolve then
+# great, but it's no huge stress to have some false positives.
+#
+# https://github.com/DavidAnson/markdownlint/issues/689
+#   - ["markdown-it-footnote"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,11 +46,13 @@ repos:
   # finds, so we don't include it. But it's reasonable to run every now & again
   # manually and take its fixes.
   #
-  # - repo: https://github.com/igorshubovych/markdownlint-cli
-  #   rev: v0.32.2
+  # - repo: https://github.com/DavidAnson/markdownlint-cli2
+  #   rev: v0.5.1
   #   hooks:
-  #     - id: markdownlint
+  #     - id: markdownlint-cli2
   #       args: ["--fix"]
+  #       additional_dependencies:
+  #         - markdown-it-footnote
 ci:
   # Currently network access isn't supported in the CI product.
   skip: [fmt, clippy, markdown-link-check]


### PR DESCRIPTION
Was hoping to try adding this as a default linter, but didn't quite get there, seems like there's actually lots of layers here (https://github.com/DavidAnson/markdownlint/issues/689). A very small issue for this repo so stopping early.
