### PR TITLE
docs: fix alignment issues on homepage

### DIFF
--- a/website/themes/prql-theme/layouts/_default/home.html
+++ b/website/themes/prql-theme/layouts/_default/home.html
@@ -48,23 +48,23 @@
               <div class="section-title">
                 <h2>{{ .title | markdownify }}</h2>
               </div>
-              <div class="row row-cols-1 row-cols-lg-2 justify-content-center">
-                {{ range .items }}
-                  <div class="col g-3">
-                    <div class="card">
-                      <h4>{{ .title | markdownify }}</h4>
-                      {{/* Probably there's a more general way of formatting
-                        this padding; the default is 2em, which looked too indented
-                      */}}
-                      <ul style="padding-left:1em">
-                        {{ range .content }}
-                          <li>{{ . | markdownify }}</li>
-                        {{ end }}
-                      </ul>
-                    </div>
-                  </div>
-                {{ end }}
+            </div>
+            <div class="row row-cols-1 row-cols-lg-2 justify-content-center">
+              {{ range .items }}
+              <div class="col g-3">
+                <div class="card">
+                  <h4>{{ .title | markdownify }}</h4>
+                  {{/* Probably there's a more general way of formatting
+                  this padding; the default is 2em, which looked too indented
+                  */}}
+                  <ul style="padding-left:1em">
+                    {{ range .content }}
+                    <li>{{ . | markdownify }}</li>
+                    {{ end }}
+                  </ul>
+                </div>
               </div>
+              {{ end }}
             </div>
           </div>
         </section>
@@ -143,19 +143,19 @@
               <div class="section-title">
                 <h2>{{ .title | markdownify }}</h2>
               </div>
-              <div class="row row-cols-1 row-cols-lg-3 justify-content-center">
-                {{ range .items }}
-                  <div class="col g-3">
-                    <div class="card">
-                      <h4>{{ .title | markdownify }}</h4>
-                      <p class="blue-border">
-                        <strong>{{ .main_text | markdownify }}</strong>
-                      </p>
-                      <p>{{ .content | markdownify }}</p>
-                    </div>
-                  </div>
-                {{ end }}
+            </div>
+            <div class="row row-cols-1 row-cols-lg-3 justify-content-center">
+              {{ range .items }}
+              <div class="col g-3">
+                <div class="card">
+                  <h4>{{ .title | markdownify }}</h4>
+                  <p class="blue-border">
+                    <strong>{{ .main_text | markdownify }}</strong>
+                  </p>
+                  <p>{{ .content | markdownify }}</p>
+                </div>
               </div>
+              {{ end }}
             </div>
           </div>
         </section>

--- a/website/themes/prql-theme/layouts/_default/home.html
+++ b/website/themes/prql-theme/layouts/_default/home.html
@@ -51,19 +51,19 @@
             </div>
             <div class="row row-cols-1 row-cols-lg-2 justify-content-center">
               {{ range .items }}
-              <div class="col g-3">
-                <div class="card">
-                  <h4>{{ .title | markdownify }}</h4>
-                  {{/* Probably there's a more general way of formatting
-                  this padding; the default is 2em, which looked too indented
-                  */}}
-                  <ul style="padding-left:1em">
-                    {{ range .content }}
-                    <li>{{ . | markdownify }}</li>
-                    {{ end }}
-                  </ul>
+                <div class="col g-3">
+                  <div class="card">
+                    <h4>{{ .title | markdownify }}</h4>
+                    {{/* Probably there's a more general way of formatting
+                      this padding; the default is 2em, which looked too indented
+                    */}}
+                    <ul style="padding-left:1em">
+                      {{ range .content }}
+                        <li>{{ . | markdownify }}</li>
+                      {{ end }}
+                    </ul>
+                  </div>
                 </div>
-              </div>
               {{ end }}
             </div>
           </div>
@@ -146,15 +146,15 @@
             </div>
             <div class="row row-cols-1 row-cols-lg-3 justify-content-center">
               {{ range .items }}
-              <div class="col g-3">
-                <div class="card">
-                  <h4>{{ .title | markdownify }}</h4>
-                  <p class="blue-border">
-                    <strong>{{ .main_text | markdownify }}</strong>
-                  </p>
-                  <p>{{ .content | markdownify }}</p>
+                <div class="col g-3">
+                  <div class="card">
+                    <h4>{{ .title | markdownify }}</h4>
+                    <p class="blue-border">
+                      <strong>{{ .main_text | markdownify }}</strong>
+                    </p>
+                    <p>{{ .content | markdownify }}</p>
+                  </div>
                 </div>
-              </div>
               {{ end }}
             </div>
           </div>

--- a/website/themes/prql-theme/layouts/partials/header.html
+++ b/website/themes/prql-theme/layouts/partials/header.html
@@ -23,7 +23,7 @@
       <i class="bx bx-list-ul mobile-nav-toggle"></i>
     </nav>
 
-    <div style="margin-left: 20px;">
+    <div style="margin-left: 20px; padding-top: 8px">
       <!-- Generated from https://buttons.github.io/ -->
       <a
         class="github-button"

--- a/website/themes/prql-theme/layouts/partials/section-cards.html
+++ b/website/themes/prql-theme/layouts/partials/section-cards.html
@@ -8,25 +8,24 @@
         <div class="section-title">
           <h2>{{ .title | markdownify }}</h2>
         </div>
-
       </div>
       <div class="row row-cols-1 row-cols-lg-4 justify-content-left">
         {{ range .sections }}
-        <div class="col g-3">
-          <div class="card">
-            {{ if and .link .label }}
-            <h4>
-              {{/* We recreate the markdown so external links will parse &
-              display as such.
-              */}}
-              {{ print "[" .label "]" "(" .link ")" | markdownify }}
-            </h4>
-            {{ else }}
-            <h4 class="text-muted">{{ .label }}</h4>
-            {{ end }}
-            {{ .text | markdownify }}
+          <div class="col g-3">
+            <div class="card">
+              {{ if and .link .label }}
+                <h4>
+                  {{/* We recreate the markdown so external links will parse &
+                    display as such.
+                  */}}
+                  {{ print "[" .label "]" "(" .link ")" | markdownify }}
+                </h4>
+              {{ else }}
+                <h4 class="text-muted">{{ .label }}</h4>
+              {{ end }}
+              {{ .text | markdownify }}
+            </div>
           </div>
-        </div>
         {{ end }}
       </div>
     </div>

--- a/website/themes/prql-theme/layouts/partials/section-cards.html
+++ b/website/themes/prql-theme/layouts/partials/section-cards.html
@@ -9,25 +9,25 @@
           <h2>{{ .title | markdownify }}</h2>
         </div>
 
-        <div class="row row-cols-1 row-cols-lg-4 justify-content-left">
-          {{ range .sections }}
-            <div class="col g-3">
-              <div class="card">
-                {{ if and .link .label }}
-                  <h4>
-                    {{/* We recreate the markdown so external links will parse &
-                      display as such.
-                    */}}
-                    {{ print "[" .label "]" "(" .link ")" | markdownify }}
-                  </h4>
-                {{ else }}
-                  <h4 class="text-muted">{{ .label }}</h4>
-                {{ end }}
-                {{ .text | markdownify }}
-              </div>
-            </div>
-          {{ end }}
+      </div>
+      <div class="row row-cols-1 row-cols-lg-4 justify-content-left">
+        {{ range .sections }}
+        <div class="col g-3">
+          <div class="card">
+            {{ if and .link .label }}
+            <h4>
+              {{/* We recreate the markdown so external links will parse &
+              display as such.
+              */}}
+              {{ print "[" .label "]" "(" .link ")" | markdownify }}
+            </h4>
+            {{ else }}
+            <h4 class="text-muted">{{ .label }}</h4>
+            {{ end }}
+            {{ .text | markdownify }}
+          </div>
         </div>
+        {{ end }}
       </div>
     </div>
   </section>

--- a/website/themes/prql-theme/layouts/partials/section-comments.html
+++ b/website/themes/prql-theme/layouts/partials/section-comments.html
@@ -5,37 +5,36 @@
         <div class="section-title">
           <h2>{{ .title | markdownify }}</h2>
         </div>
-
-        <div class="row row-cols justify-content-center">
-          {{ range .comments }}
-            <div class="card-container">
-              {{/* Margin-top & margin-bottom are set to match Tweets. Maybe there's
-                a better way of designing this? (and maybe we design from the stylesheet?)
-              */}}
-              {{ with .quote }}
-                <div
-                  class="card quote"
-                  style="margin-top: 10px; margin-bottom: 10px; height: unset;"
-                >
-                  {{ if .link }}
-                    <a class="quote-text" href="{{ .link }}" target="_blank">
-                      {{ .text }}
-                      <span> — {{ .author }} </span>
-                    </a>
-                  {{ else }}
-                    <p class="quote-text">
-                      {{ .text }}
-                      <span> — {{ .author }} </span>
-                    </p>
-                  {{ end }}
-                </div>
-              {{ end }}
-              {{ with .tweet }}
-                {{ . | markdownify }}
-              {{ end }}
-            </div>
+      </div>
+      <div class="row row-cols justify-content-center">
+        {{ range .comments }}
+        <div class="card-container">
+          {{/* Margin-top & margin-bottom are set to match Tweets. Maybe there's
+          a better way of designing this? (and maybe we design from the stylesheet?)
+          */}}
+          {{ with .quote }}
+          <div
+            class="card quote"
+            style="margin-top: 10px; margin-bottom: 10px; height: unset;"
+          >
+            {{ if .link }}
+            <a class="quote-text" href="{{ .link }}" target="_blank">
+              {{ .text }}
+              <span> — {{ .author }} </span>
+            </a>
+            {{ else }}
+            <p class="quote-text">
+              {{ .text }}
+              <span> — {{ .author }} </span>
+            </p>
+            {{ end }}
+          </div>
+          {{ end }}
+          {{ with .tweet }}
+          {{ . | markdownify }}
           {{ end }}
         </div>
+        {{ end }}
       </div>
     </div>
   </section>

--- a/website/themes/prql-theme/layouts/partials/section-comments.html
+++ b/website/themes/prql-theme/layouts/partials/section-comments.html
@@ -8,32 +8,32 @@
       </div>
       <div class="row row-cols justify-content-center">
         {{ range .comments }}
-        <div class="card-container">
-          {{/* Margin-top & margin-bottom are set to match Tweets. Maybe there's
-          a better way of designing this? (and maybe we design from the stylesheet?)
-          */}}
-          {{ with .quote }}
-          <div
-            class="card quote"
-            style="margin-top: 10px; margin-bottom: 10px; height: unset;"
-          >
-            {{ if .link }}
-            <a class="quote-text" href="{{ .link }}" target="_blank">
-              {{ .text }}
-              <span> — {{ .author }} </span>
-            </a>
-            {{ else }}
-            <p class="quote-text">
-              {{ .text }}
-              <span> — {{ .author }} </span>
-            </p>
+          <div class="card-container">
+            {{/* Margin-top & margin-bottom are set to match Tweets. Maybe there's
+              a better way of designing this? (and maybe we design from the stylesheet?)
+            */}}
+            {{ with .quote }}
+              <div
+                class="card quote"
+                style="margin-top: 10px; margin-bottom: 10px; height: unset;"
+              >
+                {{ if .link }}
+                  <a class="quote-text" href="{{ .link }}" target="_blank">
+                    {{ .text }}
+                    <span> — {{ .author }} </span>
+                  </a>
+                {{ else }}
+                  <p class="quote-text">
+                    {{ .text }}
+                    <span> — {{ .author }} </span>
+                  </p>
+                {{ end }}
+              </div>
+            {{ end }}
+            {{ with .tweet }}
+              {{ . | markdownify }}
             {{ end }}
           </div>
-          {{ end }}
-          {{ with .tweet }}
-          {{ . | markdownify }}
-          {{ end }}
-        </div>
         {{ end }}
       </div>
     </div>


### PR DESCRIPTION
Hi, 

the cards on the homepage had some alignment issues on mobile:

Before:
<img width="543" alt="image" src="https://user-images.githubusercontent.com/9823120/209987164-a1572d2d-190c-4051-9e72-13a7b43d85bb.png">
 
After:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/9823120/209987236-bd35f3b1-540d-498a-a076-c21798593674.png">

The problem was that the grid row containing the cards was nested within the grid row containing the title and all that was needed was to un-nest them.


This PR also tries to improve the alignment of the Github star button in the navbar:

Before:
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/9823120/209987416-10b9a796-1985-48ef-a87f-4d1a8838d869.png">

After:
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/9823120/209987346-810ef006-03f1-465f-9436-f79a880d44b9.png">

The Github button fix is a bit hacky and not perfect (it can't be fixed this way as either mobile or desktop would be a tiny bit misaligned, this is because the main styling is provided by the buttons.js script) but I feel like this solution is better than what was there before.