### PR TITLE
ci: Add token to `setup-task` step

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -42,6 +42,8 @@ jobs:
       - uses: ./.github/actions/build-prql-js
 
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: 🕷️ Build website
         run: task build-web
 


### PR DESCRIPTION
This was getting rate-limited by GitHub, so we need to add a token to prevent that
