### PR TITLE
docs: Fix typo from #1406

### DIFF
--- a/book/src/transforms/concat-and-union.md
+++ b/book/src/transforms/concat-and-union.md
@@ -1,7 +1,7 @@
 # Concat & Union
 
 ```admonish note
-`concot` & `union` are currently experimental and may have bugs; please
+`concat` & `union` are currently experimental and may have bugs; please
 report any as GitHub Issues.
 ```
 


### PR DESCRIPTION
Corrected from "concot" to "concat".