### PR TITLE
docs: Add docs for s-string tables

### DIFF
--- a/book/src/queries/tables.md
+++ b/book/src/queries/tables.md
@@ -13,22 +13,49 @@ table top_50 = (
 from top_50      # Starts a new pipeline
 ```
 
+```admonish note
+The table expression requires surrounding parentheses. Without parentheses, the compiler wouldn't
+be able to evaluate where the expression stopped and the main pipeline started.
+```
+
+We can even place a whole CTE in an s-string, enabling us to use features which
+PRQL doesn't yet support.
+
+```prql
+table grouping = (s"""
+  SELECT SUM(a)
+  FROM tbl
+  GROUP BY
+    GROUPING SETS
+    ((b, c, d), (d), (b, d))
+""")
+
+from grouping
+```
+
+```admonish note
+Currently a table in an s-string needs to start with `SELECT`. This is a
+limitation from the PRQL compiler which we hope to remove soon.
+```
+
+```admonish info
 In PRQL `table`s are far less common than CTEs are in SQL, since a linear series
 of CTEs can be represented with a single pipeline.
-
-## Roadmap
-
-Currently it's not yet possible to have an
-[s-string](./../language-features/s-strings.md) as a whole table. See
-[#376](https://github.com/PRQL/prql/issues/376) for more details.
-
-<!-- TODO: find an example that we can't currently represent with PRQL -->
-
-```prql_no_test
-table a = s"""
-  SELECT *
-  FROM employees
-"""
-
-from a
 ```
+
+<!--
+, like recursive queries:
+
+TODO: get this example to work by removing the restriction to start with SELECT
+
+Example from https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#recursive_keyword
+
+table recursive_example = (s"""
+  WITH RECURSIVE
+    T1 AS ( (SELECT 1 AS n) UNION ALL (SELECT n + 1 AS n FROM T1 WHERE n < 3) )
+  SELECT n FROM T1
+""")
+
+from recursive_example
+
+-->

--- a/book/tests/prql/queries/tables-1.prql
+++ b/book/tests/prql/queries/tables-1.prql
@@ -1,0 +1,9 @@
+table grouping = (s"""
+  SELECT SUM(a)
+  FROM tbl
+  GROUP BY
+    GROUPING SETS
+    ((b, c, d), (d), (b, d))
+""")
+
+from grouping

--- a/book/tests/snapshot.rs
+++ b/book/tests/snapshot.rs
@@ -63,6 +63,9 @@ fn write_reference_prql() -> Result<()> {
     // old files which wouldn't be rewritten from hanging around.
     // We use `trash`, since we don't want to be removing files with test code
     // in case there's a bug.
+    //
+    // A more elegant approach would be to keep a list of the files and remove
+    // the ones we don't write.
 
     let examples_path = Path::new("tests/prql");
     if examples_path.exists() {
@@ -85,8 +88,8 @@ fn write_reference_prql() -> Result<()> {
                 match event.clone() {
                     // At the start of a PRQL code block, push the _next_ item.
                     // Note that on windows, we only get the next _line_, and so
-                    // we exclude the writing in windows. TODO: iterate over the
-                    // lines so this works on windows; https://github.com/PRQL/prql/issues/356
+                    // we exclude the writing in windows below;
+                    // https://github.com/PRQL/prql/issues/356
                     Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(lang)))
                         if lang == "prql".into() =>
                     {

--- a/book/tests/snapshots/snapshot__@queries__tables-1.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__tables-1.prql.snap
@@ -1,0 +1,23 @@
+---
+source: book/tests/snapshot.rs
+expression: "table grouping = (s\"\"\"\n  SELECT SUM(a)\n  FROM tbl\n  GROUP BY\n    GROUPING SETS\n    ((b, c, d), (d), (b, d))\n\"\"\")\n\nfrom grouping\n"
+input_file: book/tests/prql/queries/tables-1.prql
+---
+WITH table_0 AS (
+  SELECT
+    SUM(a)
+  FROM
+    tbl
+  GROUP BY
+    GROUPING SETS ((b, c, d), (d), (b, d))
+),
+grouping AS (
+  SELECT
+    *
+  FROM
+    table_0 AS table_1
+)
+SELECT
+  *
+FROM
+  grouping

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__tables-1.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__tables-1.prql.snap
@@ -1,0 +1,19 @@
+---
+source: book/tests/snapshot.rs
+expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
+input_file: book/tests/prql/queries/tables-1.prql
+---
+table grouping = s"
+  SELECT SUM(a)
+  FROM tbl
+  GROUP BY
+    GROUPING SETS
+    ((b, c, d), (d), (b, d))
+"
+
+
+
+from grouping
+
+
+

--- a/prql-compiler/src/parser.rs
+++ b/prql-compiler/src/parser.rs
@@ -1554,6 +1554,18 @@ take 20
                             Integer: 50
                       named_args: {}
         "###);
+
+        assert_yaml_snapshot!(stmts_of_string(r#"
+            table e = (s"SELECT * FROM employees")
+            "#)?, @r###"
+        ---
+        - TableDef:
+            name: e
+            value:
+              SString:
+                - String: SELECT * FROM employees
+        "###);
+
         Ok(())
     }
 


### PR DESCRIPTION
Based on https://github.com/PRQL/prql/issues/1394

The parentheses constraint isn't flexible I think.

But the `SELECT` one should be (though actually not as easy as I thought). That would let us add recursive queries. I took the example from https://github.com/PRQL/prql/issues/1384.