### PR TITLE
feat: Make s-string select req case insensitive

### DIFF
--- a/prql-compiler/src/sql/codegen.rs
+++ b/prql-compiler/src/sql/codegen.rs
@@ -292,39 +292,49 @@ pub(super) fn translate_query_sstring(
     items: Vec<crate::ast::pl::InterpolateItem<Expr>>,
     context: &mut Context,
 ) -> Result<sql_ast::Query> {
+
     let string = translate_sstring(items, context)?;
-    if let Some(string) = string.trim().strip_prefix("SELECT ") {
-        Ok(sql_ast::Query {
-            body: Box::new(sql_ast::SetExpr::Select(Box::new(sql_ast::Select {
-                projection: vec![sql_ast::SelectItem::UnnamedExpr(sql_ast::Expr::Identifier(
-                    sql_ast::Ident::new(string),
-                ))],
-                distinct: false,
-                top: None,
-                into: None,
-                from: Vec::new(),
-                lateral_views: Vec::new(),
-                selection: None,
-                group_by: Vec::new(),
-                cluster_by: Vec::new(),
-                distribute_by: Vec::new(),
-                sort_by: Vec::new(),
-                having: None,
-                qualify: None,
-            }))),
-            with: None,
-            order_by: Vec::new(),
-            limit: None,
-            offset: None,
-            fetch: None,
-            locks: vec![],
-        })
+
+    let prefix = if let Some(string) = string.trim().get(0..7) {
+        string
     } else {
-        bail!(Error::new(Reason::Simple(
-            "s-strings representing a table must start with `SELECT `".to_string()
-        ))
-        .with_help("this is a limitation by current compiler implementation"))
+        ""
+    };
+
+    if prefix.eq_ignore_ascii_case("SELECT ")  {
+        if let Some(string) = string.trim().strip_prefix(prefix) {
+            return Ok(sql_ast::Query {
+                body: Box::new(sql_ast::SetExpr::Select(Box::new(sql_ast::Select {
+                    projection: vec![sql_ast::SelectItem::UnnamedExpr(sql_ast::Expr::Identifier(
+                        sql_ast::Ident::new(string),
+                    ))],
+                    distinct: false,
+                    top: None,
+                    into: None,
+                    from: Vec::new(),
+                    lateral_views: Vec::new(),
+                    selection: None,
+                    group_by: Vec::new(),
+                    cluster_by: Vec::new(),
+                    distribute_by: Vec::new(),
+                    sort_by: Vec::new(),
+                    having: None,
+                    qualify: None,
+                }))),
+                with: None,
+                order_by: Vec::new(),
+                limit: None,
+                offset: None,
+                fetch: None,
+                locks: vec![],
+            });
+        }
     }
+
+    bail!(Error::new(Reason::Simple(
+        "s-strings representing a table must start with `SELECT `".to_string()
+    ))
+    .with_help("this is a limitation by current compiler implementation"))
 }
 
 /// Aggregate several ordered ranges into one, computing the intersection.

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -1325,6 +1325,62 @@ fn test_bare_s_string() {
       grouping
     "###
     );
+
+    // Test that case insensitive SELECT is accepted. We allow it as it is valid SQL.
+    let query = r###"
+    table a = s"select insensitive from rude"
+    from a
+    "###;
+
+    let sql = compile(query).unwrap();
+    assert_display_snapshot!(sql,
+        @r###"
+    WITH table_0 AS (
+      SELECT
+        insensitive
+      from
+        rude
+    ),
+    a AS (
+      SELECT
+        *
+      FROM
+        table_0 AS table_1
+    )
+    SELECT
+      *
+    FROM
+      a
+    "###
+    );
+
+    // Check a mixture of cases for good measure.
+    let query = r###"
+    table a = s"sElEcT insensitive from rude"
+    from a
+    "###;
+
+    let sql = compile(query).unwrap();
+    assert_display_snapshot!(sql,
+        @r###"
+    WITH table_0 AS (
+      SELECT
+        insensitive
+      from
+        rude
+    ),
+    a AS (
+      SELECT
+        *
+      FROM
+        table_0 AS table_1
+    )
+    SELECT
+      *
+    FROM
+      a
+    "###
+    );
 }
 
 #[test]


### PR DESCRIPTION
Attempts to close https://github.com/PRQL/prql/issues/1439

- Uses eq_ignore_ascii_case to confirm the prefix is correct.
- Adds two tests for "select" and "sElEcT". (We have plenty of "SELECT" coverage already.)

Very new to Rust so if anything I do is contrived please let me know so I can learn 👍 