### PR TITLE
feat: Make s-string select req case insensitive

### DIFF
--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -1325,6 +1325,62 @@ fn test_bare_s_string() {
       grouping
     "###
     );
+
+    // Test that case insensitive SELECT is accepted. We allow it as it is valid SQL.
+    let query = r###"
+    table a = s"select insensitive from rude"
+    from a
+    "###;
+
+    let sql = compile(query).unwrap();
+    assert_display_snapshot!(sql,
+        @r###"
+    WITH table_0 AS (
+      SELECT
+        insensitive
+      from
+        rude
+    ),
+    a AS (
+      SELECT
+        *
+      FROM
+        table_0 AS table_1
+    )
+    SELECT
+      *
+    FROM
+      a
+    "###
+    );
+
+    // Check a mixture of cases for good measure.
+    let query = r###"
+    table a = s"sElEcT insensitive from rude"
+    from a
+    "###;
+
+    let sql = compile(query).unwrap();
+    assert_display_snapshot!(sql,
+        @r###"
+    WITH table_0 AS (
+      SELECT
+        insensitive
+      from
+        rude
+    ),
+    a AS (
+      SELECT
+        *
+      FROM
+        table_0 AS table_1
+    )
+    SELECT
+      *
+    FROM
+      a
+    "###
+    );
 }
 
 #[test]


### PR DESCRIPTION
Attempts to close https://github.com/PRQL/prql/issues/1439

Uses eq_ignore_ascii_case to confirm the prefix is correct.
Adds two tests for "select" and "sElEcT". (We have plenty of "SELECT" coverage already.)
Very new to Rust so if anything I do is contrived please let me know so I can learn 👍

Take 2 with formatting corrected.