### PR TITLE
fix: playground now highlights window, switch, concat, union, prql

### DIFF
--- a/playground/src/workbench/prql-syntax.js
+++ b/playground/src/workbench/prql-syntax.js
@@ -14,20 +14,13 @@ const TRANSFORMS = [
 ];
 const BUILTIN_FUNCTIONS = ["switch"]; // "in", "as"
 const KEYWORDS = ["func", "table", "prql"];
-const LITERALS = [
-  "and",
-  "or",
-  "not",
-  "null",
-  "true",
-  "false",
-];
+const LITERALS = ["and", "or", "not", "null", "true", "false"];
 
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
 
-  keywords:  [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
+  keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
 
   operators: [
     "-",

--- a/playground/src/workbench/prql-syntax.js
+++ b/playground/src/workbench/prql-syntax.js
@@ -14,13 +14,14 @@ const TRANSFORMS = [
 ];
 const BUILTIN_FUNCTIONS = ["switch"]; // "in", "as"
 const KEYWORDS = ["func", "table", "prql"];
-const LITERALS = ["and", "or", "not", "null", "true", "false"];
+const LITERALS = ["null", "true", "false"];
+const OPERATORS = ["and", "or"]; // "not"
 
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
 
-  keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
+  keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS, ...OPERATORS],
 
   operators: [
     "-",

--- a/playground/src/workbench/prql-syntax.js
+++ b/playground/src/workbench/prql-syntax.js
@@ -21,7 +21,13 @@ const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
 
-  keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS, ...OPERATORS],
+  keywords: [
+    ...TRANSFORMS,
+    ...BUILTIN_FUNCTIONS,
+    ...KEYWORDS,
+    ...LITERALS,
+    ...OPERATORS,
+  ],
 
   operators: [
     "-",

--- a/playground/src/workbench/prql-syntax.js
+++ b/playground/src/workbench/prql-syntax.js
@@ -15,7 +15,23 @@ const TRANSFORMS = [
 const BUILTIN_FUNCTIONS = ["switch"]; // "in", "as"
 const KEYWORDS = ["func", "table", "prql"];
 const LITERALS = ["null", "true", "false"];
-const OPERATORS = ["and", "or"]; // "not"
+const OPERATORS = [
+  "-",
+  "*",
+  "/",
+  "%",
+  "+",
+  "-",
+  "==",
+  "!=",
+  ">",
+  "<",
+  ">=",
+  "<=",
+  "??",
+  "and",
+  "or"
+]; // "not"
 
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
@@ -26,24 +42,9 @@ const def = {
     ...BUILTIN_FUNCTIONS,
     ...KEYWORDS,
     ...LITERALS,
-    ...OPERATORS,
   ],
 
-  operators: [
-    "-",
-    "*",
-    "/",
-    "%",
-    "+",
-    "-",
-    "==",
-    "!=",
-    ">",
-    "<",
-    ">=",
-    "<=",
-    "??",
-  ],
+  operators: OPERATORS,
 
   // The main tokenizer for our languages
   tokenizer: {

--- a/playground/src/workbench/prql-syntax.js
+++ b/playground/src/workbench/prql-syntax.js
@@ -1,26 +1,33 @@
+const TRANSFORMS = [
+  "from",
+  "select",
+  "derive",
+  "filter",
+  "take",
+  "sort",
+  "join",
+  "aggregate",
+  "group",
+  "window",
+  "concat",
+  "union",
+];
+const BUILTIN_FUNCTIONS = ["switch"]; // "in", "as"
+const KEYWORDS = ["func", "table", "prql"];
+const LITERALS = [
+  "and",
+  "or",
+  "not",
+  "null",
+  "true",
+  "false",
+];
+
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
 
-  keywords: [
-    "from",
-    "select",
-    "derive",
-    "filter",
-    "take",
-    "sort",
-    "join",
-    "aggregate",
-    "group",
-    "func",
-    "table",
-    "and",
-    "or",
-    "not",
-    "null",
-    "true",
-    "false",
-  ],
+  keywords:  [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
 
   operators: [
     "-",

--- a/playground/src/workbench/prql-syntax.js
+++ b/playground/src/workbench/prql-syntax.js
@@ -30,19 +30,14 @@ const OPERATORS = [
   "<=",
   "??",
   "and",
-  "or"
+  "or",
 ]; // "not"
 
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
 
-  keywords: [
-    ...TRANSFORMS,
-    ...BUILTIN_FUNCTIONS,
-    ...KEYWORDS,
-    ...LITERALS,
-  ],
+  keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
 
   operators: OPERATORS,
 


### PR DESCRIPTION
I have:

- Added window, switch, concat, union and prql to match the book highlighting.
- Split the keyword list up to be more consistent with prql.js and highlight-prql.js
- Left out as/in for now as they've not really landed yet AFAIK.