### PR TITLE
docs: Move some content from Contributing to Development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,53 +90,6 @@ in examples.)
 - Find a group of users who would be interested in PRQL, help them get up to
   speed, help the project understand what they need.
 
-## Commits
-
-- If a change is user-facing, it would be helpful to add a line in
-  [**`CHANGELOG.md`**](CHANGELOG.md), with `{message}, ({@contributor, #X})`
-  where `X` is the PR number.
-- We're experimenting with using the
-  [Conventional Commits](https://www.conventionalcommits.org) message format,
-  enforced through
-  [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request).
-  This would let us generate Changelogs automatically. The check is not required
-  to pass at the moment.
-
-## Merges
-
-- **We merge any code that makes PRQL better**
-- A PR doesn't need to be perfect to be merged; it doesn't need to solve a big
-  problem. It needs to:
-  - be in the right direction
-  - make incremental progress
-  - be explicit on its current state, so others can continue the progress
-- If you have merge permissions, and are reasonably confident that a PR is
-  suitable to merge (whether or not you're the author), feel free to merge.
-  - If you don't have merge permissions and have authored a few PRs, ask and ye
-    shall receive.
-- The primary way we ratchet the code quality is through automated tests.
-  - This means PRs almost always need a test to demonstrate incremental
-    progress.
-  - If a change breaks functionality without breaking tests, our tests were
-    insufficient.
-- We use PR reviews to give general context, offer specific assistance, and
-  collaborate on larger decisions.
-  - Reviews around 'nits' like code formatting / idioms / etc are very welcome.
-    But the norm is for them to be received as helpful advice, rather than as
-    mandatory tasks to complete. Adding automated tests & lints to automate
-    these suggestions is welcome.
-  - If you have merge permissions and would like a PR to be reviewed before it
-    merges, that's great — ask or assign a reviewer.
-  - If a PR hasn't received attention after a day, please feel free to ping the
-    pull request.
-- People may review a PR after it's merged. As part of the understanding that we
-  can merge quickly, contributors are expected to incorporate substantive
-  feedback into a future PR.
-- We should revert quickly if the impact of a PR turns out not to be consistent
-  with our expectations, or there isn't as much consensus on a decision as we
-  had hoped. It's very easy to revert code and then re-revert when we've
-  resolved the issue; it's a sign of moving quickly.
-
 ## Core team
 
 If you have any questions or feedback and don't receive a response on one of the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -129,6 +129,58 @@ task test-all
 These require installing Task, either `brew install go-task/tap/go-task` or as
 described on [Task](https://taskfile.dev/#/installation).
 
+## Contribution workflow
+
+We're similar to most projects on GitHub — open a Pull Request with a suggested
+change!
+
+### Commits
+
+- If a change is user-facing, it would be helpful to add a line in
+  [**`CHANGELOG.md`**](CHANGELOG.md), with `{message}, ({@contributor, #X})`
+  where `X` is the PR number.
+- We're experimenting with using the
+  [Conventional Commits](https://www.conventionalcommits.org) message format,
+  enforced through
+  [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request).
+  This would let us generate Changelogs automatically. The check is not required
+  to pass at the moment.
+
+### Merges
+
+- **We merge any code that makes PRQL better**
+- A PR doesn't need to be perfect to be merged; it doesn't need to solve a big
+  problem. It needs to:
+  - be in the right direction
+  - make incremental progress
+  - be explicit on its current state, so others can continue the progress
+- If you have merge permissions, and are reasonably confident that a PR is
+  suitable to merge (whether or not you're the author), feel free to merge.
+  - If you don't have merge permissions and have authored a few PRs, ask and ye
+    shall receive.
+- The primary way we ratchet the code quality is through automated tests.
+  - This means PRs almost always need a test to demonstrate incremental
+    progress.
+  - If a change breaks functionality without breaking tests, our tests were
+    insufficient.
+- We use PR reviews to give general context, offer specific assistance, and
+  collaborate on larger decisions.
+  - Reviews around 'nits' like code formatting / idioms / etc are very welcome.
+    But the norm is for them to be received as helpful advice, rather than as
+    mandatory tasks to complete. Adding automated tests & lints to automate
+    these suggestions is welcome.
+  - If you have merge permissions and would like a PR to be reviewed before it
+    merges, that's great — ask or assign a reviewer.
+  - If a PR hasn't received attention after a day, please feel free to ping the
+    pull request.
+- People may review a PR after it's merged. As part of the understanding that we
+  can merge quickly, contributors are expected to incorporate substantive
+  feedback into a future PR.
+- We should revert quickly if the impact of a PR turns out not to be consistent
+  with our expectations, or there isn't as much consensus on a decision as we
+  had hoped. It's very easy to revert code and then re-revert when we've
+  resolved the issue; it's a sign of moving quickly.
+
 ## Components of PRQL
 
 The PRQL project has several components. Instructions for working with them are


### PR DESCRIPTION
Still not thrilled about the split here, but some of this def belongs in Development.
