### PR TITLE
docs: Try and explain parentheses...

### DIFF
--- a/book/src/queries/syntax.md
+++ b/book/src/queries/syntax.md
@@ -104,10 +104,10 @@ other languages.
 Parentheses are required around:
 
 - Any nested function call containing a pipe, either the `|` symbol or a new
-  line. "nested" means within a transform; i.e. not just the main pipeline.
+  line. "Nested" means within a transform; i.e. not just the main pipeline.
 - Any function call that isn't separated from other expressions, like
   `sum distance` in `round 0 (sum distance)`. "Separated" means being a single
-  item in a list or a pipeline[^1]
+  item in a list or a pipeline[^1].
 - A minus sign in a function argument, like in `add (-1) (-3)`
 
 Parentheses are not required around operators
@@ -124,13 +124,15 @@ derive total_distance = (sum distance)
 derive min_capped_distance = (min distance ?? 5)
 # No parentheses needed, because no function call
 derive travel_time = distance / 40
+# No inner parentheses needed around `1+1` because no function call
+derive distance_rounded_2_dp = (round 1+1 distance)
 derive [
   # Requires parentheses, because it contains a pipe
   is_far = (distance | in 100..),
   # The left value of the range requires parentheses,
   # because of the minus sign
   is_negative = (distance | in (-100..0)),
-  # Doesn't require parentheses, because it's in a list (*confusing)!
+  # Doesn't require parentheses, because it's in a list (confusing, see footnote)!
   average_distance = average distance,
 ]
 # Requires parentheses because of the minus sign
@@ -146,10 +148,10 @@ circumstances. And we're planning to make the error messages much better,
 so the compiler is there to help out.
 ```
 
-Consistent with this, in transforms which take another transform as an argument,
-such as `group` and `window`, parentheses are used to nest the inner transforms.
-Here, the `aggregate` pipeline is applied to each group of unique `title` and
-`country` values:
+Consistent with this, parentheses are used to nest the inner transforms in
+transforms which take another transform as an argument, such as `group` and
+`window`, Here, the `aggregate` pipeline is applied to each group of unique
+`title` and `country` values:
 
 ```prql
 from employees

--- a/book/src/queries/syntax.md
+++ b/book/src/queries/syntax.md
@@ -103,35 +103,49 @@ other languages.
 
 Parentheses are required around:
 
-- any expression containing a pipe, either the `|` symbol or a linebreak
-- any function call that isn't otherwise separated from other expressions (for
-  example, it's in a list)
-- when a minus sign is used to make a negative value in a function argument
+- Any nested function call containing a pipe, either the `|` symbol or a new
+  line. "nested" means within a transform; i.e. not just the main pipeline.
+- Any function call that isn't separated from other expressions, like
+  `sum distance` in `round 0 (sum distance)`. "Separated" means being a single
+  item in a list or a pipeline[^1]
+- A minus sign in a function argument, like in `add (-1) (-3)`
+
+Parentheses are not required around operators
+
+[^1]: or, technically, on the right side of an assignment in a list....
 
 ```prql
 from employees
 # Requires parentheses, because it's contains a pipe
 derive is_proximate = (distance | in 0..20)
 # Requires parentheses, because it's a function call
-derive average_distance = (sum distance)
+derive total_distance = (sum distance)
+# `??` doesn't require parentheses, as it's not a function call
+derive min_capped_distance = (min distance ?? 5)
+# No parentheses needed, because no function call
+derive travel_time = distance / 40
 derive [
-  # Requires parentheses, because it's contains a pipe
-  is_mid = (distance | in 20..100),
-  # Doesn't require parentheses, because it's in a list!
-  is_far = in 100.. distance,
-  # The left value of the range also requires parentheses,
+  # Requires parentheses, because it contains a pipe
+  is_far = (distance | in 100..),
+  # The left value of the range requires parentheses,
   # because of the minus sign
-  is_negative = (distance | in (-100..0))
+  is_negative = (distance | in (-100..0)),
+  # This is fine too
+  is_negative = (distance | in (-100)..0),
+  # Doesn't require parentheses, because it's in a list (*confusing)!
+  average_distance = average distance,
 ]
 # Requires parentheses because of the minus sign
 sort (-distance)
+# A list is fine too
+sort [-distance]
 ```
 
 ```admonish note
 We realize some of this is not intuitive. We are considering approaches to
 make this more intuitive — even at the cost of requiring more syntax in some
 circumstances. And we're planning to make the error messages much better,
-so the compiler s there to help out.
+so the compiler is there to help out.
 ```
 
 Consistent with this, in transforms which take another transform as an argument,

--- a/book/src/queries/syntax.md
+++ b/book/src/queries/syntax.md
@@ -130,8 +130,6 @@ derive [
   # The left value of the range requires parentheses,
   # because of the minus sign
   is_negative = (distance | in (-100..0)),
-  # This is fine too
-  is_negative = (distance | in (-100)..0),
   # Doesn't require parentheses, because it's in a list (*confusing)!
   average_distance = average distance,
 ]

--- a/book/src/queries/syntax.md
+++ b/book/src/queries/syntax.md
@@ -101,9 +101,43 @@ select first_name
 Parentheses — `()` — are used to give precedence to inner expressions, like in
 other languages.
 
-In particular, parentheses are used to nest pipelines for transforms such as
-`group` and `window`, which take a pipeline. Here, the `aggregate` pipeline is
-applied to each group of unique `title` and `country` values.
+Parentheses are required around:
+
+- any expression containing a pipe, either the `|` symbol or a linebreak
+- any function call that isn't otherwise separated from other expressions (for
+  example, it's in a list)
+- when a minus sign is used to make a negative value in a function argument
+
+```prql
+from employees
+# Requires parentheses, because it's contains a pipe
+derive is_proximate = (distance | in 0..20)
+# Requires parentheses, because it's a function call
+derive average_distance = (sum distance)
+derive [
+  # Requires parentheses, because it's contains a pipe
+  is_mid = (distance | in 20..100),
+  # Doesn't require parentheses, because it's in a list!
+  is_far = in 100.. distance,
+  # The left value of the range also requires parentheses,
+  # because of the minus sign
+  is_negative = (distance | in (-100..0))
+]
+# Requires parentheses because of the minus sign
+sort (-distance)
+```
+
+```admonish note
+We realize some of this is not intuitive. We are considering approaches to
+make this more intuitive — even at the cost of requiring more syntax in some
+circumstances. And we're planning to make the error messages much better,
+so the compiler s there to help out.
+```
+
+Consistent with this, in transforms which take another transform as an argument,
+such as `group` and `window`, parentheses are used to nest the inner transforms.
+Here, the `aggregate` pipeline is applied to each group of unique `title` and
+`country` values:
 
 ```prql
 from employees

--- a/book/src/queries/syntax.md
+++ b/book/src/queries/syntax.md
@@ -110,7 +110,8 @@ Parentheses are required around:
   item in a list or a pipeline[^1].
 - A minus sign in a function argument, like in `add (-1) (-3)`
 
-Parentheses are not required around operators
+Parentheses are not required around expressions which use operators but no
+function call, like `foo + bar`.
 
 [^1]: or, technically, on the right side of an assignment in a list....
 

--- a/book/tests/prql/queries/syntax-10.prql
+++ b/book/tests/prql/queries/syntax-10.prql
@@ -1,2 +1,3 @@
-from employees
-filter id == $1
+prql target:sql.bigquery
+from `project-foo.dataset.table`
+join `project-bar.dataset.table` [==col_bax]

--- a/book/tests/prql/queries/syntax-11.prql
+++ b/book/tests/prql/queries/syntax-11.prql
@@ -1,5 +1,2 @@
-from numbers
-select [
-    small = 1.000_000_1,
-    big = 5_000_000,
-]
+from employees
+filter id == $1

--- a/book/tests/prql/queries/syntax-12.prql
+++ b/book/tests/prql/queries/syntax-12.prql
@@ -1,0 +1,5 @@
+from numbers
+select [
+    small = 1.000_000_1,
+    big = 5_000_000,
+]

--- a/book/tests/prql/queries/syntax-5.prql
+++ b/book/tests/prql/queries/syntax-5.prql
@@ -13,8 +13,6 @@ derive [
   # The left value of the range requires parentheses,
   # because of the minus sign
   is_negative = (distance | in (-100..0)),
-  # This is fine too
-  is_negative = (distance | in (-100)..0),
   # Doesn't require parentheses, because it's in a list (*confusing)!
   average_distance = average distance,
 ]

--- a/book/tests/prql/queries/syntax-5.prql
+++ b/book/tests/prql/queries/syntax-5.prql
@@ -7,13 +7,15 @@ derive total_distance = (sum distance)
 derive min_capped_distance = (min distance ?? 5)
 # No parentheses needed, because no function call
 derive travel_time = distance / 40
+# No inner parentheses needed around `1+1` because no function call
+derive distance_rounded_2_dp = (round 1+1 distance)
 derive [
   # Requires parentheses, because it contains a pipe
   is_far = (distance | in 100..),
   # The left value of the range requires parentheses,
   # because of the minus sign
   is_negative = (distance | in (-100..0)),
-  # Doesn't require parentheses, because it's in a list (*confusing)!
+  # Doesn't require parentheses, because it's in a list (confusing, see footnote)!
   average_distance = average distance,
 ]
 # Requires parentheses because of the minus sign

--- a/book/tests/prql/queries/syntax-5.prql
+++ b/book/tests/prql/queries/syntax-5.prql
@@ -1,7 +1,16 @@
 from employees
-group [title, country] (
-  aggregate [
-    average salary,
-    ct = count
-  ]
-)
+# Requires parentheses, because it's contains a pipe
+derive is_proximate = (distance | in 0..20)
+# Requires parentheses, because it's a function call
+derive average_distance = (sum distance)
+derive [
+  # Requires parentheses, because it's contains a pipe
+  is_mid = (distance | in 20..100),
+  # Doesn't require parentheses, because it's in a list!
+  is_far = in 100.. distance,
+  # The left value of the range also requires parentheses,
+  # because of the minus sign
+  is_negative = (distance | in (-100..0))
+]
+# Requires parentheses because of the minus sign
+sort (-distance)

--- a/book/tests/prql/queries/syntax-5.prql
+++ b/book/tests/prql/queries/syntax-5.prql
@@ -2,15 +2,23 @@ from employees
 # Requires parentheses, because it's contains a pipe
 derive is_proximate = (distance | in 0..20)
 # Requires parentheses, because it's a function call
-derive average_distance = (sum distance)
+derive total_distance = (sum distance)
+# `??` doesn't require parentheses, as it's not a function call
+derive min_capped_distance = (min distance ?? 5)
+# No parentheses needed, because no function call
+derive travel_time = distance / 40
 derive [
-  # Requires parentheses, because it's contains a pipe
-  is_mid = (distance | in 20..100),
-  # Doesn't require parentheses, because it's in a list!
-  is_far = in 100.. distance,
-  # The left value of the range also requires parentheses,
+  # Requires parentheses, because it contains a pipe
+  is_far = (distance | in 100..),
+  # The left value of the range requires parentheses,
   # because of the minus sign
-  is_negative = (distance | in (-100..0))
+  is_negative = (distance | in (-100..0)),
+  # This is fine too
+  is_negative = (distance | in (-100)..0),
+  # Doesn't require parentheses, because it's in a list (*confusing)!
+  average_distance = average distance,
 ]
 # Requires parentheses because of the minus sign
 sort (-distance)
+# A list is fine too
+sort [-distance]

--- a/book/tests/prql/queries/syntax-6.prql
+++ b/book/tests/prql/queries/syntax-6.prql
@@ -1,3 +1,7 @@
-from employees  # Comment 1
-# Comment 2
-aggregate [average salary]
+from employees
+group [title, country] (
+  aggregate [
+    average salary,
+    ct = count
+  ]
+)

--- a/book/tests/prql/queries/syntax-7.prql
+++ b/book/tests/prql/queries/syntax-7.prql
@@ -1,3 +1,3 @@
-prql target:sql.mysql
-from employees
-select `first name`
+from employees  # Comment 1
+# Comment 2
+aggregate [average salary]

--- a/book/tests/prql/queries/syntax-8.prql
+++ b/book/tests/prql/queries/syntax-8.prql
@@ -1,3 +1,3 @@
-prql target:sql.postgres
+prql target:sql.mysql
 from employees
 select `first name`

--- a/book/tests/prql/queries/syntax-9.prql
+++ b/book/tests/prql/queries/syntax-9.prql
@@ -1,3 +1,3 @@
-prql target:sql.bigquery
-from `project-foo.dataset.table`
-join `project-bar.dataset.table` [==col_bax]
+prql target:sql.postgres
+from employees
+select `first name`

--- a/book/tests/snapshots/snapshot__@queries__syntax-10.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-10.prql.snap
@@ -1,11 +1,11 @@
 ---
 source: book/tests/snapshot.rs
-expression: "from employees\nfilter id == $1\n"
+expression: "prql target:sql.bigquery\nfrom `project-foo.dataset.table`\njoin `project-bar.dataset.table` [==col_bax]\n"
 input_file: book/tests/prql/queries/syntax-10.prql
 ---
 SELECT
-  *
+  `project-foo.dataset.table`.*,
+  `project-bar.dataset.table`.*
 FROM
-  employees
-WHERE
-  id = $1
+  `project-foo.dataset.table`
+  JOIN `project-bar.dataset.table` ON `project-foo.dataset.table`.col_bax = `project-bar.dataset.table`.col_bax

--- a/book/tests/snapshots/snapshot__@queries__syntax-11.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-11.prql.snap
@@ -1,10 +1,11 @@
 ---
 source: book/tests/snapshot.rs
-expression: "    from numbers\n    select [\n        small = 1.000_000_1,\n        big = 5_000_000,\n    ]\n"
+expression: "from employees\nfilter id == $1\n"
 input_file: book/tests/prql/queries/syntax-11.prql
 ---
 SELECT
-  1.0000001 AS small,
-  5000000 AS big
+  *
 FROM
-  numbers
+  employees
+WHERE
+  id = $1

--- a/book/tests/snapshots/snapshot__@queries__syntax-12.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-12.prql.snap
@@ -1,0 +1,10 @@
+---
+source: book/tests/snapshot.rs
+expression: "from numbers\nselect [\n    small = 1.000_000_1,\n    big = 5_000_000,\n]\n"
+input_file: book/tests/prql/queries/syntax-12.prql
+---
+SELECT
+  1.0000001 AS small,
+  5000000 AS big
+FROM
+  numbers

--- a/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
@@ -1,15 +1,19 @@
 ---
 source: book/tests/snapshot.rs
-expression: "from employees\ngroup [title, country] (\n  aggregate [\n    average salary,\n    ct = count\n  ]\n)\n"
+expression: "from employees\n# Requires parentheses, because it's contains a pipe\nderive is_proximate = (distance | in 0..20)\n# Requires parentheses, because it's a function call\nderive average_distance = (sum distance)\nderive [\n  # Requires parentheses, because it's contains a pipe\n  is_mid = (distance | in 20..100),\n  # Doesn't require parentheses, because it's in a list!\n  is_far = in 100.. distance,\n  # The left value of the range also requires parentheses,\n  # because of the minus sign\n  is_negative = (distance | in (-100..0))\n]\n# Requires parentheses because of the minus sign\nsort (-distance)\n"
 input_file: book/tests/prql/queries/syntax-5.prql
 ---
 SELECT
-  title,
-  country,
-  AVG(salary),
-  COUNT(*) AS ct
+  *,
+  distance BETWEEN 0
+  AND 20 AS is_proximate,
+  SUM(distance) OVER () AS average_distance,
+  distance BETWEEN 20
+  AND 100 AS is_mid,
+  distance >= 100 AS is_far,
+  distance BETWEEN -100
+  AND 0 AS is_negative
 FROM
   employees
-GROUP BY
-  title,
-  country
+ORDER BY
+  distance DESC

--- a/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
@@ -1,6 +1,6 @@
 ---
 source: book/tests/snapshot.rs
-expression: "from employees\n# Requires parentheses, because it's contains a pipe\nderive is_proximate = (distance | in 0..20)\n# Requires parentheses, because it's a function call\nderive total_distance = (sum distance)\n# `??` doesn't require parentheses, as it's not a function call\nderive min_capped_distance = (min distance ?? 5)\n# No parentheses needed, because no function call\nderive travel_time = distance / 40\nderive [\n  # Requires parentheses, because it contains a pipe\n  is_far = (distance | in 100..),\n  # The left value of the range requires parentheses,\n  # because of the minus sign\n  is_negative = (distance | in (-100..0)),\n  # Doesn't require parentheses, because it's in a list (*confusing)!\n  average_distance = average distance,\n]\n# Requires parentheses because of the minus sign\nsort (-distance)\n# A list is fine too\nsort [-distance]\n"
+expression: "from employees\n# Requires parentheses, because it's contains a pipe\nderive is_proximate = (distance | in 0..20)\n# Requires parentheses, because it's a function call\nderive total_distance = (sum distance)\n# `??` doesn't require parentheses, as it's not a function call\nderive min_capped_distance = (min distance ?? 5)\n# No parentheses needed, because no function call\nderive travel_time = distance / 40\n# No inner parentheses needed around `1+1` because no function call\nderive distance_rounded_2_dp = (round 1+1 distance)\nderive [\n  # Requires parentheses, because it contains a pipe\n  is_far = (distance | in 100..),\n  # The left value of the range requires parentheses,\n  # because of the minus sign\n  is_negative = (distance | in (-100..0)),\n  # Doesn't require parentheses, because it's in a list (confusing, see footnote)!\n  average_distance = average distance,\n]\n# Requires parentheses because of the minus sign\nsort (-distance)\n# A list is fine too\nsort [-distance]\n"
 input_file: book/tests/prql/queries/syntax-5.prql
 ---
 SELECT
@@ -10,6 +10,7 @@ SELECT
   SUM(distance) OVER () AS total_distance,
   MIN(COALESCE(distance, 5)) OVER () AS min_capped_distance,
   distance / 40 AS travel_time,
+  ROUND(distance, 2) AS distance_rounded_2_dp,
   distance >= 100 AS is_far,
   distance BETWEEN -100
   AND 0 AS is_negative,

--- a/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
@@ -1,19 +1,39 @@
 ---
 source: book/tests/snapshot.rs
-expression: "from employees\n# Requires parentheses, because it's contains a pipe\nderive is_proximate = (distance | in 0..20)\n# Requires parentheses, because it's a function call\nderive average_distance = (sum distance)\nderive [\n  # Requires parentheses, because it's contains a pipe\n  is_mid = (distance | in 20..100),\n  # Doesn't require parentheses, because it's in a list!\n  is_far = in 100.. distance,\n  # The left value of the range also requires parentheses,\n  # because of the minus sign\n  is_negative = (distance | in (-100..0))\n]\n# Requires parentheses because of the minus sign\nsort (-distance)\n"
+expression: "from employees\n# Requires parentheses, because it's contains a pipe\nderive is_proximate = (distance | in 0..20)\n# Requires parentheses, because it's a function call\nderive total_distance = (sum distance)\n# `??` doesn't require parentheses, as it's not a function call\nderive min_capped_distance = (min distance ?? 5)\n# No parentheses needed, because no function call\nderive travel_time = distance / 40\nderive [\n  # Requires parentheses, because it contains a pipe\n  is_far = (distance | in 100..),\n  # The left value of the range requires parentheses,\n  # because of the minus sign\n  is_negative = (distance | in (-100..0)),\n  # This is fine too\n  is_negative = (distance | in (-100)..0),\n  # Doesn't require parentheses, because it's in a list (*confusing)!\n  average_distance = average distance,\n]\n# Requires parentheses because of the minus sign\nsort (-distance)\n# A list is fine too\nsort [-distance]\n"
 input_file: book/tests/prql/queries/syntax-5.prql
 ---
-SELECT
-  *,
-  distance BETWEEN 0
-  AND 20 AS is_proximate,
-  SUM(distance) OVER () AS average_distance,
-  distance BETWEEN 20
-  AND 100 AS is_mid,
-  distance >= 100 AS is_far,
-  distance BETWEEN -100
-  AND 0 AS is_negative
-FROM
-  employees
-ORDER BY
-  distance DESC
+from employees
+# Requires parentheses, because it's contains a pipe
+derive is_proximate = (distance | in 0..20)
+# Requires parentheses, because it's a function call
+derive total_distance = (sum distance)
+# `??` doesn't require parentheses, as it's not a function call
+derive min_capped_distance = (min distance ?? 5)
+# No parentheses needed, because no function call
+derive travel_time = distance / 40
+derive [
+  # Requires parentheses, because it contains a pipe
+  is_far = (distance | in 100..),
+  # The left value of the range requires parentheses,
+  # because of the minus sign
+  is_negative = (distance | in (-100..0)),
+  # This is fine too
+  is_negative = (distance | in (-100)..0),
+  # Doesn't require parentheses, because it's in a list (*confusing)!
+  average_distance = average distance,
+]
+# Requires parentheses because of the minus sign
+sort (-distance)
+# A list is fine too
+sort [-distance]
+
+
+Error:
+    ╭─[:17:32]
+    │
+ 17 │   is_negative = (distance | in (-100)..0),
+    ·                                ───┬──
+    ·                                   ╰──── std.in expected a pattern, but found -100
+────╯
+

--- a/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-5.prql.snap
@@ -1,39 +1,20 @@
 ---
 source: book/tests/snapshot.rs
-expression: "from employees\n# Requires parentheses, because it's contains a pipe\nderive is_proximate = (distance | in 0..20)\n# Requires parentheses, because it's a function call\nderive total_distance = (sum distance)\n# `??` doesn't require parentheses, as it's not a function call\nderive min_capped_distance = (min distance ?? 5)\n# No parentheses needed, because no function call\nderive travel_time = distance / 40\nderive [\n  # Requires parentheses, because it contains a pipe\n  is_far = (distance | in 100..),\n  # The left value of the range requires parentheses,\n  # because of the minus sign\n  is_negative = (distance | in (-100..0)),\n  # This is fine too\n  is_negative = (distance | in (-100)..0),\n  # Doesn't require parentheses, because it's in a list (*confusing)!\n  average_distance = average distance,\n]\n# Requires parentheses because of the minus sign\nsort (-distance)\n# A list is fine too\nsort [-distance]\n"
+expression: "from employees\n# Requires parentheses, because it's contains a pipe\nderive is_proximate = (distance | in 0..20)\n# Requires parentheses, because it's a function call\nderive total_distance = (sum distance)\n# `??` doesn't require parentheses, as it's not a function call\nderive min_capped_distance = (min distance ?? 5)\n# No parentheses needed, because no function call\nderive travel_time = distance / 40\nderive [\n  # Requires parentheses, because it contains a pipe\n  is_far = (distance | in 100..),\n  # The left value of the range requires parentheses,\n  # because of the minus sign\n  is_negative = (distance | in (-100..0)),\n  # Doesn't require parentheses, because it's in a list (*confusing)!\n  average_distance = average distance,\n]\n# Requires parentheses because of the minus sign\nsort (-distance)\n# A list is fine too\nsort [-distance]\n"
 input_file: book/tests/prql/queries/syntax-5.prql
 ---
-from employees
-# Requires parentheses, because it's contains a pipe
-derive is_proximate = (distance | in 0..20)
-# Requires parentheses, because it's a function call
-derive total_distance = (sum distance)
-# `??` doesn't require parentheses, as it's not a function call
-derive min_capped_distance = (min distance ?? 5)
-# No parentheses needed, because no function call
-derive travel_time = distance / 40
-derive [
-  # Requires parentheses, because it contains a pipe
-  is_far = (distance | in 100..),
-  # The left value of the range requires parentheses,
-  # because of the minus sign
-  is_negative = (distance | in (-100..0)),
-  # This is fine too
-  is_negative = (distance | in (-100)..0),
-  # Doesn't require parentheses, because it's in a list (*confusing)!
-  average_distance = average distance,
-]
-# Requires parentheses because of the minus sign
-sort (-distance)
-# A list is fine too
-sort [-distance]
-
-
-Error:
-    ╭─[:17:32]
-    │
- 17 │   is_negative = (distance | in (-100)..0),
-    ·                                ───┬──
-    ·                                   ╰──── std.in expected a pattern, but found -100
-────╯
-
+SELECT
+  *,
+  distance BETWEEN 0
+  AND 20 AS is_proximate,
+  SUM(distance) OVER () AS total_distance,
+  MIN(COALESCE(distance, 5)) OVER () AS min_capped_distance,
+  distance / 40 AS travel_time,
+  distance >= 100 AS is_far,
+  distance BETWEEN -100
+  AND 0 AS is_negative,
+  AVG(distance) OVER () AS average_distance
+FROM
+  employees
+ORDER BY
+  distance DESC

--- a/book/tests/snapshots/snapshot__@queries__syntax-6.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-6.prql.snap
@@ -1,9 +1,15 @@
 ---
 source: book/tests/snapshot.rs
-expression: "from employees  # Comment 1\n# Comment 2\naggregate [average salary]\n"
+expression: "from employees\ngroup [title, country] (\n  aggregate [\n    average salary,\n    ct = count\n  ]\n)\n"
 input_file: book/tests/prql/queries/syntax-6.prql
 ---
 SELECT
-  AVG(salary)
+  title,
+  country,
+  AVG(salary),
+  COUNT(*) AS ct
 FROM
   employees
+GROUP BY
+  title,
+  country

--- a/book/tests/snapshots/snapshot__@queries__syntax-7.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-7.prql.snap
@@ -1,9 +1,9 @@
 ---
 source: book/tests/snapshot.rs
-expression: "prql target:sql.mysql\nfrom employees\nselect `first name`\n"
+expression: "from employees  # Comment 1\n# Comment 2\naggregate [average salary]\n"
 input_file: book/tests/prql/queries/syntax-7.prql
 ---
 SELECT
-  `first name`
+  AVG(salary)
 FROM
   employees

--- a/book/tests/snapshots/snapshot__@queries__syntax-8.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-8.prql.snap
@@ -1,9 +1,9 @@
 ---
 source: book/tests/snapshot.rs
-expression: "prql target:sql.postgres\nfrom employees\nselect `first name`\n"
+expression: "prql target:sql.mysql\nfrom employees\nselect `first name`\n"
 input_file: book/tests/prql/queries/syntax-8.prql
 ---
 SELECT
-  "first name"
+  `first name`
 FROM
   employees

--- a/book/tests/snapshots/snapshot__@queries__syntax-9.prql.snap
+++ b/book/tests/snapshots/snapshot__@queries__syntax-9.prql.snap
@@ -1,11 +1,9 @@
 ---
 source: book/tests/snapshot.rs
-expression: "prql target:sql.bigquery\nfrom `project-foo.dataset.table`\njoin `project-bar.dataset.table` [==col_bax]\n"
+expression: "prql target:sql.postgres\nfrom employees\nselect `first name`\n"
 input_file: book/tests/prql/queries/syntax-9.prql
 ---
 SELECT
-  `project-foo.dataset.table`.*,
-  `project-bar.dataset.table`.*
+  "first name"
 FROM
-  `project-foo.dataset.table`
-  JOIN `project-bar.dataset.table` ON `project-foo.dataset.table`.col_bax = `project-bar.dataset.table`.col_bax
+  employees

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-10.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-10.prql.snap
@@ -3,8 +3,12 @@ source: book/tests/snapshot.rs
 expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/syntax-10.prql
 ---
-from employees
-filter id == $1
+prql target:sql.bigquery
+
+
+
+from `project-foo.dataset.table`
+join `project-bar.dataset.table` [==col_bax]
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-11.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-11.prql.snap
@@ -3,11 +3,8 @@ source: book/tests/snapshot.rs
 expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/syntax-11.prql
 ---
-from numbers
-select [
-  small = 1.0000001,
-  big = 5000000,
-]
+from employees
+filter id == $1
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-12.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-12.prql.snap
@@ -1,0 +1,13 @@
+---
+source: book/tests/snapshot.rs
+expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
+input_file: book/tests/prql/queries/syntax-12.prql
+---
+from numbers
+select [
+  small = 1.0000001,
+  big = 5000000,
+]
+
+
+

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
@@ -4,15 +4,25 @@ expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/syntax-5.prql
 ---
 from employees
-group [
-  title,
-  country,
-] (
-  aggregate [
-  average salary,
-  ct = count,
-]
+derive is_proximate = (
+  distance
+  in 0..20
 )
+derive (
+  average_distance = sum distance
+)
+derive [
+  is_mid = (
+  distance
+  in 20..100
+),
+  is_far = in 100.. distance,
+  is_negative = (
+  distance
+  in -100..0
+),
+]
+sort -distance
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
@@ -24,10 +24,6 @@ derive [
   distance
   in -100..0
 ),
-  is_negative = (
-  distance
-  in -100 ..0
-),
   average_distance = average distance,
 ]
 sort -distance

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
@@ -9,20 +9,29 @@ derive is_proximate = (
   in 0..20
 )
 derive (
-  average_distance = sum distance
+  total_distance = sum distance
 )
+derive (
+  min_capped_distance = min distance ?? 5
+)
+derive travel_time = distance / 40
 derive [
-  is_mid = (
+  is_far = (
   distance
-  in 20..100
+  in 100..
 ),
-  is_far = in 100.. distance,
   is_negative = (
   distance
   in -100..0
 ),
+  is_negative = (
+  distance
+  in -100 ..0
+),
+  average_distance = average distance,
 ]
 sort -distance
+sort [-distance]
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-5.prql.snap
@@ -15,6 +15,9 @@ derive (
   min_capped_distance = min distance ?? 5
 )
 derive travel_time = distance / 40
+derive (
+  distance_rounded_2_dp = round 1 + 1 distance
+)
 derive [
   is_far = (
   distance

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-6.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-6.prql.snap
@@ -4,7 +4,15 @@ expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/syntax-6.prql
 ---
 from employees
-aggregate [average salary]
+group [
+  title,
+  country,
+] (
+  aggregate [
+  average salary,
+  ct = count,
+]
+)
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-7.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-7.prql.snap
@@ -3,12 +3,8 @@ source: book/tests/snapshot.rs
 expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/syntax-7.prql
 ---
-prql target:sql.mysql
-
-
-
 from employees
-select `first name`
+aggregate [average salary]
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-8.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-8.prql.snap
@@ -3,7 +3,7 @@ source: book/tests/snapshot.rs
 expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/syntax-8.prql
 ---
-prql target:sql.postgres
+prql target:sql.mysql
 
 
 

--- a/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-9.prql.snap
+++ b/book/tests/snapshots/snapshot__run_display_reference_prql@queries__syntax-9.prql.snap
@@ -3,12 +3,12 @@ source: book/tests/snapshot.rs
 expression: prql_to_pl(&prql).and_then(pl_to_prql).unwrap()
 input_file: book/tests/prql/queries/syntax-9.prql
 ---
-prql target:sql.bigquery
+prql target:sql.postgres
 
 
 
-from `project-foo.dataset.table`
-join `project-bar.dataset.table` [==col_bax]
+from employees
+select `first name`
 
 
 


### PR DESCRIPTION
Helps with https://github.com/PRQL/prql/issues/648

I find this the most confusing comparison:

```elm
# Requires parentheses, because it's a function call
derive total_distance = (sum distance)
derive [
  # Doesn't require parentheses, because it's in a list!
  average_distance = average distance,
]
```

...this is because we can't allow a full function call in an assign outside of a list, because it might be an alias:

```elm
join e=employees [==id]
```

...where we don't want `employees [==id]` to be parsed as a function employees taking an argument `[==id]`

(Unfortunately this creates a huge diff, because it adds a query to the Syntax page, which does n+1 to the filename of all subsequent queries.)
