### PR TITLE
build: Use 2021 edition for prql-js

### DIFF
--- a/prql-js/Cargo.toml
+++ b/prql-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "Javascript bindings for prql-compiler"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 name = "prql-js"
 publish = false


### PR DESCRIPTION
No big change but for consistency
