### PR TITLE
refactor: Inherit logic in prql-js

### DIFF
--- a/prql-elixir/native/prql/src/lib.rs
+++ b/prql-elixir/native/prql/src/lib.rs
@@ -113,8 +113,7 @@ pub struct Response {
 #[rustler::nif]
 /// compile a prql query into sql
 pub fn compile(prql_query: &str, options: CompileOptions) -> NifResult<Response> {
-    let result = prql_compiler::compile(prql_query, Some(options.into()));
-    to_result_tuple(result)
+    to_result_tuple(prql_compiler::compile(prql_query, Some(options.into())));
 }
 
 #[rustler::nif]

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -4,21 +4,10 @@ mod utils;
 
 use wasm_bindgen::prelude::*;
 
-// TODO: these functions could be smaller and automatically inherit
-// `prql-compiler` behavior if we replaced this logic with a call directly to
-// the prql-compiler functions, and these functions just did the JS<>Rust
-// conversions. Ref this discussion re `prql-elixir`
-// https://github.com/PRQL/prql/pull/1500/files#r1070213774
-
 #[wasm_bindgen]
 pub fn compile(prql_query: &str, options: Option<SQLCompileOptions>) -> Option<String> {
     return_or_throw(
-        Ok(prql_query)
-            .and_then(prql_compiler::prql_to_pl)
-            .and_then(prql_compiler::pl_to_rq)
-            .and_then(|rq| {
-                prql_compiler::rq_to_sql(rq, options.map(prql_compiler::sql::Options::from))
-            })
+        prql_compiler::compile(prql_query, options.map(|x| x.into()))
             .map_err(|e| e.composed("", prql_query, false)),
     )
 }


### PR DESCRIPTION
@kasvith actually the logic in the other functions was as simple as it could be — it was only the compile function that was overly versbose. So there's no work in this specific area in `prql-elixir` either.
