### PR TITLE
fix: Renames from_csv to from_text (#286)

### DIFF
--- a/prql-compiler/src/semantic/std.prql
+++ b/prql-compiler/src/semantic/std.prql
@@ -58,4 +58,4 @@ func _eq<list> a<list> -> null
 func _is_null a -> a == null
 
 # Misc
-func from_csv<table> csv<string> -> null
+func from_text<table> text<string> -> null

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -295,20 +295,20 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Closure) -> Result<Resul
             return Ok(Ok(res));
         }
 
-        "std.from_csv" => {
+        "std.from_text" => {
             // yes, this is not a transform, but this is the most appropriate place for it
 
-            let [csv_expr] = unpack::<1>(closure);
+            let [text_expr] = unpack::<1>(closure);
 
-            let ExprKind::Literal(Literal::String(csv)) = csv_expr.kind else {
-                return Err(Error::new(Reason::Expected { who: Some("std.from_csv".to_string()), expected: "a string literal".to_string(), found: format!("`{csv_expr}`") }).with_span(csv_expr.span).into())
+            let ExprKind::Literal(Literal::String(text)) = text_expr.kind else {
+                return Err(Error::new(Reason::Expected { who: Some("std.from_text".to_string()), expected: "a string literal".to_string(), found: format!("`{text_expr}`") }).with_span(text_expr.span).into())
             };
 
-            let res = parse_csv(&csv)?;
+            let res = parse_csv(&text)?;
 
             let input = FrameInput {
-                id: csv_expr.id.unwrap(),
-                name: csv_expr.alias.unwrap_or_else(|| "csv".to_string()),
+                id: text_expr.id.unwrap(),
+                name: text_expr.alias.unwrap_or_else(|| "text".to_string()),
                 table: None,
             };
 
@@ -329,7 +329,7 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Closure) -> Result<Resul
             let res = Expr::from(ExprKind::Literal(Literal::Relation(res)));
             let res = Expr {
                 ty: Some(Ty::Table(frame)),
-                id: csv_expr.id,
+                id: text_expr.id,
                 ..res
             };
             return Ok(Ok(res));
@@ -853,8 +853,8 @@ impl AstFold for Flattener {
 // TODO: Can we dynamically get the types, like in pandas? We need to put
 // quotes around strings and not around numbers.
 // https://stackoverflow.com/questions/64369887/how-do-i-read-csv-data-without-knowing-the-structure-at-compile-time
-fn parse_csv(csv: &str) -> Result<RelationLiteral> {
-    let mut rdr = csv::Reader::from_reader(csv.as_bytes());
+fn parse_csv(text: &str) -> Result<RelationLiteral> {
+    let mut rdr = csv::Reader::from_reader(text.as_bytes());
 
     Ok(RelationLiteral {
         columns: rdr


### PR DESCRIPTION
I'd like to add a `format` parameter as well but that can probably come later.

This should probably also get a mention in the docs and the changelog. I could take a stab at those in maybe 9 hours time.

I also haven't run any tests as my env is not set up. Will making this a PR automatically trigger a CI run?