### PR TITLE
build: Inherit more from the workspace in Cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,3 @@ opt-level = "s"
 [workspace.metadata.release]
 consolidate-commits = true
 pre-release-commit-message = "chore: Release {{version}}"
-shared-version = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,16 @@ members = [
 # commands like `cargo test` to only run tests from the default package. And
 # `cargo insta test` doesn't have a `--workspace` flag.
 
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/PRQL/prql"
+rust-version = "1.60.0"
+version = "0.4.0"
+
 [profile.release.package.prql-js]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
-
-[workspace.package]
-version = "0.4.0"
 
 [workspace.metadata.release]
 consolidate-commits = true

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-edition = "2021"
-license = "Apache-2.0"
 name = "mdbook-prql"
 publish = false
-repository = "https://github.com/PRQL/prql"
-rust-version = "1.59.0"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [lib]

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -47,6 +47,5 @@ walkdir = "2.3.2"
 trash = "3.0.0"
 
 [package.metadata.release]
-shared-version = true
 tag-name = "{{version}}"
 tag-prefix = ""

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 description = "PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement."
-edition = "2021"
-license = "Apache-2.0"
 name = "prql-compiler"
-repository = "https://github.com/PRQL/prql"
-rust-version = "1.60.0"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [features]
@@ -18,6 +19,10 @@ required-features = ["cli"]
 [dependencies]
 anyhow = {version = "1.0.57", features = ["backtrace"]}
 ariadne = "0.1.5"
+atty = {version = "0.2.14", optional = true}
+clap = {version = "4.1.1", optional = true, features = ["derive"]}
+clio = {version = "0.2.4", features = ['clap-parse'], optional = true}
+color-eyre = {version = "0.6.1", optional = true}
 csv = "1.1.6"
 enum-as-inner = "0.5.0"
 env_logger = {version = "0.9.1", features = ["termcolor"]}
@@ -36,10 +41,6 @@ sqlformat = "0.2.0"
 sqlparser = {version = "0.30.0", features = ["serde"]}
 strum = {version = "0.24.0", features = ["std", "derive"]}# for converting enum variants to string
 strum_macros = "0.24.0"
-atty = {version = "0.2.14", optional = true}
-clap = {version = "4.1.1", optional = true, features = ["derive"]}
-clio = {version = "0.2.4", features = ['clap-parse'], optional = true}
-color-eyre = {version = "0.6.1", optional = true}
 
 [dev-dependencies]
 cfg-if = "1.0"

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -68,6 +68,5 @@ harness = false
 name = "bench"
 
 [package.metadata.release]
-shared-version = true
 tag-name = "{{version}}"
 tag-prefix = ""

--- a/prql-compiler/examples/compile-files/Cargo.toml
+++ b/prql-compiler/examples/compile-files/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
-edition = "2021"
 name = "compile-files"
+publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [build-dependencies]

--- a/prql-compiler/prql-compiler-macros/Cargo.toml
+++ b/prql-compiler/prql-compiler-macros/Cargo.toml
@@ -18,6 +18,5 @@ prql-compiler = {path = "..", default-features = false}
 syn = "1.0"
 
 [package.metadata.release]
-shared-version = true
 tag-name = "{{version}}"
 tag-prefix = ""

--- a/prql-compiler/prql-compiler-macros/Cargo.toml
+++ b/prql-compiler/prql-compiler-macros/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
-edition = "2021"
 name = "prql-compiler-macros"
 publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [lib]

--- a/prql-java/Cargo.toml
+++ b/prql-java/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
-edition = "2021"
 name = "prql-java"
 publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [lib]

--- a/prql-java/Cargo.toml
+++ b/prql-java/Cargo.toml
@@ -18,6 +18,5 @@ jni = "0.20.0"
 prql-compiler = {path = "../prql-compiler", default-features = false}
 
 [package.metadata.release]
-shared-version = true
 tag-name = "{{version}}"
 tag-prefix = ""

--- a/prql-js/Cargo.toml
+++ b/prql-js/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
 description = "Javascript bindings for prql-compiler"
-edition = "2021"
-license = "Apache-2.0"
 name = "prql-js"
 publish = false
-repository = "https://github.com/PRQL/prql"
+
+edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
+
+# Unsupported by `wasm-pack` (which seems kinda unmaintained now...)
+# license.workspace = true
+# repository.workspace = true
+license = "Apache-2.0"
+repository = "https://github.com/PRQL/prql"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/prql-js/Cargo.toml
+++ b/prql-js/Cargo.toml
@@ -35,7 +35,6 @@ console_error_panic_hook = {version = "0.1.7", optional = true}
 wasm-bindgen-test = "0.3.30"
 
 [package.metadata.release]
-shared-version = true
 tag-name = "{{version}}"
 tag-prefix = ""
 

--- a/prql-lib/Cargo.toml
+++ b/prql-lib/Cargo.toml
@@ -15,6 +15,5 @@ prql-compiler = {path = "../prql-compiler", default-features = false}
 serde_json = "1.0"
 
 [package.metadata.release]
-shared-version = true
 tag-name = "{{version}}"
 tag-prefix = ""

--- a/prql-python/Cargo.toml
+++ b/prql-python/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 build = "build.rs"
-edition = "2021"
 name = "prql-python"
 publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [lib]

--- a/prql-python/Cargo.toml
+++ b/prql-python/Cargo.toml
@@ -26,6 +26,5 @@ insta = {version = "1.26", features = ["colors", "glob", "yaml"]}
 pyo3-build-config = "0.17.0"
 
 [package.metadata.release]
-shared-version = true
 tag-name = "{{version}}"
 tag-prefix = ""


### PR DESCRIPTION
I saw how @epage did things in `typos`; this approach is simpler, allows for less variance.

Unsupported by `wasm-pack` though
