### PR TITLE
build: Add `cli` as a default feature

### DIFF
--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -10,19 +10,19 @@ version.workspace = true
 
 [features]
 cli = ["clio", "atty", "clap", "color-eyre"]
+default = ["cli"]
 
 [[bin]]
 name = "prqlc"
 path = "src/cli.rs"
 required-features = ["cli"]
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = {version = "1.0.57", features = ["backtrace"]}
 ariadne = "0.1.5"
-atty = {version = "0.2.14", optional = true}
-clap = {version = "4.1.1", optional = true, features = ["derive"]}
-clio = {version = "0.2.4", features = ['clap-parse'], optional = true}
-color-eyre = {version = "0.6.1", optional = true}
 csv = "1.1.6"
 enum-as-inner = "0.5.0"
 env_logger = {version = "0.9.1", features = ["termcolor"]}
@@ -41,6 +41,14 @@ sqlformat = "0.2.0"
 sqlparser = {version = "0.30.0", features = ["serde"]}
 strum = {version = "0.24.0", features = ["std", "derive"]}# for converting enum variants to string
 strum_macros = "0.24.0"
+
+# These bring in `errno`, which fails under wasm. We disable the cli in wasm
+# anyway, so they're not required.
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+atty = {version = "0.2.14", optional = true}
+clap = {version = "4.1.1", optional = true, features = ["derive"]}
+clio = {version = "0.2.4", features = ['clap-parse'], optional = true}
+color-eyre = {version = "0.6.1", optional = true}
 
 [dev-dependencies]
 cfg-if = "1.0"


### PR DESCRIPTION
This reverts a change from @aljazerzen, so I'll wait for his review. It's required for `cargo install` to work without a `--features` flag.

Even if we don't want this, I would vote to merge this, release 0.4.1, and then do the work to the docs & brew recipe so that works again
