### PR TITLE
ci: Remove `job` from concurrency

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-pr
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-pr
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -25,6 +25,7 @@ jobs:
           - target_option: ""
           - target_option: "--target=wasm32-unknown-unknown"
     steps:
+      - run: echo ${{ github.workflow }}-${{ github.ref }}
       - name: 📂 Checkout code
         uses: actions/checkout@v3
       - name: 📋 Test workspace

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,10 +12,7 @@ on:
       - main
 
 concurrency:
-  # This adds `job` to the key so when running full tests, we don't cancel the
-  # overlapping jobs, since GH relies on them passing before allowing a PR to
-  # pass.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.job }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,6 +12,13 @@ on:
       - main
 
 concurrency:
+  # This seems to require `-pr` on the end; I _think_ because this calls
+  # `test-all`, which calls `test-python`, and if `test-python` runs too, then
+  # we have two workflows with the same concurrency group, which GitHub calls a
+  # deadlock. Here's an example:
+  # https://github.com/PRQL/prql/actions/runs/3945798229. By adding `-pr` here,
+  # the job that runs under `test-all` (called from here) will have `-pr` on the
+  # end, and so won't deadlock.
   group: ${{ github.workflow }}-${{ github.ref }}-pr
   cancel-in-progress: true
 
@@ -25,7 +32,6 @@ jobs:
           - target_option: ""
           - target_option: "--target=wasm32-unknown-unknown"
     steps:
-      - run: echo ${{ github.workflow }}-${{ github.ref }}
       - name: 📂 Checkout code
         uses: actions/checkout@v3
       - name: 📋 Test workspace

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-test-all
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-test-all
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -18,7 +18,7 @@ on:
 # `pr-test-all` label on the PR. Or some other way...
 #
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-py
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -28,6 +28,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - run:
+          echo ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
       - name: 📂 Checkout code
         uses: actions/checkout@v3
       - name: Build wheel

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -10,17 +10,6 @@ on:
       - ".github/workflows/test-python.yaml"
   workflow_call:
 
-# TODO: we needed to remove this, because if there's a) a change in the path
-# such that this is run on a PR and b) a label on the PR such that `test-all` is
-# triggered, then this deadlocks. I'm sure there's a way of designing this so it
-# doesn't deadlock — either adding something to the key so it knows the "parent"
-# workflow, or (worse but acceptable) skipping the job if there's a
-# `pr-test-all` label on the PR. Or some other way...
-#
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -28,7 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - run: echo ${{ github.workflow }}-${{ github.ref }}
       - name: 📂 Checkout code
         uses: actions/checkout@v3
       - name: Build wheel

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -18,7 +18,7 @@ on:
 # `pr-test-all` label on the PR. Or some other way...
 #
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -28,8 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - run:
-          echo ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+      - run: echo ${{ github.workflow }}-${{ github.ref }}
       - name: 📂 Checkout code
         uses: actions/checkout@v3
       - name: Build wheel

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -17,8 +17,9 @@ on:
 # workflow, or (worse but acceptable) skipping the job if there's a
 # `pr-test-all` label on the PR. Or some other way...
 #
-# concurrency: group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-py
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
I don't think this is doing anything -- I'll merge if tests pass
