### PR TITLE
docs: use `prqlr::prql_compile` instead of `prqlr::prql_to_sql`

### DIFF
--- a/book/src/bindings/r.md
+++ b/book/src/bindings/r.md
@@ -28,5 +28,5 @@ group [dept_id, gender] (
   ]
 )
 " |>
-  prql_to_sql()
+  prql_compile()
 ```


### PR DESCRIPTION
I changed prqlr's function name to match other language bindings.
`prql_to_sql` continues to work but is deprecated.
https://github.com/eitsupi/prqlr/blob/main/NEWS.md