### PR TITLE
revert: feat!: change switch syntax to =>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # PRQL Changelog
 
-## 0.5.0 — [unreleased]
-
-**Features**:
-
-- Change switch syntax to use `=>` instead of `->` due to clash with planned
-  lambda function syntax.
-
 ## 0.4.2 — [unreleased]
 
 **Features**:

--- a/book/src/language-features/switch.md
+++ b/book/src/language-features/switch.md
@@ -9,8 +9,8 @@ PRQL uses `switch` for both SQL's `CASE` and `IF` statements. Here's an example:
 ```prql
 from employees
 derive distance = switch [
-  city == "Calgary" => 0,
-  city == "Edmonton" => 300,
+  city == "Calgary" -> 0,
+  city == "Edmonton" -> 300,
 ]
 ```
 
@@ -20,8 +20,8 @@ If no condition is met, the value takes a `null` value. To set a default, use a
 ```prql
 from employees
 derive distance = switch [
-  city == "Calgary" => 0,
-  city == "Edmonton" => 300,
-  true => "Unknown",
+  city == "Calgary" -> 0,
+  city == "Edmonton" -> 300,
+  true -> "Unknown",
 ]
 ```

--- a/book/tests/prql/language-features/switch-0.prql
+++ b/book/tests/prql/language-features/switch-0.prql
@@ -1,5 +1,5 @@
 from employees
 derive distance = switch [
-  city == "Calgary" => 0,
-  city == "Edmonton" => 300,
+  city == "Calgary" -> 0,
+  city == "Edmonton" -> 300,
 ]

--- a/book/tests/prql/language-features/switch-1.prql
+++ b/book/tests/prql/language-features/switch-1.prql
@@ -1,6 +1,6 @@
 from employees
 derive distance = switch [
-  city == "Calgary" => 0,
-  city == "Edmonton" => 300,
-  true => "Unknown",
+  city == "Calgary" -> 0,
+  city == "Edmonton" -> 300,
+  true -> "Unknown",
 ]

--- a/prql-compiler/src/parser/prql.pest
+++ b/prql-compiler/src/parser/prql.pest
@@ -144,4 +144,4 @@ end_expr = _{ WHITESPACE | "," | ")" | "]" | EOI | NEWLINE | ".." }
 jinja = { ("{{" ~ (!"}}" ~ ANY)* ~ "}}") }
 
 switch = { "switch" ~ "[" ~ (NEWLINE* ~ switch_case ~ ("," ~ NEWLINE* ~ switch_case )* ~ ","?)? ~ NEWLINE* ~ "]" }
-switch_case = { expr_call ~ "=>" ~ expr_call }
+switch_case = { expr_call ~ "->" ~ expr_call }

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -2366,8 +2366,8 @@ fn test_switch() {
         r###"
     from employees
     derive display_name = switch [
-        nickname != null => nickname,
-        true => f'{first_name} {last_name}'
+        nickname != null -> nickname,
+        true -> f'{first_name} {last_name}'
     ]
         "###).unwrap(),
         @r###"
@@ -2386,8 +2386,8 @@ fn test_switch() {
         r###"
     from employees
     derive display_name = switch [
-        nickname != null => nickname,
-        first_name != null => f'{first_name} {last_name}'
+        nickname != null -> nickname,
+        first_name != null -> f'{first_name} {last_name}'
     ]
         "###).unwrap(),
         @r###"
@@ -2407,7 +2407,7 @@ fn test_switch() {
         r###"
     from tracks
     select category = switch [
-        length > avg_length => 'long'
+        length > avg_length -> 'long'
     ]
     group category (aggregate count)
         "###).unwrap(),
@@ -2478,12 +2478,12 @@ fn test_static_analysis() {
         a3 = null ?? y,
 
         a3 = switch [
-            false == true => 1,
-            7 == 3 => 2,
-            7 == y => 3,
-            7.3 == 7.3 => 4,
-            z => 5,
-            true => 6
+            false == true -> 1,
+            7 == 3 -> 2,
+            7 == y -> 3,
+            7.3 == 7.3 -> 4,
+            z -> 5,
+            true -> 6
         ]
     ]
         "###).unwrap(),


### PR DESCRIPTION
Reverts PRQL/prql#1581 based on it breaking the playground and @max-sixty thinking it deserves more discussion

(as ever, reverting is Good, not a sign of anything wrong...)