### PR TITLE
build: Add any `target` path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 
 dist
-target
+target*
 
 **/.vscode/settings.json
 **/.vscode/launch.json


### PR DESCRIPTION
I'm using this in my vscode settings, as I realize that's what's causing lots of recompilations. This will be fixed in an upcoming version of rustup though.

```json
  "rust-analyzer.cargo.extraEnv": {
    "CARGO_TARGET_DIR": "target-ra"
  }
```
