### PR TITLE
feat(prql-compiler): make `prql_compiler::PRQL_VERSION` public

### DIFF
--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -92,7 +92,7 @@ pub use utils::IntoOnly;
 use once_cell::sync::Lazy;
 use semver::Version;
 
-static PRQL_VERSION: Lazy<Version> =
+pub static PRQL_VERSION: Lazy<Version> =
     Lazy::new(|| Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid PRQL version number"));
 
 /// Compile a PRQL string into a SQL string.


### PR DESCRIPTION
When embedding prql-compiler in a package such as prqlr (own version does not match prql-compiler version), it would be useful to be able to easily check the version of the embedded prql-compiler. (eitsupi/prqlr#51)

If the release cycle is fast (related to #1507), downstream software may not be able to keep up with the latest version, so users will want to check the version of PRQL that is supported.