### PR TITLE
docs(prqlr): change the URL from R-universe to CRAN

### DIFF
--- a/book/src/bindings/r.md
+++ b/book/src/bindings/r.md
@@ -11,7 +11,7 @@ R bindings for [`prql-compiler`](https://github.com/PRQL/prql/). Check out
 ## Installation
 
 ```r
-install.packages("prqlr", repos = "https://eitsupi.r-universe.dev")
+install.packages("prqlr")
 ```
 
 ## Usage

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -394,7 +394,7 @@ bindings_section:
       label: "prql-js"
       text: "JavaScript bindings for prql-compiler."
 
-    - link: https://eitsupi.r-universe.dev/ui#package:prqlr
+    - link: https://CRAN.R-project.org/package=prqlr
       label: "prqlr"
       text: "R bindings for prql-compiler."
 


### PR DESCRIPTION
I have confirmed that binary installation of prqlr has been enabled on CRAN.
On R-universe, the recent version failed to build on Windows and arm mac was not able to do binary installs.

So installation from CRAN is more convenient for many users. (Except that versions tend to be outdated due to release frequency)