### PR TITLE
ci: Add `os` as cache key

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -22,9 +22,7 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          # Without inputs.target, it seems to select linux x64 in the wasm32
-          # tests, though in the docs it says it uses the target as the key?
-          key: ${{ inputs.target_option }}
+          key: ${{ inputs.os }}-${{ inputs.target_option }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jetli/wasm-bindgen-action@v0.2.0
         if: inputs.target_option == '--target=wasm32-unknown-unknown'


### PR DESCRIPTION
Something is causing the cache to fail to speedup builds; I _think_ it's this
