### PR TITLE
fix: Typo "sqllite" -> "sqlite"

### DIFF
--- a/prql-elixir/lib/prql.ex
+++ b/prql-elixir/lib/prql.ex
@@ -17,7 +17,7 @@ defmodule PRQL do
           | :bigquery
           | :clickhouse
           | :hive
-          | :sqllite
+          | :sqlite
           | :snowflake
   @type format_opt :: {:format, boolean()}
   @type signature_comment_opt :: {:signature_comment, boolean()}
@@ -37,7 +37,7 @@ defmodule PRQL do
 
     * `:dialect` - Dialect used for generate SQL. Accepted values are
     `:generic`, `:mssql`, `:mysql`, `:postgres`, `:ansi`, `:bigquery`,
-    `:clickhouse`, `:hive`, `:sqllite`, `:snowflake`
+    `:clickhouse`, `:hive`, `:sqlite`, `:snowflake`
 
     * `:format` - Formats the output, defaults to `true`
 

--- a/prql-elixir/lib/prql/native.ex
+++ b/prql-elixir/lib/prql/native.ex
@@ -26,7 +26,7 @@ defmodule PRQL.Native.CompileOptions do
           | :bigquery
           | :clickhouse
           | :hive
-          | :sqllite
+          | :sqlite
           | :snowflake
 
   @type t :: %__MODULE__{

--- a/prql-elixir/native/prql/src/lib.rs
+++ b/prql-elixir/native/prql/src/lib.rs
@@ -14,7 +14,7 @@ mod atoms {
       mssql,
       mysql,
       postgres,
-      sqllite,
+      sqlite,
       snowflake
     }
 }
@@ -53,7 +53,7 @@ fn dialect_from_atom(a: Atom) -> prql_compiler::sql::Dialect {
         D::MySql
     } else if a == atoms::postgres() {
         D::PostgreSql
-    } else if a == atoms::sqllite() {
+    } else if a == atoms::sqlite() {
         D::SQLite
     } else if a == atoms::snowflake() {
         D::Snowflake


### PR DESCRIPTION
👋

I think there's a typo in Elixir bindings for SQLite dialect. This PR fixes it.

`sqllite` -> `sqlite`