### PR TITLE
docs: Correcting the name of the python method

### DIFF
--- a/book/src/bindings/python.md
+++ b/book/src/bindings/python.md
@@ -19,5 +19,5 @@ prql_query = """
     )
 """
 
-sql = prql.to_sql(prql_query)
+sql = prql.compile(prql_query)
 ```


### PR DESCRIPTION
The name of the compile method seems to have changed since the python bindings page was written:
https://pypi.org/project/prql-python/
This PR aims to correct that.