### PR TITLE
fix(prql-elixir): fix tests to match prql-compiler update

### DIFF
--- a/prql-elixir/lib/prql.ex
+++ b/prql-elixir/lib/prql.ex
@@ -48,12 +48,12 @@ defmodule PRQL do
 
   Using default `Generic` dialect:
       iex> PRQL.compile("from customers", signature_comment: false)
-      {:ok, "SELECT\n  *\nFROM\n  customers"}
+      {:ok, "SELECT\n  *\nFROM\n  customers\n"}
 
 
   Using `MSSQL` dialect:
       iex> PRQL.compile("from customers\ntake 10", dialect: :mssql, signature_comment: false)
-      {:ok, "SELECT\n  TOP (10) *\nFROM\n  customers"}
+      {:ok, "SELECT\n  TOP (10) *\nFROM\n  customers\n"}
   """
   @spec compile(binary(), [compile_opts()]) :: {:ok, binary()} | {:error, binary()}
   def compile(prql_query, opts \\ []) when is_binary(prql_query) and is_list(opts) do

--- a/prql-elixir/test/prql_test.exs
+++ b/prql-elixir/test/prql_test.exs
@@ -9,7 +9,7 @@ defmodule PRQLTest do
       from customers
     """
 
-    excepted_result = "SELECT\n  *\nFROM\n  customers"
+    excepted_result = "SELECT\n  *\nFROM\n  customers\n"
 
     assert PRQL.compile(prql_query, @compile_opts) == {:ok, excepted_result}
   end


### PR DESCRIPTION
Follow up #1644

I was not aware that the update in #1644 would cause the test to fail.
Perhaps tests for subprojects that depend on prql-compiler should also be run if the prql-compiler is updated in PRs......