### PR TITLE
feat: Small playground improvements

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -20,7 +20,8 @@
         "react-dom": "^18.2.0",
         "react-syntax-highlighter": "^15.5.0",
         "wasm-react-scripts": "5.0.3",
-        "web-vitals": "^3.1.0"
+        "web-vitals": "^3.1.0",
+        "yaml": "^2.2.1"
       },
       "devDependencies": {
         "npm-watch": "^0.11.0"
@@ -6222,6 +6223,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6582,6 +6591,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/cssnano/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/csso": {
@@ -8380,6 +8397,14 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/form-data": {
@@ -13463,6 +13488,14 @@
         }
       }
     },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/postcss-loader": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -17522,11 +17555,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {
@@ -22036,6 +22069,13 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+        }
       }
     },
     "cross-spawn": {
@@ -22222,6 +22262,13 @@
         "cssnano-preset-default": "^5.2.12",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+        }
       }
     },
     "cssnano-preset-default": {
@@ -23590,6 +23637,11 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
           "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
         }
       }
     },
@@ -27275,6 +27327,13 @@
       "requires": {
         "lilconfig": "^2.0.5",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+        }
       }
     },
     "postcss-loader": {
@@ -30233,9 +30292,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/playground/package.json
+++ b/playground/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^18.2.0",
     "react-syntax-highlighter": "^15.5.0",
     "wasm-react-scripts": "5.0.3",
-    "web-vitals": "^3.1.0"
+    "web-vitals": "^3.1.0",
+    "yaml": "^2.2.1"
   },
   "devDependencies": {
     "npm-watch": "^0.11.0"

--- a/playground/src/output/Output.js
+++ b/playground/src/output/Output.js
@@ -123,7 +123,7 @@ class Output extends React.Component {
 
   async copyOutput() {
     try {
-      await navigator.clipboard.writeText(this.props.content.sql);
+      await navigator.clipboard.writeText(this.props.content[this.props.tab]);
 
       this.setState({ justCopied: true });
 

--- a/playground/src/output/Output.js
+++ b/playground/src/output/Output.js
@@ -1,6 +1,7 @@
 import "./Output.css";
 
 import React from "react";
+import YAML from "yaml";
 
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
 
@@ -26,8 +27,8 @@ class Output extends React.Component {
         <div className="tab-top">
           <Tab text="output.sql" name="sql" parent={this.props} />
           <Tab text="output.arrow" name="arrow" parent={this.props} />
-          <Tab text="output.pl.json" name="pl" parent={this.props} />
-          <Tab text="output.rq.json" name="rq" parent={this.props} />
+          <Tab text="output.pl.yaml" name="pl" parent={this.props} />
+          <Tab text="output.rq.yaml" name="rq" parent={this.props} />
 
           <div className="spacer"></div>
 
@@ -103,7 +104,7 @@ class Output extends React.Component {
       );
     }
     if (this.props.tab === "pl" && this.props.content.pl) {
-      const pl = JSON.stringify(JSON.parse(this.props.content.pl), null, 4);
+      const pl = YAML.stringify(JSON.parse(this.props.content.pl));
       return (
         <SyntaxHighlighter language="json" useInlineStyles={false}>
           {pl}
@@ -111,7 +112,7 @@ class Output extends React.Component {
       );
     }
     if (this.props.tab === "rq" && this.props.content.rq) {
-      const rq = JSON.stringify(JSON.parse(this.props.content.rq), null, 4);
+      const rq = YAML.stringify(JSON.parse(this.props.content.rq));
       return (
         <SyntaxHighlighter language="json" useInlineStyles={false}>
           {rq}

--- a/playground/src/workbench/Workbench.js
+++ b/playground/src/workbench/Workbench.js
@@ -1,11 +1,11 @@
 import "./Workbench.css";
 
-import React from "react";
 import * as prql from "prql-js/dist/bundler";
+import React from "react";
 
-import * as monacoTheme from "./monaco-theme.json";
-import * as monaco from "monaco-editor";
 import Editor, { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+import * as monacoTheme from "./monaco-theme.json";
 import prqlSyntax from "./prql-syntax";
 
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -165,6 +165,7 @@ class Workbench extends React.Component {
               options={{
                 minimap: { enabled: false },
                 scrollBeyondLastLine: false,
+                fontSize: 14,
               }}
             />
           </div>


### PR DESCRIPTION
This improves a couple small things in the playground:
- Increase the editor font size to be the same size as the output tab to make it easier to read (they are still different fonts, so it doesn't look perfect). I want to follow up with a PR to change the output to be rendered in a readonly Monaco window.
- Copy the contents of the active tab (fixes #1533).
- Swap the output from JSON to YAML (fixes #1534).

<img width="1512" alt="Screenshot 2023-02-02 at 8 56 39 AM" src="https://user-images.githubusercontent.com/3722365/216375421-bf308731-5973-4f65-916c-03db789c02f4.png">

This is my first contribution, so please let me know if there's anything I'm missing. I can also update the changelog if it'd be helpful.