### PR TITLE
docs: Use bold font for the website header

### DIFF
--- a/website/themes/prql-theme/static/style.css
+++ b/website/themes/prql-theme/static/style.css
@@ -167,6 +167,7 @@ pre ::-webkit-scrollbar-thumb:hover {
 #header a:not(.btn-icon) {
   color: var(--main-color);
   transition: 0.2s;
+  text-decoration: none;
 }
 
 #header a:hover,
@@ -204,6 +205,7 @@ pre ::-webkit-scrollbar-thumb:hover {
   align-items: center;
   justify-content: space-between;
   padding: 10px 0 3px 30px;
+  font-family: var(--title-font);
   font-size: 18px;
   white-space: nowrap;
 }


### PR DESCRIPTION
I realize I'm behind on stuff, so making cosmetic changes is probably not the most productive thing I could be doing.

But I thought the original website header was cleaner, what do others think? I don't trust myself here, so we can default to closing unless others agree. 

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/5635139/216528820-fc83307f-279d-4813-80f4-37916035d7e3.png">

