### PR TITLE
ci: Use `prql-bot` token for backport

### DIFF
--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -30,4 +30,5 @@ jobs:
     steps:
       - uses: tibdex/backport@v2
         with:
+          # This is a personal access token from the @prql-bot
           github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -30,4 +30,4 @@ jobs:
     steps:
       - uses: tibdex/backport@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}


### PR DESCRIPTION
Possibly this will allow the tests to run without manual intervention
