### PR TITLE
build: Disable prql-elixir on Mac

### DIFF
--- a/prql-elixir/native/prql/Cargo.toml
+++ b/prql-elixir/native/prql/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 authors = ["Kasun Vithanage <kasvith.me@gmail.com>"]
 description = "Elixir NIF bindings for prql-compiler"
-edition = "2021"
 # TODO: should this be `prql-elixir`?
 name = "prql"
 publish = false
 
-# edition.workspace = true
+edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
@@ -19,5 +18,6 @@ path = "src/lib.rs"
 
 [dependencies]
 prql-compiler = {path = "../../../prql-compiler", default-features = false, version = "0.4.2"}
-[target.'cfg(not(target_family="wasm"))'.dependencies]
+# See notes in `lib.rs` re excluding these targets.
+[target.'cfg(not(any(target_family="wasm", target_os="macos")))'.dependencies]
 rustler = "0.26.0"

--- a/prql-elixir/native/prql/src/lib.rs
+++ b/prql-elixir/native/prql/src/lib.rs
@@ -1,4 +1,8 @@
+// These bindings aren't relevant on wasm
 #![cfg(not(target_family = "wasm"))]
+// TODO: we would really like to compile on Mac, but we're getting linking
+// errors at the moment. (Though I'm not sure we always used to get them?)
+#![cfg(not(target_os = "macos"))]
 // TODO: unclear why we need this `allow`; it's required in `CompileOptions`,
 // likely because of the `NifStruct` derive.
 #![allow(clippy::needless_borrow)]


### PR DESCRIPTION
I'm not sure why we're now getting failures on Mac; possibly something to do with the workspace / compile options from that? We never ran tests in `prql-elixir`, but we used to run the build step implicitly in the `taskfile` tests.

Regardless, disabling for the moment.
