### PR TITLE
build: Remove `prql-elixir` tests from `test-all` locally

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -175,7 +175,8 @@ tasks:
       - task: test-rust
       - task: build-all
       - task: test-js
-      - task: test-elixir
+      # Currently breaking, wait for Elixir tests to run on MacOS
+      # - task: test-elixir
       - pre-commit run -a
 
   test-rust:


### PR DESCRIPTION
Reenable after https://github.com/PRQL/prql/pull/1707 merges. I may have broken these, apologies if so; though having the tests run in CI will be quite important for this to be reliable

Here's an example of a failure: https://github.com/PRQL/prql/actions/runs/4106944537/jobs/7085820400
