### PR TITLE
feat(prqlc)!: preprocess Jinja templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "0.30.2"
+source = "git+https://github.com/aljazerzen/minijinja#af5a4fd89e5ee5455d673a23098dcbc3d8444229"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,10 +2225,14 @@ dependencies = [
  "env_logger 0.9.3",
  "insta",
  "itertools",
+ "minijinja",
  "notify",
  "prql-compiler",
+ "regex",
+ "serde",
  "serde_json",
  "serde_yaml",
+ "similar-asserts",
  "walkdir",
 ]
 
@@ -2397,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2687,6 +2699,20 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf644ad016b75129f01a34a355dcb8d66a5bc803e417c7a77cc5d5ee9fa0f18"
+dependencies = [
+ "console",
+ "similar",
+]
 
 [[package]]
 name = "siphasher"
@@ -3088,6 +3114,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "similar-asserts",
  "walkdir",
 ]
 
@@ -2699,20 +2698,6 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf644ad016b75129f01a34a355dcb8d66a5bc803e417c7a77cc5d5ee9fa0f18"
-dependencies = [
- "console",
- "similar",
-]
 
 [[package]]
 name = "siphasher"
@@ -3114,12 +3099,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/prql-compiler/prqlc/Cargo.toml
+++ b/prql-compiler/prqlc/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.10.3"
 notify = "^5.1.0"
 minijinja = {git = "https://github.com/aljazerzen/minijinja"}
 prql-compiler = {path = '..', version = "0.5.2"}
-regex = {version = "1.7", features = ["std", "unicode", "pattern"]}
+regex = {version = "1.7.1", features = ["std", "unicode"]}
 serde_json = "1.0.81"
 serde_yaml = "0.9.1"
 serde = "^1"
@@ -28,4 +28,3 @@ walkdir = "^2.3.2"
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
 insta = {version = "1.28", features = ["colors", "glob", "yaml"]}
-similar-asserts = "1.4.2"

--- a/prql-compiler/prqlc/Cargo.toml
+++ b/prql-compiler/prqlc/Cargo.toml
@@ -18,10 +18,14 @@ color-eyre = "0.6.1"
 env_logger = {version = "0.9.1", features = ["termcolor"]}
 itertools = "0.10.3"
 notify = "^5.1.0"
-prql-compiler = {path = '..', version = "0.5.2" }
+minijinja = {git = "https://github.com/aljazerzen/minijinja"}
+prql-compiler = {path = '..', version = "0.5.2"}
+regex = {version = "1.7", features = ["std", "unicode", "pattern"]}
 serde_json = "1.0.81"
 serde_yaml = "0.9.1"
+serde = "^1"
 walkdir = "^2.3.2"
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
 insta = {version = "1.28", features = ["colors", "glob", "yaml"]}
+similar-asserts = "1.4.2"

--- a/prql-compiler/prqlc/src/jinja.rs
+++ b/prql-compiler/prqlc/src/jinja.rs
@@ -1,0 +1,173 @@
+//! Handling of Jinja templates
+//!
+//! dbt is using the following pipeline: `Jinja+SQL -> SQL -> execution`.
+//!
+//! To prevent messing up the templates, we have create the following pipeline:
+//! ```
+//! Jinja+PRQL -> Jinja+SQL -> SQL -> execution
+//! ```
+//!
+//! But because prql-compiler does not (and should not) know how to handle Jinja,
+//! we have to extract the interpolations, replace them something that is valid PRQL,
+//! compile the query and inject interpolations back in.
+//!
+//! Unfortunately, this requires parsing Jinja.
+//!
+//! use crate::compiler::tokens::{Span, Token};
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use minijinja::compiler::tokens::{Span, Token};
+use regex::Regex;
+
+const ANCHOR_PREFIX: &'static str = "_jinja_";
+
+#[derive(Debug)]
+pub enum JinjaBlock<'a> {
+    Data(&'a str),
+    Interpolation(Vec<(Token<'a>, Span)>),
+}
+
+#[derive(Default)]
+pub struct JinjaContext<'a> {
+    anchor_map: HashMap<String, &'a str>,
+    header: Vec<&'a str>,
+}
+
+/// Parse source as Jinja template, extract all interpolations
+/// and replace them with anchors.
+pub fn pre_process(source: &str) -> Result<(String, JinjaContext)> {
+    let mut blocks = Vec::new();
+    let mut current_block = Vec::new();
+
+    for res in minijinja::compiler::lexer::tokenize(source, false) {
+        let (token, span) = res?;
+
+        if let Token::TemplateData(data) = token {
+            if !current_block.is_empty() {
+                blocks.push(JinjaBlock::Interpolation(current_block));
+                current_block = Vec::new();
+            }
+            blocks.push(JinjaBlock::Data(data))
+        } else {
+            current_block.push((token, span));
+        }
+    }
+    if !current_block.is_empty() {
+        blocks.push(JinjaBlock::Interpolation(current_block));
+    }
+
+    let mut anchored_source = String::new();
+    let mut next_anchor_id = 0;
+    let mut context = JinjaContext::default();
+    for block in blocks {
+        match block {
+            JinjaBlock::Data(data) => anchored_source += data,
+            JinjaBlock::Interpolation(block) => {
+                let (tokens, spans): (Vec<_>, _) = block.into_iter().unzip();
+
+                let source_span = find_span(source, spans);
+
+                if let Some(Token::Ident("config" | "set")) = tokens.get(1) {
+                    context.header.push(source_span);
+                } else {
+                    let id = format!("{ANCHOR_PREFIX}{next_anchor_id}");
+                    next_anchor_id += 1;
+
+                    anchored_source += &format!("{id}");
+
+                    context.anchor_map.insert(id, source_span);
+                }
+            }
+        }
+    }
+
+    Ok((anchored_source, context))
+}
+
+fn find_span(source: &str, spans: Vec<Span>) -> &str {
+    let start = spans.first().unwrap();
+    let end = spans.last().unwrap();
+
+    let mut start_index = 0;
+    let mut end_index = source.len();
+
+    let mut line = 1;
+    let mut col = 0;
+    for (index, char) in source.chars().enumerate() {
+        if char == '\n' {
+            line += 1;
+            col = 0;
+            continue;
+        } else {
+            col += 1;
+        }
+
+        if line == start.start_line && col == start.start_col {
+            start_index = index;
+        }
+        if line == end.end_line && col == end.end_col {
+            end_index = index + 1;
+        }
+    }
+    &source[start_index..end_index]
+}
+
+/// Replace anchors with their values.
+pub fn post_process(source: &str, context: JinjaContext) -> String {
+    let mut res = String::new();
+
+    for stmt in context.header {
+        res += stmt;
+        res += "\n";
+    }
+
+    let re = Regex::new(&format!(r"{ANCHOR_PREFIX}\d+")).unwrap();
+
+    let mut last_index = 0;
+    for (index, anchor_id) in source.match_indices(&re) {
+        res += &source[last_index..index];
+        res += context.anchor_map.get(anchor_id).unwrap_or(&anchor_id);
+
+        last_index = index + anchor_id.len();
+    }
+    res += &source[last_index..];
+
+    res
+}
+
+#[cfg(test)]
+mod test {
+    use super::Span;
+
+    #[test]
+    fn test_find_span() {
+        let text = r#"line 1 col 13
+        line 2 col 21
+        some text line 3 col 31 more text
+        "#;
+
+        assert_eq!(
+            super::find_span(
+                text,
+                vec![
+                    Span {
+                        start_line: 2,
+                        start_col: 9,
+                        end_line: 12123123,
+                        end_col: 2930293,
+                    },
+                    Span {
+                        start_line: 7893648,
+                        start_col: 79678,
+                        end_line: 3,
+                        end_col: 31,
+                    }
+                ]
+            ),
+            r#"line 2 col 21
+        some text line 3 col 31"#
+        );
+    }
+}

--- a/prql-compiler/prqlc/src/jinja.rs
+++ b/prql-compiler/prqlc/src/jinja.rs
@@ -21,7 +21,7 @@ use anyhow::Result;
 use minijinja::compiler::tokens::{Span, Token};
 use regex::Regex;
 
-const ANCHOR_PREFIX: &'static str = "_jinja_";
+const ANCHOR_PREFIX: &str = "_jinja_";
 
 #[derive(Debug)]
 pub enum JinjaBlock<'a> {
@@ -75,7 +75,7 @@ pub fn pre_process(source: &str) -> Result<(String, JinjaContext)> {
                     let id = format!("{ANCHOR_PREFIX}{next_anchor_id}");
                     next_anchor_id += 1;
 
-                    anchored_source += &format!("{id}");
+                    anchored_source += &id;
 
                     context.anchor_map.insert(id, source_span);
                 }
@@ -126,7 +126,11 @@ pub fn post_process(source: &str, context: JinjaContext) -> String {
     let re = Regex::new(&format!(r"{ANCHOR_PREFIX}\d+")).unwrap();
 
     let mut last_index = 0;
-    for (index, anchor_id) in source.match_indices(&re) {
+    for cap in re.captures_iter(source) {
+        let cap = cap.get(0).unwrap();
+        let index = cap.start();
+        let anchor_id = cap.as_str();
+
         res += &source[last_index..index];
         res += context.anchor_map.get(anchor_id).unwrap_or(&anchor_id);
 

--- a/prql-compiler/prqlc/src/main.rs
+++ b/prql-compiler/prqlc/src/main.rs
@@ -7,6 +7,8 @@
 #[cfg(not(target_family = "wasm"))]
 mod cli;
 #[cfg(not(target_family = "wasm"))]
+mod jinja;
+#[cfg(not(target_family = "wasm"))]
 mod watch;
 
 #[cfg(not(target_family = "wasm"))]

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -847,10 +847,13 @@ Canada
 
     #[test]
     fn test_parse_jinja() {
-        stmts_of_string(r#"
+        stmts_of_string(
+            r#"
         from {{ ref('stg_orders') }}
         aggregate (sum order_id)
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
     }
 
     #[test]

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -233,10 +233,6 @@ fn expr_of_parse_pair(pair: Pair<Rule>) -> Result<Expr> {
                 named_args: named,
             })
         }
-        Rule::jinja => {
-            let inner = pair.as_str();
-            ExprKind::Ident(Ident::from_name(inner))
-        }
         Rule::ident => {
             // Pest has already parsed, so Chumsky should never fail
             let ident = ::chumsky::Parser::parse(&chumsky::ident(), pair.as_str()).unwrap();
@@ -850,39 +846,11 @@ Canada
     }
 
     #[test]
-    fn test_parse_jinja() -> Result<()> {
-        assert_yaml_snapshot!(stmts_of_string(r#"
+    fn test_parse_jinja() {
+        stmts_of_string(r#"
         from {{ ref('stg_orders') }}
         aggregate (sum order_id)
-        "#)?, @r###"
-        ---
-        - Main:
-            Pipeline:
-              exprs:
-                - FuncCall:
-                    name:
-                      Ident:
-                        - from
-                    args:
-                      - Ident:
-                          - "{{ ref('stg_orders') }}"
-                    named_args: {}
-                - FuncCall:
-                    name:
-                      Ident:
-                        - aggregate
-                    args:
-                      - FuncCall:
-                          name:
-                            Ident:
-                              - sum
-                          args:
-                            - Ident:
-                                - order_id
-                          named_args: {}
-                    named_args: {}
-        "###);
-        Ok(())
+        "#).unwrap_err();
     }
 
     #[test]

--- a/prql-compiler/src/parser/prql.pest
+++ b/prql-compiler/src/parser/prql.pest
@@ -57,7 +57,7 @@ expr_compare = { expr_add ~ (operator_compare ~ expr_add)? }
 expr_add = { expr_mul ~ (operator_add ~ expr_add)? }
 expr_mul = { term ~ (operator_mul ~ expr_mul)? }
 
-term = _{ ( switch | s_string | f_string | range | literal | ident | nested_pipeline | expr_unary | list | jinja ) }
+term = _{ ( switch | s_string | f_string | range | literal | ident | nested_pipeline | expr_unary | list ) }
 expr_unary = { ( operator_unary ~ ( nested_pipeline | ident | list )) }
 literal = _{ value_and_unit | number | boolean | null | string | timestamp | date | time | "(" ~ literal ~ ")" }
 // `assign | pipeline` based on discussion in #648
@@ -145,9 +145,6 @@ timestamp_inner = ${ date_inner ~ "T" ~ time_inner }
 // free to demote it to those items if `end_expr` is used somewhere where it's
 // not supported)
 end_expr = _{ WHITESPACE | "," | ")" | "]" | EOI | NEWLINE | ".." }
-
-// We pass text between `{{` and `}}` through, so dbt can use Jinja.
-jinja = { ("{{" ~ (!"}}" ~ ANY)* ~ "}}") }
 
 switch = { "switch" ~ "[" ~ (NEWLINE* ~ switch_case ~ ("," ~ NEWLINE* ~ switch_case )* ~ ","?)? ~ NEWLINE* ~ "]" }
 switch_case = { expr_call ~ "->" ~ expr_call }

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -664,9 +664,6 @@ fn is_keyword(ident: &str) -> bool {
 }
 
 pub(super) fn translate_ident_part(ident: String, ctx: &Context) -> sql_ast::Ident {
-    // We'll remove this when we get the new dbt plugin working (so no need to
-    // integrate into the regex)
-    let is_jinja = ident.starts_with("{{") && ident.ends_with("}}");
     lazy_static! {
         // One of:
         // - `*`
@@ -679,7 +676,7 @@ pub(super) fn translate_ident_part(ident: String, ctx: &Context) -> sql_ast::Ide
 
     let is_bare = VALID_BARE_IDENT.is_match(&ident);
 
-    if is_jinja || is_bare && !is_keyword(&ident) {
+    if is_bare && !is_keyword(&ident) {
         sql_ast::Ident::new(ident)
     } else {
         sql_ast::Ident::with_quote(ctx.dialect.ident_quote(), ident)

--- a/prql-compiler/src/sql/mod.rs
+++ b/prql-compiler/src/sql/mod.rs
@@ -32,10 +32,7 @@ pub fn compile(query: Query, options: Options) -> Result<String> {
             sqlformat::FormatOptions::default(),
         );
 
-        // The sql formatter turns `{{` into `{ {`, and while that's reasonable SQL,
-        // we want to allow jinja expressions through. So we (somewhat hackily) replace
-        // any `{ {` with `{{`.
-        formatted.replace("{ {", "{{").replace("} }", "}}") + "\n"
+        formatted + "\n"
     } else {
         sql
     };

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -1456,19 +1456,6 @@ fn test_distinct() {
 }
 
 #[test]
-fn test_dbt_query() {
-    assert_display_snapshot!((compile(r###"
-    from {{ ref('stg_orders') }}
-    aggregate (min order_id)
-    "###).unwrap()), @r###"
-    SELECT
-      MIN(order_id)
-    FROM
-      {{ ref('stg_orders') }}
-    "###);
-}
-
-#[test]
 fn test_join() {
     assert_display_snapshot!((compile(r###"
     from x

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -246,7 +246,7 @@ showcase_section:
         SELECT
           *
         FROM
-          table_1 as table_0
+          table_1 AS table_0
         WHERE
           _expr_0 <= 1
 


### PR DESCRIPTION
See demo repo: https://github.com/aljazerzen/jaffle_shop

### Method

We start with Jinja-PRQL:
```
from {{ ref('my_model') }}
```
... parse Jinja and extract interpolations:
```
from _jinja_0
```
... compile PRQL:
```
SELECT * FROM _jinja_0
```
... replace anchor with original Jinja expressions:
```
SELECT * FROM {{ ref('my_model') }}
```

### Minijinja

I used [minijinja](https://github.com/mitsuhiko/minijinja) to lex the input into tokens. For that I had to [fork](https://github.com/aljazerzen/minijinja) the project so it exposes the lexer. 

### Problems

This approach does not work any jinja expression that would not produce exactly one output token. This includes for loops and if statements.

We could do full Jinja evaluation and provide all functions that are available in dbt, but set them to evaluate to anchor tokens just as I do now. This would make for loops work, but could not fully emulate evaluation that depends on any state that is provided by dbt.

I don't know much about dbt, should I'd ask for people to check it out and try to translate a few dbt projects.

### Ideal solution

Have access to dbt state, i.e. compile PRQL **after** dbt evaluates the Jinja template.
