### PR TITLE
ci: Add concurrency to pull-request-target

### DIFF
--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, labeled, closed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
We're seeing multiple instances of this workflow at https://github.com/PRQL/prql/pull/1731/checks, which then doesn't clear up failures...
