### PR TITLE
ci: Improve caching

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,10 +29,10 @@ jobs:
     strategy:
       matrix:
         target_option: ["", "--target=wasm32-unknown-unknown"]
-        os: [ubuntu-latest]
     uses: ./.github/workflows/test-rust.yaml
     with:
       target_option: ${{ matrix.target_option }}
+      os: ubuntu-latest
 
   test-book:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         target_option: ["", "--target=wasm32-unknown-unknown"]
+        os: [ubuntu-latest]
     uses: ./.github/workflows/test-rust.yaml
     with:
       target_option: ${{ matrix.target_option }}

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -5,10 +5,8 @@ on:
   workflow_call:
     inputs:
       os:
-        required: false
         type: string
       target_option:
-        required: false
         type: string
 
 jobs:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -6,11 +6,9 @@ on:
     inputs:
       os:
         required: false
-        default: ubuntu-latest
         type: string
       target_option:
         required: false
-        default: ""
         type: string
 
 jobs:


### PR DESCRIPTION
This will let the rust test from `pull-request` use the same cache as that from `test-all`
