### PR TITLE
docs: Update dev call

### DIFF
--- a/book/src/contributing/fortnightly-dev-call.ics
+++ b/book/src/contributing/fortnightly-dev-call.ics
@@ -1,7 +1,7 @@
 COMMENT: iCalendar .ics format file to add Fortnightly PRQL Dev Call to your calendar
 COMMENT: DTSTART is the starting time of the first event
 COMMENT: DTEND is the ending time of the first event
-COMMENT: RRULE specifies the repeat interval (2nd & 4th Sunday), and end date ("UNTIL")
+COMMENT: RRULE specifies the repeat interval (1st & 3rd Sunday), and end date ("UNTIL")
 COMMENT:
 BEGIN:VCALENDAR
 PRODID:-//Apple Inc.//macOS 12.6.1//EN
@@ -11,8 +11,8 @@ DTSTAMP:20230105T164630
 UID:dev-call.prql-lang.org
 DTSTART;TZID=America/New_York:20230108T123000
 DTEND;TZID=America/New_York:20230108T130000
-RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=2SU,4SU;UNTIL=20230331
-DESCRIPTION:Discord #dev-voice-channel\nhttps://discord.gg/2RUBzz3R3J\n1730Z on 2nd & 4th Sunday
+RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1SU,3SU;UNTIL=20230331
+DESCRIPTION:Discord #dev-voice-channel\nhttps://discord.gg/2RUBzz3R3J\n1730Z on 1st & 3rd Sunday
 LOCATION:https://discord.gg/2RUBzz3R3J\n1730Z
 SEQUENCE:0
 STATUS:CONFIRMED


### PR DESCRIPTION
From Discord:

> I think I realize why it was just me & Aljaz & Tobias on Sunday — the original invite of every two weeks is out of sync with the new invite, which is the 2nd & 4th Sunday of each month!
>
> I'm going to change the invite to 1st & 3rd Sunday so we're back in sync, and remove the old invitation.
>
> Sorry for the churn