### PR TITLE
ci: Only cache publish-web on `web` branch

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -33,6 +33,8 @@ jobs:
       # Book setup
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/web' }}
       - uses: peaceiris/actions-mdbook@v1
       - uses: baptiste0928/cargo-install@next
         with:


### PR DESCRIPTION
These are important to stop the cache churning
