### PR TITLE
ci: Remove branch filters from releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,6 @@ version = "0.5.0"
 opt-level = "s"
 
 [workspace.metadata.release]
+allow_branch = ["*"]
 consolidate-commits = true
 pre-release-commit-message = "chore: Release {{version}}"


### PR DESCRIPTION
We release from a tag, so there's no active branch (I released locally this time)
