### PR TITLE
feat(prql-compiler): implement Target::from_str and Target::default

### DIFF
--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -155,9 +155,10 @@ impl FromStr for Target {
 
     fn from_str(s: &str) -> Result<Target, Self::Err> {
         s.strip_prefix("sql.")
-            .map(|dialect| sql::Dialect::from_str(dialect).unwrap_or_default())
+            .map(sql::Dialect::from_str)
+            .unwrap()
             .map(|d| Target::Sql(Some(d)))
-            .ok_or_else(|| {
+            .map_err(|_| {
                 Error::new(Reason::NotFound {
                     name: format!("{s:?}"),
                     namespace: "target".to_string(),
@@ -285,12 +286,15 @@ mod tests {
         "###);
 
         assert_debug_snapshot!(Target::from_str(&"sql.poostgres".to_string()), @r###"
-        Ok(
-            Sql(
-                Some(
-                    Generic,
-                ),
-            ),
+        Err(
+            Error {
+                span: None,
+                reason: NotFound {
+                    name: "\"sql.poostgres\"",
+                    namespace: "target",
+                },
+                help: None,
+            },
         )
         "###);
 

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -154,22 +154,19 @@ impl FromStr for Target {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Target, Self::Err> {
+        let not_found_error = Error::new(Reason::NotFound {
+            name: format!("{s:?}"),
+            namespace: "target".to_string(),
+        });
+
         if s.starts_with("sql.") {
             s.strip_prefix("sql.")
                 .map(sql::Dialect::from_str)
                 .transpose()
                 .map(Target::Sql)
-                .map_err(|_| {
-                    Error::new(Reason::NotFound {
-                        name: format!("{s:?}"),
-                        namespace: "target".to_string(),
-                    })
-                })
+                .map_err(|_| not_found_error)
         } else {
-            Err(Error::new(Reason::NotFound {
-                name: format!("{s:?}"),
-                namespace: "target".to_string(),
-            }))
+            Err(not_found_error)
         }
     }
 }

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -137,7 +137,7 @@ pub enum Target {
 
 impl Default for Target {
     fn default() -> Self {
-        Self::Sql(Some(sql::Dialect::default()))
+        Self::Sql(None)
     }
 }
 

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -154,16 +154,15 @@ impl FromStr for Target {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Target, Self::Err> {
-        if s.starts_with("sql.") {
-            let maybe_dialect = s.strip_prefix("sql.").unwrap_or(s);
-            let dialect = sql::Dialect::from_str(maybe_dialect).unwrap_or_default();
-            Ok(Target::Sql(Some(dialect)))
-        } else {
-            Err(Error::new(Reason::NotFound {
-                name: format!("{s:?}"),
-                namespace: "target".to_string(),
-            }))
-        }
+        s.strip_prefix("sql.")
+            .map(|dialect| sql::Dialect::from_str(dialect).unwrap_or_default())
+            .map(|d| Target::Sql(Some(d)))
+            .ok_or_else(|| {
+                Error::new(Reason::NotFound {
+                    name: format!("{s:?}"),
+                    namespace: "target".to_string(),
+                })
+            })
     }
 }
 

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -265,3 +265,46 @@ pub mod json {
         serde_json::from_str(json).map_err(|e| error::downcast(anyhow::anyhow!(e)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Target;
+    use insta::assert_debug_snapshot;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_target_from_str() {
+        assert_debug_snapshot!(Target::from_str(&"sql.postgres".to_string()), @r###"
+        Ok(
+            Sql(
+                Some(
+                    PostgreSql,
+                ),
+            ),
+        )
+        "###);
+
+        assert_debug_snapshot!(Target::from_str(&"sql.poostgres".to_string()), @r###"
+        Ok(
+            Sql(
+                Some(
+                    Generic,
+                ),
+            ),
+        )
+        "###);
+
+        assert_debug_snapshot!(Target::from_str(&"postgres".to_string()), @r###"
+        Err(
+            Error {
+                span: None,
+                reason: NotFound {
+                    name: "\"postgres\"",
+                    namespace: "target",
+                },
+                help: None,
+            },
+        )
+        "###);
+    }
+}

--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -241,6 +241,28 @@ impl DialectHandler for DuckDbDialect {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::Dialect;
+    use insta::assert_debug_snapshot;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_dialect_from_str() {
+        assert_debug_snapshot!(Dialect::from_str("postgres"), @r###"
+        Ok(
+            PostgreSql,
+        )
+        "###);
+
+        assert_debug_snapshot!(Dialect::from_str("foo"), @r###"
+        Err(
+            VariantNotFound,
+        )
+        "###);
+    }
+}
+
 /*
 ## Set operations support matrix
 

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -5,7 +5,6 @@ mod utils;
 use std::str::FromStr;
 
 use prql_compiler::Target;
-use prql_compiler::sql::Dialect;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -4,6 +4,7 @@ mod utils;
 
 use std::str::FromStr;
 
+use prql_compiler::Target;
 use prql_compiler::sql::Dialect;
 use wasm_bindgen::prelude::*;
 
@@ -103,13 +104,11 @@ impl CompileOptions {
 
 impl From<CompileOptions> for prql_compiler::Options {
     fn from(o: CompileOptions) -> Self {
-        let maybe_dialect = o.target.strip_prefix("sql.");
-        let dialect =
-            maybe_dialect.map(|dialect| Dialect::from_str(dialect).unwrap_or(Dialect::Generic));
+        let target = Target::from_str(&o.target).unwrap_or_default();
 
         prql_compiler::Options {
             format: o.format,
-            target: prql_compiler::Target::Sql(dialect),
+            target,
             signature_comment: o.signature_comment,
         }
     }

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -4,7 +4,7 @@ mod utils;
 
 use std::str::FromStr;
 
-use prql_compiler::Target;
+use prql_compiler::{sql::Dialect, Target};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -103,7 +103,7 @@ impl CompileOptions {
 
 impl From<CompileOptions> for prql_compiler::Options {
     fn from(o: CompileOptions) -> Self {
-        let target = Target::from_str(&o.target).unwrap_or_default();
+        let target = Target::from_str(&o.target).unwrap_or(Target::Sql(Some(Dialect::Generic)));
 
         prql_compiler::Options {
             format: o.format,


### PR DESCRIPTION
Currently, the `sql.` prefix have to be removed from the target name and pass to `Dialect::from_str`.
This PR implements `Target::from_str` and does this on the `Target::from_str` side, eliminating the need for downstream software to implement this process.

Example of Use: eitsupi/prqlr#78