### PR TITLE
build: Differentiate between `web` and `website` in task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -278,7 +278,7 @@ tasks:
       - mix compile
       - mix test
 
-  run-web:
+  run-website:
     desc: Build & serve the static website.
     dir: website
     cmds:


### PR DESCRIPTION
Currently there are two tasks with similar names that do different things

Overall in the project, let's use `web` for static website, book & playground, and `website` as just the static website
