### PR TITLE
fix(prql-compiler): not found error for target not starts with `sql.`

### DIFF
--- a/prql-compiler/src/sql/gen_query.rs
+++ b/prql-compiler/src/sql/gen_query.rs
@@ -14,7 +14,6 @@ use sqlparser::ast::{
 
 use crate::ast::pl::{BinOp, Literal, RelationLiteral};
 use crate::ast::rq::{CId, Expr, ExprKind, Query, Relation, RelationKind, TableDecl, Transform};
-use crate::error::{Error, Reason};
 use crate::utils::{BreakUp, IntoOnly, Pluck};
 use crate::Target;
 
@@ -30,14 +29,7 @@ pub fn translate_query(query: Query, dialect: Option<Dialect>) -> Result<sql_ast
     } else {
         let target = query.def.other.get("target");
         let Target::Sql(maybe_dialect) = target
-            .map(|target| {
-                Target::from_str(target).map_err(|_| {
-                    Error::new(Reason::NotFound {
-                        name: format!("{target:?}"),
-                        namespace: "target".to_string(),
-                    })
-                })
-            })
+            .map(|s| Target::from_str(s))
             .transpose()?
             .unwrap_or_default();
         maybe_dialect.unwrap_or_default()

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -3213,3 +3213,16 @@ a,b,c
     "###
     );
 }
+
+#[test]
+fn test_header_target_error() {
+    assert_display_snapshot!(compile(r#"
+    prql target:foo
+    from a
+    "#).unwrap_err(),@r###"target `"foo"` not found"###);
+
+    assert_display_snapshot!(compile(r#"
+    prql target:sql.foo
+    from a
+    "#).unwrap_err(),@r###"target `"sql.foo"` not found"###)
+}


### PR DESCRIPTION
Fix to properly generate errors for invalid target names.

Currently, target names that do not start with `sql.` are ignored. (eitsupi/prqlr#81)

```r
"prql target:sql.duckd\nfrom a" |> prqlr::prql_compile()
#> Error in unwrap(compile(prql_query, target, format, signature_comment)) :
#>   dialect `"duckd"` not found
"prql target:duckd\nfrom a" |> prqlr::prql_compile()
#> "SELECT\n  *\nFROM\n  a\n\n-- Generated by PRQL compiler version:0.5.0 (https://prql-lang.org)\n"
```