### PR TITLE
feat(prql-python): expose CompileOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 **Features**:
 
-- Compilation options can now be specified from Python. (@eitsupi, #1807)
-
 **Fixes**:
 
 - Delegate dividing literal integers to the DB. Previously integer division was
@@ -20,6 +18,8 @@
 **Web**:
 
 **Integrations**:
+
+- [prql-python] Compilation options can now be specified from Python. (@eitsupi, #1807)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 **Integrations**:
 
-- [prql-python] Compilation options can now be specified from Python. (@eitsupi, #1807)
+- [prql-python] Compilation options can now be specified from Python. (@eitsupi,
+  #1807)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Features**:
 
+- Compilation options can now be specified from Python. (@eitsupi, #1807)
+
 **Fixes**:
 
 - Delegate dividing literal integers to the DB. Previously integer division was

--- a/prql-python/README.md
+++ b/prql-python/README.md
@@ -29,7 +29,8 @@ prql_query = """
 """
 
 options = prql.CompileOptions(
-    format=True, signature_comment=True, target="sql.postgres")
+    format=True, signature_comment=True, target="sql.postgres"
+)
 
 sql = prql.compile(prql_query)
 sql_postgres = prql.compile(prql_query, options)

--- a/prql-python/README.md
+++ b/prql-python/README.md
@@ -28,7 +28,11 @@ prql_query = """
     )
 """
 
+options = prql.CompileOptions(
+    format=True, signature_comment=True, target="sql.postgres")
+
 sql = prql.compile(prql_query)
+sql_postgres = prql.compile(prql_query, options)
 ```
 
 Relies on [pyo3](https://github.com/PyO3/pyo3) for all the magic.

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -33,4 +33,8 @@ def test_all():
         )
     """
 
+    options = prql.CompileOptions(
+        format=True, signature_comment=True, target="sql.postgres")
+
     assert prql.compile(prql_query)
+    assert prql.compile(prql_query, options)

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -49,4 +49,5 @@ def test_compile_options():
     options = prql.CompileOptions(format=False, signature_comment=False, target="foo")
 
     assert prql.compile(query_mssql).startswith("SELECT\n  TOP (3) *\nFROM\n  a")
+    # TODO: This should be unknown target error?
     assert prql.compile(query_mssql, options) == "SELECT * FROM a LIMIT 3"

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -39,3 +39,14 @@ def test_all():
 
     assert prql.compile(prql_query)
     assert prql.compile(prql_query, options)
+
+
+def test_compile_options():
+    """
+    Test the CompileOptions
+    """
+    query_mssql = "prql target:sql.mssql\nfrom a | take 3"
+    options = prql.CompileOptions(format=False, signature_comment=False, target="foo")
+
+    assert prql.compile(query_mssql).startswith("SELECT\n  TOP (3) *\nFROM\n  a")
+    assert prql.compile(query_mssql, options) == "SELECT * FROM a LIMIT 3"

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -34,7 +34,8 @@ def test_all():
     """
 
     options = prql.CompileOptions(
-        format=True, signature_comment=True, target="sql.postgres")
+        format=True, signature_comment=True, target="sql.postgres"
+    )
 
     assert prql.compile(prql_query)
     assert prql.compile(prql_query, options)


### PR DESCRIPTION
Close #1792

Expose `CompileOptions` to allow compile options to be specified from the Python side.

Note: This is a basic implementation only.
For example, I am not sure if the behavior when an invalid target name is specified falling back to `sql.generic` silently is appropriate.
It would be worth changing later.