### PR TITLE
docs: s/Tables/Variables/

### DIFF
--- a/book/src/queries/README.md
+++ b/book/src/queries/README.md
@@ -7,4 +7,4 @@ The major items of a _query_ are listed at the left:
 
 - [Pipelines](./pipelines.md)
 - [Functions](./functions.md)
-- [Tables](./tables.md)
+- [Variables](./variables.md)


### PR DESCRIPTION
Found another place that refers to the name change from "Tables" to "Variables"