### PR TITLE
refactor: Remove `default-target` from Taskfile

### DIFF
--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -35,3 +35,4 @@ jobs:
       - run: task setup-dev
       # This also encompasses `build-all`
       - run: task test-all
+      - run: task test-rust-fast

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,13 +58,12 @@ tasks:
     cmds:
       # `--locked` installs from the underlying lock files (which is not the
       # default?!)
-      - cargo install --locked cargo-audit cargo-insta cargo-release
-        default-target mdbook mdbook-admonish mdbook-toc wasm-bindgen-cli
-        wasm-pack
+      - cargo install --locked cargo-audit cargo-insta cargo-release mdbook
+        mdbook-admonish mdbook-toc wasm-bindgen-cli wasm-pack
         # Can't install atm with `--locked`
       - cargo install mdbook-footnote
       - cmd: |
-          [ "$(which default-target)" ] || echo "🔴 Can't find a binary that cargo just installed. Is the cargo bin path (generally at ~/.cargo/bin) on the \$PATH?"
+          [ "$(which cargo-insta)" ] || echo "🔴 Can't find a binary that cargo just installed. Is the cargo bin path (generally at ~/.cargo/bin) on the \$PATH?"
         silent: true
 
   install-maturin:
@@ -151,17 +150,9 @@ tasks:
       Build everything.
 
       Running this isn't required when developing; it's for caching or as a reference.
-    vars:
-      default_target:
-        sh: default-target
-      targets: |
-        {{ .default_target }}
-        wasm32-unknown-unknown
     cmds:
-      - |
-        {{ range ( .targets | trim | splitLines ) -}}
-        cargo build --all-targets --target={{.}}
-        {{ end -}}
+      - cargo build --all-targets
+      - cargo build --all-targets --target=wasm32-unknown-unknown
       - task: build-web
 
   test-all:
@@ -182,9 +173,6 @@ tasks:
 
   test-rust:
     desc: Test all rust code, accepting snapshots.
-    vars:
-      default_target:
-        sh: default-target
     # Commenting out the ability to watch, since Task seems to trip over itself,
     # starting a new process before the old one has finished when a process
     # changes output files.
@@ -212,13 +200,11 @@ tasks:
       # tests to extract them, which include compiling prql-compiler, c) not
       # fail other compilation steps if they can't be extracted.
       - cargo insta test --accept -p mdbook-prql --test snapshot
-        --target={{.default_target}}
       # Only delete unreferenced snapshots on the default target — lots are
       # excluded under wasm. Note that this will also over-delete on Windows.
       # Note that we need to pass the target explicitly to manage
       # https://github.com/rust-lang/cargo/issues/8899
-      - cargo insta test --accept --target={{.default_target}}
-        --unreferenced=auto
+      - cargo insta test --accept --unreferenced=auto
       - cargo insta test --accept --target=wasm32-unknown-unknown
       # We build the book too, because that acts as a test
       - cd book && mdbook build
@@ -247,8 +233,7 @@ tasks:
       - "prql-compiler/**/*.pest"
       - "prql-compiler/**/*.snap"
     cmds:
-      - cargo insta test --accept -p prql-compiler --lib --target=$(cargo
-        default-target)
+      - cargo insta test --accept -p prql-compiler --lib
 
   build-web:
     desc: Build the website, including the book & playground.

--- a/book/book.toml
+++ b/book/book.toml
@@ -12,15 +12,11 @@ git-repository-url = "https://github.com/PRQL/prql"
 [preprocessor.prql]
 # This is required because mdbook-prql isn't necessarily installed; maybe
 # there's a better way.
-#
-# We put the target directory in `target-book` because of
-# https://github.com/rust-lang/cargo/issues/8899, as an alternative to requiring
-# `default-target` to be installed.
-command = "cargo run --bin mdbook-prql --target-dir=target-book"
+command = "cargo run --bin mdbook-prql"
 
 [preprocessor.admonish]
 assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`
-command = "mdbook-admonish"
+command = "mdbook-admonish" 
 
 [preprocessor.footnote]
 # Seems to be required for footnotes to show properly.

--- a/book/book.toml
+++ b/book/book.toml
@@ -16,7 +16,7 @@ command = "cargo run --bin mdbook-prql"
 
 [preprocessor.admonish]
 assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`
-command = "mdbook-admonish" 
+command = "mdbook-admonish"
 
 [preprocessor.footnote]
 # Seems to be required for footnotes to show properly.


### PR DESCRIPTION
I realized I'd added this to make the Taskfile simpler, but then we add build flags, and to retain caching we had to add it everywhere. So removing it completely is actually much simpler.
