### PR TITLE
revert: Remove `default-target` from Taskfile (#1847)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,12 +58,13 @@ tasks:
     cmds:
       # `--locked` installs from the underlying lock files (which is not the
       # default?!)
-      - cargo install --locked cargo-audit cargo-insta cargo-release mdbook
-        mdbook-admonish mdbook-toc wasm-bindgen-cli wasm-pack
+      - cargo install --locked cargo-audit cargo-insta cargo-release
+        default-target mdbook mdbook-admonish mdbook-toc wasm-bindgen-cli
+        wasm-pack
         # Can't install atm with `--locked`
       - cargo install mdbook-footnote
       - cmd: |
-          [ "$(which cargo-insta)" ] || echo "🔴 Can't find a binary that cargo just installed. Is the cargo bin path (generally at ~/.cargo/bin) on the \$PATH?"
+          [ "$(which default-target)" ] || echo "🔴 Can't find a binary that cargo just installed. Is the cargo bin path (generally at ~/.cargo/bin) on the \$PATH?"
         silent: true
 
   install-maturin:
@@ -150,9 +151,17 @@ tasks:
       Build everything.
 
       Running this isn't required when developing; it's for caching or as a reference.
+    vars:
+      default_target:
+        sh: default-target
+      targets: |
+        {{ .default_target }}
+        wasm32-unknown-unknown
     cmds:
-      - cargo build --all-targets
-      - cargo build --all-targets --target=wasm32-unknown-unknown
+      - |
+        {{ range ( .targets | trim | splitLines ) -}}
+        cargo build --all-targets --target={{.}}
+        {{ end -}}
       - task: build-web
 
   test-all:
@@ -173,6 +182,9 @@ tasks:
 
   test-rust:
     desc: Test all rust code, accepting snapshots.
+    vars:
+      default_target:
+        sh: default-target
     # Commenting out the ability to watch, since Task seems to trip over itself,
     # starting a new process before the old one has finished when a process
     # changes output files.
@@ -200,11 +212,13 @@ tasks:
       # tests to extract them, which include compiling prql-compiler, c) not
       # fail other compilation steps if they can't be extracted.
       - cargo insta test --accept -p mdbook-prql --test snapshot
+        --target={{.default_target}}
       # Only delete unreferenced snapshots on the default target — lots are
       # excluded under wasm. Note that this will also over-delete on Windows.
       # Note that we need to pass the target explicitly to manage
       # https://github.com/rust-lang/cargo/issues/8899
-      - cargo insta test --accept --unreferenced=auto
+      - cargo insta test --accept --target={{.default_target}}
+        --unreferenced=auto
       - cargo insta test --accept --target=wasm32-unknown-unknown
       # We build the book too, because that acts as a test
       - cd book && mdbook build
@@ -234,6 +248,7 @@ tasks:
       - "prql-compiler/**/*.snap"
     cmds:
       - cargo insta test --accept -p prql-compiler --lib
+        --target=$(default-target)
 
   build-web:
     desc: Build the website, including the book & playground.

--- a/book/book.toml
+++ b/book/book.toml
@@ -12,7 +12,11 @@ git-repository-url = "https://github.com/PRQL/prql"
 [preprocessor.prql]
 # This is required because mdbook-prql isn't necessarily installed; maybe
 # there's a better way.
-command = "cargo run --bin mdbook-prql"
+#
+# We put the target directory in `target-book` because of
+# https://github.com/rust-lang/cargo/issues/8899, as an alternative to requiring
+# `default-target` to be installed.
+command = "cargo run --bin mdbook-prql --target-dir=target-book"
 
 [preprocessor.admonish]
 assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`


### PR DESCRIPTION
This reverts commit e0a6647c7d7f5b7f506da147c15d699b12c5e273. I was mistaken on how the build flags worked — actually the current version has to recompile everything after running on a different target.

I left a couple of changes in re adding a test

I may try and resolve this in a different way soon.
