### PR TITLE
feat(prql-js)!: use Sql(None) for default Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - [prql-python] Compilation options can now be specified from Python. (@eitsupi,
   #1807)
+- [prql-js] Default compile target changed from `Sql(Generic)` to `Sql(None)`.
+  (@eitsupi, #1856)
 
 **Internal changes**:
 

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -103,7 +103,7 @@ impl CompileOptions {
 
 impl From<CompileOptions> for prql_compiler::Options {
     fn from(o: CompileOptions) -> Self {
-        let target = Target::from_str(&o.target).unwrap_or(Target::Sql(Some(Dialect::Generic)));
+        let target = Target::from_str(&o.target).unwrap_or_default();
 
         prql_compiler::Options {
             format: o.format,

--- a/prql-js/src/lib.rs
+++ b/prql-js/src/lib.rs
@@ -4,7 +4,7 @@ mod utils;
 
 use std::str::FromStr;
 
-use prql_compiler::{sql::Dialect, Target};
+use prql_compiler::Target;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -69,14 +69,13 @@ describe("prql-js", () => {
       assert.equal(opts.target, "sql.sqlite");
     });
 
-    it("should fallback to generic dialect", () => {
+    it("should fallback to the target in header", () => {
       const opts = new prql.CompileOptions();
 
       opts.target = "sql.not_existing";
-      const res = prql.compile("from a", opts);
+      const res = prql.compile("prql target:mssql\nfrom a | take 1", opts);
 
-      // target should appear in signature comment
-      assert(res.includes("target:sql.generic"));
+      assert(res.includes("TOP (1)"));
     });
   });
 

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -55,7 +55,10 @@ describe("prql-js", () => {
       opts.format = false;
       opts.signature_comment = false;
 
-      const res = prql.compile("prql target:sql.sqlite\nfrom a | take 10", opts);
+      const res = prql.compile(
+        "prql target:sql.sqlite\nfrom a | take 10",
+        opts
+      );
       assert(res.includes("SELECT TOP (10) * FROM a"));
       assert(res.includes("target:sql.mssql"));
     });

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -85,15 +85,5 @@ describe("prql-js", () => {
       assert(targets.length > 0);
       assert(targets.includes("sql.sqlite"));
     });
-
-    it("should fallback to generic dialect", () => {
-      const opts = new prql.CompileOptions();
-
-      opts.target = "sql.not_existing";
-      const res = prql.compile("from a", opts);
-
-      // target should appear in signature comment
-      assert(res.includes("target:sql.generic"));
-    });
   });
 });

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -84,7 +84,7 @@ describe("prql-js", () => {
       const opts = new prql.CompileOptions();
 
       opts.target = "sql.not_existing";
-      const res = prql.compile("prql target:mssql\nfrom a | take 1", opts);
+      const res = prql.compile("prql target:sql.mssql\nfrom a | take 1", opts);
 
       assert(res.includes("TOP (1)"));
     });

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -48,6 +48,17 @@ describe("prql-js", () => {
       const res = prql.compile("from a | take 10", opts);
       assert.equal(res, "SELECT TOP (10) * FROM a");
     });
+
+    it("CompileOptions should be preferred and should ignore target in header", () => {
+      const opts = new prql.CompileOptions();
+      opts.target = "sql.mssql";
+      opts.format = false;
+      opts.signature_comment = false;
+
+      const res = prql.compile("prql target:sql.sqlite\nfrom a | take 10", opts);
+      assert(res.includes("SELECT TOP (10) * FROM a"));
+      assert(res.includes("target:sql.mssql"));
+    });
   });
 
   describe("prql_to_pl", () => {

--- a/prql-js/tests/test_all.js
+++ b/prql-js/tests/test_all.js
@@ -53,7 +53,7 @@ describe("prql-js", () => {
       const opts = new prql.CompileOptions();
       opts.target = "sql.mssql";
       opts.format = false;
-      opts.signature_comment = false;
+      opts.signature_comment = true;
 
       const res = prql.compile("prql target:sql.sqlite\nfrom a | take 10", opts);
       assert(res.includes("SELECT TOP (10) * FROM a"));


### PR DESCRIPTION
Part of #1855

Change the default to `Sql(None)` to fall back to the target specified in the PRQL query header when the compile option is set.