### PR TITLE
feat(prql-python)!: use Sql(None) for default Target and allow CompileOptions without target argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@
   (@eitsupi, #1856)
 - [prql-python] Compilation options can now be specified from Python. (@eitsupi,
   #1807)
-- [prql-python] Default compile target changed from `Sql(Generic)` to `Sql(None)`.
-  (@eitsupi, #1861)
+- [prql-python] Default compile target changed from `Sql(Generic)` to
+  `Sql(None)`. (@eitsupi, #1861)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@
 
 **Integrations**:
 
-- [prql-python] Compilation options can now be specified from Python. (@eitsupi,
-  #1807)
 - [prql-js] Default compile target changed from `Sql(Generic)` to `Sql(None)`.
   (@eitsupi, #1856)
+- [prql-python] Compilation options can now be specified from Python. (@eitsupi,
+  #1807)
+- [prql-python] Default compile target changed from `Sql(Generic)` to `Sql(None)`.
+  (@eitsupi, #1861)
 
 **Internal changes**:
 

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -48,8 +48,13 @@ def test_compile_options():
     Test the CompileOptions
     """
     query_mssql = "prql target:sql.mssql\nfrom a | take 3"
-    options = prql.CompileOptions(format=False, signature_comment=False, target="foo")
+
+    options_with_known_target = prql.CompileOptions(format=False, signature_comment=False, target="sql.sqlite")
+    options_without_target = prql.CompileOptions(format=False, signature_comment=False)
+    options_with_unknown_target = prql.CompileOptions(format=False, signature_comment=False, target="foo")
 
     assert prql.compile(query_mssql).startswith("SELECT\n  TOP (3) *\nFROM\n  a")
+    assert prql.compile(query_mssql, options_with_known_target) == "SELECT * FROM a LIMIT 3"
+    assert prql.compile(query_mssql, options_without_target) == "SELECT TOP (3) * FROM a"
     # TODO: This should be unknown target error?
-    assert prql.compile(query_mssql, options) == "SELECT TOP (3) * FROM a"
+    assert prql.compile(query_mssql, options_with_unknown_target) == "SELECT TOP (3) * FROM a"

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -49,12 +49,24 @@ def test_compile_options():
     """
     query_mssql = "prql target:sql.mssql\nfrom a | take 3"
 
-    options_with_known_target = prql.CompileOptions(format=False, signature_comment=False, target="sql.sqlite")
+    options_with_known_target = prql.CompileOptions(
+        format=False, signature_comment=False, target="sql.sqlite"
+    )
     options_without_target = prql.CompileOptions(format=False, signature_comment=False)
-    options_with_unknown_target = prql.CompileOptions(format=False, signature_comment=False, target="foo")
+    options_with_unknown_target = prql.CompileOptions(
+        format=False, signature_comment=False, target="foo"
+    )
 
     assert prql.compile(query_mssql).startswith("SELECT\n  TOP (3) *\nFROM\n  a")
-    assert prql.compile(query_mssql, options_with_known_target) == "SELECT * FROM a LIMIT 3"
-    assert prql.compile(query_mssql, options_without_target) == "SELECT TOP (3) * FROM a"
+    assert (
+        prql.compile(query_mssql, options_with_known_target)
+        == "SELECT * FROM a LIMIT 3"
+    )
+    assert (
+        prql.compile(query_mssql, options_without_target) == "SELECT TOP (3) * FROM a"
+    )
     # TODO: This should be unknown target error?
-    assert prql.compile(query_mssql, options_with_unknown_target) == "SELECT TOP (3) * FROM a"
+    assert (
+        prql.compile(query_mssql, options_with_unknown_target)
+        == "SELECT TOP (3) * FROM a"
+    )

--- a/prql-python/python/tests/test_all.py
+++ b/prql-python/python/tests/test_all.py
@@ -52,4 +52,4 @@ def test_compile_options():
 
     assert prql.compile(query_mssql).startswith("SELECT\n  TOP (3) *\nFROM\n  a")
     # TODO: This should be unknown target error?
-    assert prql.compile(query_mssql, options) == "SELECT * FROM a LIMIT 3"
+    assert prql.compile(query_mssql, options) == "SELECT TOP (3) * FROM a"

--- a/prql-python/src/lib.rs
+++ b/prql-python/src/lib.rs
@@ -95,7 +95,7 @@ impl CompileOptions {
 
 impl From<CompileOptions> for prql_compiler::Options {
     fn from(o: CompileOptions) -> Self {
-        let target = Target::from_str(&o.target).unwrap_or(Target::Sql(Some(Dialect::Generic)));
+        let target = Target::from_str(&o.target).unwrap_or_default();
 
         prql_compiler::Options {
             format: o.format,

--- a/prql-python/src/lib.rs
+++ b/prql-python/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
 use std::str::FromStr;
 
-use prql_compiler::{self, sql::Dialect, IntoOnly, Target};
+use prql_compiler::{self, IntoOnly, Target};
 use pyo3::{exceptions, prelude::*};
 
 #[pyfunction]

--- a/prql-python/src/lib.rs
+++ b/prql-python/src/lib.rs
@@ -84,7 +84,8 @@ pub struct CompileOptions {
 #[pymethods]
 impl CompileOptions {
     #[new]
-    pub fn new(format: bool, target: String, signature_comment: bool) -> Self {
+    pub fn new(format: bool, signature_comment: bool, target: Option<String>) -> Self {
+        let target = target.unwrap_or_default();
         CompileOptions {
             format,
             target,


### PR DESCRIPTION
Part of #1855

Update to fall back to the target specified in the query header if no target is specified.