### PR TITLE
feat: Generate C header file for prql-lib

### DIFF
--- a/prql-lib/README.md
+++ b/prql-lib/README.md
@@ -82,3 +82,11 @@ func ToJSON(prql string) (string, error) {
     return "", errors.New(C.GoString(cstr))
 }
 ```
+
+## C header file
+
+The C header file `libprql_lib.h` was generated using [cbindgen](https://github.com/eqrion/cbindgen).
+To generate a new one run:
+
+    cargo install --force cbindgen
+    cbindgen --crate prql-lib --output libprql_lib.h

--- a/prql-lib/README.md
+++ b/prql-lib/README.md
@@ -85,8 +85,8 @@ func ToJSON(prql string) (string, error) {
 
 ## C header file
 
-The C header file `libprql_lib.h` was generated using [cbindgen](https://github.com/eqrion/cbindgen).
-To generate a new one run:
+The C header file `libprql_lib.h` was generated using
+[cbindgen](https://github.com/eqrion/cbindgen). To generate a new one run:
 
     cargo install --force cbindgen
     cbindgen --crate prql-lib --output libprql_lib.h

--- a/prql-lib/cbindgen.toml
+++ b/prql-lib/cbindgen.toml
@@ -1,0 +1,1 @@
+language = "C"

--- a/prql-lib/libprql_lib.h
+++ b/prql-lib/libprql_lib.h
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * # Safety
+ *
+ * This function is inherently unsafe because it is using C ABI.
+ */
+int to_sql(const char *query, char *out);
+
+/**
+ * # Safety
+ *
+ * This function is inherently unsafe because it using C ABI.
+ */
+int to_json(const char *query, char *out);


### PR DESCRIPTION
The C header file `libprql_lib.h` was generated using [cbindgen](https://github.com/eqrion/cbindgen).
To generate a new one run:

    cargo install --force cbindgen
    cbindgen --crate prql-lib --output libprql_lib.h

Closes #1858