### PR TITLE
build(js): Fix wasm-pack's use of `.gitignore`

### DIFF
--- a/prql-js/README.md
+++ b/prql-js/README.md
@@ -173,4 +173,4 @@ npm test
 [^1]:
     Though we would be very open to other approaches, given wasm-pack does not
     seem maintained, and we're eliding many of its features to build for three
-    targets.
+    targets. See <https://github.com/PRQL/prql/issues/1836> for more details.

--- a/prql-js/package.json
+++ b/prql-js/package.json
@@ -18,9 +18,9 @@
   },
   "scripts": {
     "build": "npm run build:node && npm run build:bundler && npm run build:web",
-    "build:bundler": "wasm-pack build --target bundler --release --out-dir dist/bundler",
-    "build:node": "wasm-pack build --target nodejs --release --out-dir dist/node",
-    "build:web": "wasm-pack build --target no-modules --release --out-dir dist/web",
+    "build:bundler": "wasm-pack build --target bundler --release --out-dir dist/bundler && rm dist/bundler/.gitignore",
+    "build:node": "wasm-pack build --target nodejs --release --out-dir dist/node && rm dist/node/.gitignore",
+    "build:web": "wasm-pack build --target no-modules --release --out-dir dist/web && rm dist/web/.gitignore",
     "test": "wasm-pack test --firefox && mocha tests"
   },
   "types": "dist/node/prql_js.d.ts",


### PR DESCRIPTION
Closes https://github.com/PRQL/prql/issues/1875. Not sure why this used to work and doesn't work, but the `.gitignore`s were causing no files to be added to the package. Now we hackily remove them.

This event adds weight to https://github.com/PRQL/prql/issues/1836
