### PR TITLE
ci: Run non-core tests through `test-all.yaml`

### DIFF
--- a/.github/workflows/test-elixir.yaml
+++ b/.github/workflows/test-elixir.yaml
@@ -1,9 +1,6 @@
 name: test-elixir
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - "prql-elixir/**"

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -1,9 +1,6 @@
 name: test-java
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - "prql-java/**"

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -1,9 +1,6 @@
 name: test-js
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - "prql-js/**"

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -1,9 +1,6 @@
 name: test-python
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - "prql-python/**"

--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -2,9 +2,6 @@
 name: test-taskfile
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, reopened, synchronize, labeled]
     paths:

--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -3,7 +3,6 @@ name: test-taskfile
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
     paths:
       - Taskfile.yml
       - .github/workflows/test-taskfile.yaml


### PR DESCRIPTION
As pointed out in https://github.com/PRQL/prql/pull/1860/files#r1112279486, we're currently running these tests twice — once because they're in the `test-all.yaml` workflow, which is called on `main` commits, and once because they're called on `main` themselves.

This disables them being called by `main` commits.

It's possible the existing mode is required to generate caches; let's try disabling and assess, though.
