### PR TITLE
chore: Add changelog for #1883

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - [prql-php] Added PHP bindings (@vanillajonathan, #1860)
 - [prql-lib] Added C header file (@vanillajonathan, #1879)
+- Added a workflow building a `.deb` on each release. (Note that it's not yet
+  published on each release). (@vanillajonathan, #1883)
 
 **Internal changes**:
 


### PR DESCRIPTION
As requested by @vanillajonathan.

@vanillajonathan one thing we could add for all these is to upload them as artifacts, as an easy way to have them published, using something like https://github.com/PRQL/prql/pull/1883#discussion_r1112342801.

It's less permanent than publishing them as release assets, but we can do the artifact upload now without changing our release process.
