### PR TITLE
internal: Implement std::error::Error for ErrorMessages

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use ariadne::Source;
 use clap::Parser;
 use clio::{Input, Output};
@@ -98,17 +98,13 @@ impl Cli {
         // we could possibly extract that, but not sure it would neatly .
         Ok(match self {
             Cli::Parse(_) => {
-                let ast = prql_to_pl(source).map_err(|e| anyhow!(e))?;
+                let ast = prql_to_pl(source)?;
 
                 serde_yaml::to_string(&ast)?.into_bytes()
             }
-            Cli::Format(_) => prql_to_pl(source)
-                .and_then(pl_to_prql)
-                .map_err(|x| anyhow!(x))?
-                .as_bytes()
-                .to_vec(),
+            Cli::Format(_) => prql_to_pl(source).and_then(pl_to_prql)?.as_bytes().to_vec(),
             Cli::Debug(_) => {
-                let stmts = prql_to_pl(source).map_err(|x| anyhow!(x))?;
+                let stmts = prql_to_pl(source)?;
                 let (stmts, context) = semantic::resolve_only(stmts, None)?;
 
                 let (references, stmts) =
@@ -122,7 +118,7 @@ impl Cli {
                 .concat()
             }
             Cli::Annotate(_) => {
-                let stmts = prql_to_pl(source).map_err(|x| anyhow!(x))?;
+                let stmts = prql_to_pl(source)?;
 
                 // resolve
                 let (stmts, _) = semantic::resolve_only(stmts, None)?;
@@ -133,15 +129,12 @@ impl Cli {
                 combine_prql_and_frames(source, frames).as_bytes().to_vec()
             }
             Cli::Resolve(_) => {
-                let ast = prql_to_pl(source).map_err(|x| anyhow!(x))?;
+                let ast = prql_to_pl(source)?;
                 let ir = semantic::resolve(ast)?;
 
                 serde_json::to_string_pretty(&ir)?.into_bytes()
             }
-            Cli::Compile(_) => compile(source, &Options::default())
-                .map_err(|x| anyhow!(x))?
-                .as_bytes()
-                .to_vec(),
+            Cli::Compile(_) => compile(source, &Options::default())?.as_bytes().to_vec(),
             Cli::Watch(_) => unreachable!(),
         })
     }

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -430,7 +430,6 @@ impl From<ExprKind> for anyhow::Error {
     // https://github.com/bluejekyll/enum-as-inner/issues/84
     #[allow(unreachable_code)]
     fn from(kind: ExprKind) -> Self {
-        // panic!("Failed to convert {item}")
         anyhow!("Failed to convert `{}`", Expr::from(kind))
     }
 }
@@ -439,7 +438,6 @@ impl From<TransformKind> for anyhow::Error {
     // https://github.com/bluejekyll/enum-as-inner/issues/84
     #[allow(unreachable_code)]
     fn from(kind: TransformKind) -> Self {
-        // panic!("Failed to convert {item}")
         anyhow!("Failed to convert `{kind:?}`")
     }
 }

--- a/prql-compiler/src/error.rs
+++ b/prql-compiler/src/error.rs
@@ -120,6 +120,7 @@ impl Display for Error {
 pub struct ErrorMessages {
     pub inner: Vec<ErrorMessage>,
 }
+impl StdError for ErrorMessages {}
 
 impl From<ErrorMessage> for ErrorMessages {
     fn from(e: ErrorMessage) -> Self {


### PR DESCRIPTION
Not sure whether this has other implications. It allows for some code clean-up in `error.rs`