### PR TITLE
web: Attempt to default to the SQL view in playground

### DIFF
--- a/playground/src/examples.js
+++ b/playground/src/examples.js
@@ -1,6 +1,6 @@
 const examples = {
   "introduction.prql": [
-    "arrow",
+    "sql",
     `from invoices
 filter invoice_date >= @1970-01-16
 derive [                        # This adds columns
@@ -27,7 +27,7 @@ derive db_version = s"version()" # S-string, escape hatch to SQL
   ],
 
   "let-table-0.prql": [
-    "arrow",
+    "sql",
     `let soundtracks = (
   from playlists
   filter name == 'TV Shows'
@@ -56,7 +56,7 @@ take 10
   ],
 
   "artists-0.prql": [
-    "arrow",
+    "sql",
     `from tracks
 select [album_id, name, unit_price]
 sort [-unit_price, name]


### PR DESCRIPTION
At attempt to solve https://github.com/PRQL/prql/issues/1779

This doesn't seem to work though — it still defaults to the arrow tab. I tried opening in Incognito but that doesn't help clear the state. 

@aljazerzen I know it's not fun if you build something cool, and then people nag you for support — but do you have any ideas of where the default gets set?