### PR TITLE
feat: Add compile function to library

### DIFF
--- a/prql-lib/libprql_lib.h
+++ b/prql-lib/libprql_lib.h
@@ -3,6 +3,33 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+typedef struct CompileOptions {
+  /**
+   * Pass generated SQL string trough a formatter that splits it
+   * into multiple lines and prettifies indentation and spacing.
+   *
+   * Defaults to true.
+   */
+  bool format;
+  /**
+   * Target and dialect to compile to.
+   */
+  const char *target;
+  /**
+   * Emits the compiler signature as a comment after generated SQL
+   *
+   * Defaults to true.
+   */
+  bool signature_comment;
+} CompileOptions;
+
+/**
+ * # Safety
+ *
+ * This function is inherently unsafe because it is using C ABI.
+ */
+const char *compile(const char *query, struct CompileOptions options);
+
 /**
  * # Safety
  *

--- a/prql-lib/src/lib.rs
+++ b/prql-lib/src/lib.rs
@@ -35,7 +35,7 @@ impl From<CompileOptions> for Options {
             ""
         };
 
-        let target = Target::from_str(&target_str).unwrap_or_default();
+        let target = Target::from_str(target_str).unwrap_or_default();
 
         Options {
             format: o.format,

--- a/prql-lib/src/lib.rs
+++ b/prql-lib/src/lib.rs
@@ -3,8 +3,8 @@
 extern crate libc;
 
 use libc::{c_char, c_int};
-use prql_compiler::{Options, Target};
 use prql_compiler::{json, prql_to_pl};
+use prql_compiler::{Options, Target};
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::str::FromStr;
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn compile(query: *const c_char, options: CompileOptions) 
 
     let result = match prql_compiler::compile(&prql_query, &Options::from(options)) {
         Ok(sql_str) => sql_str,
-        Err(_) => "".to_string()
+        Err(_) => "".to_string(),
     };
 
     let c_string = CString::new(result).unwrap();

--- a/prql-lib/src/lib.rs
+++ b/prql-lib/src/lib.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn compile(query: *const c_char, options: CompileOptions) 
     };
 
     let c_string = CString::new(result).unwrap();
-    
+
     c_string.into_raw()
 }
 

--- a/prql-lib/src/lib.rs
+++ b/prql-lib/src/lib.rs
@@ -3,10 +3,65 @@
 extern crate libc;
 
 use libc::{c_char, c_int};
-use prql_compiler::Options;
+use prql_compiler::{Options, Target};
 use prql_compiler::{json, prql_to_pl};
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::str::FromStr;
+
+#[repr(C)]
+pub struct CompileOptions {
+    /// Pass generated SQL string trough a formatter that splits it
+    /// into multiple lines and prettifies indentation and spacing.
+    ///
+    /// Defaults to true.
+    pub format: bool,
+
+    /// Target and dialect to compile to.
+    pub target: *const c_char,
+
+    /// Emits the compiler signature as a comment after generated SQL
+    ///
+    /// Defaults to true.
+    pub signature_comment: bool,
+}
+
+impl From<CompileOptions> for Options {
+    fn from(o: CompileOptions) -> Self {
+        let target_str = if o.target.is_null() {
+            let c_str = unsafe { CStr::from_ptr(o.target) };
+            c_str.to_str().unwrap()
+        } else {
+            ""
+        };
+
+        let target = Target::from_str(&target_str).unwrap_or_default();
+
+        Options {
+            format: o.format,
+            target,
+            signature_comment: o.signature_comment,
+        }
+    }
+}
+
+#[no_mangle]
+//#[allow(non_snake_case)]
+/// # Safety
+///
+/// This function is inherently unsafe because it is using C ABI.
+pub unsafe extern "C" fn compile(query: *const c_char, options: CompileOptions) -> *const c_char {
+    let prql_query: String = CStr::from_ptr(query).to_string_lossy().into_owned();
+
+    let result = match prql_compiler::compile(&prql_query, &Options::from(options)) {
+        Ok(sql_str) => sql_str,
+        Err(_) => "".to_string()
+    };
+
+    let c_string = CString::new(result).unwrap();
+    
+    c_string.into_raw()
+}
 
 #[no_mangle]
 #[allow(non_snake_case)]


### PR DESCRIPTION
I need someone to review this.

Should the struct be named `CompileOptions` or `CompilerOptions`?
Should the struct be passed as `options` or `&options`?

I named it `CompileOptions` because that is what it is named in the Python binding.
The `compile` C library function returns a string (well a `*const c_char`), just like the in the Python binding, however contrary to the Rust code itself which returns a  `Result<T>` enum containing the success result or an [ErrorMessage](https://docs.rs/prql-compiler/latest/prql_compiler/struct.ErrorMessage.html) struct. On error it returns a empty string.

You can test it with the following program:
```c
#include <stdio.h>

#include <libprql_lib.h>

int main() {
    char *prql_query;
    prql_query = "from albums | select [album_id, title] | take 3";

    struct CompileOptions options;
    options.format = true;
    options.signature_comment = true;
    options.target = "haha";

    const char *sql_query = compile(prql_query, options);

    printf("%s", sql_query);
    return 0;
}
```

Closes #1859