### PR TITLE
test: Disable PHP tests until aligned with `prql-lib`

### DIFF
--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -38,5 +38,7 @@ jobs:
           args: --working-dir=prql-php
           php_extensions: FFI
       - name: 🧪 Run tests using PHPUnit
+        # TODO: enable when aligned with https://github.com/PRQL/prql/pull/1941
+        if: false
         run: vendor/bin/phpunit tests
         working-directory: prql-php


### PR DESCRIPTION
Just to ensure the build stays green as discussed in https://discord.com/channels/936728116712316989/1078360136978022510.

Thanks to @aljazerzen & @vanillajonathan for the changes.
