### PR TITLE
feat: Add a `--format=yaml` option to `prqlc parse`

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -18,7 +18,7 @@ use crate::watch;
 pub fn main() -> color_eyre::eyre::Result<()> {
     env_logger::builder().format_timestamp(None).init();
     color_eyre::install()?;
-    let mut cli = dbg!(Cli::parse());
+    let mut cli = Cli::parse();
 
     if let Err(error) = cli.run() {
         eprintln!("{error}");

--- a/prql-compiler/prqlc/src/watch.rs
+++ b/prql-compiler/prqlc/src/watch.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 
 use crate::jinja;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 pub struct WatchCommand {
     /// Directory or file to watch for changes
     pub path: OsString,


### PR DESCRIPTION
Would close #1912 

Unfortunately it doesn't work on producing RQ, because `serde_yaml` doesn't seem to support its AST. I added a link to the relevant `serde_yaml` code inline.

RQ serialization works in the playground because we serialize to YAML in JS.

---

I think this might need some refactoring before merging — it currently adds a `--format` option to every command, but actually only works on one. This might mean we need to make an Args struct for each command (the Args struct is currently named `CommandIO`).