### PR TITLE
chore: Remove reference to pest grammar

### DIFF
--- a/book/src/internals/syntax-highlighting.md
+++ b/book/src/internals/syntax-highlighting.md
@@ -30,8 +30,3 @@ an index.
   and helix. The grammar can be found at
   [https://github.com/matthias-Q/tree-sitter-prql](https://github.com/matthias-Q/tree-sitter-prql).
   This is in a very early stage.
-
-While the [pest](https://pest.rs/) grammar at
-[`prql-compiler/src/parser/prql.pest`](https://github.com/PRQL/prql/blob/main/prql-compiler/src/parser/prql.pest)
-isn't used for syntax highlighting, it's the arbiter of truth given it currently
-powers the PRQL compiler.


### PR DESCRIPTION
This was causing a build failure on main
