### PR TITLE
test: repro timestamp parsing issue

### DIFF
--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -3320,3 +3320,20 @@ fn test_params() {
     "###
     );
 }
+
+#[test]
+fn test_datetime_parsing() {
+    assert_display_snapshot!(compile(r#"
+    from test_tables
+    select [date = @2022-12-31, time = @08:30, timestamp = @2020-01-01T13:19:55-0800]
+    "#).unwrap(),
+        @r###"
+      SELECT
+        DATE '2022-12-31' AS date,
+        TIME '08:30' AS time,
+        TIMESTAMP '2020-01-01T13:19:55-0800' AS timestamp
+      FROM
+        test_table
+    "###
+    );
+}

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -3322,6 +3322,7 @@ fn test_params() {
 }
 
 #[test]
+#[should_panic]
 fn test_datetime_parsing() {
     assert_display_snapshot!(compile(r#"
     from test_tables

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -3321,6 +3321,7 @@ fn test_params() {
     );
 }
 
+// TODO: fix this based on https://github.com/PRQL/prql/pull/1818
 #[test]
 #[should_panic]
 fn test_datetime_parsing() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1975118/221717133-88ed6267-8535-45a1-9f50-48cd16d6b4d3.png)

This is the output I got from 0.5.2