### PR TITLE
devops: Add `bacon` config file

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,7 +58,7 @@ tasks:
     cmds:
       # `--locked` installs from the underlying lock files (which is not the
       # default?!)
-      - cargo install --locked cargo-audit cargo-insta cargo-release
+      - cargo install --locked bacon cargo-audit cargo-insta cargo-release
         default-target mdbook mdbook-admonish mdbook-toc wasm-bindgen-cli
         wasm-pack
         # Can't install atm with `--locked`

--- a/bacon.toml
+++ b/bacon.toml
@@ -36,8 +36,8 @@ need_stdout = false
 # If the doc compiles, then it opens in your browser and bacon switches
 # to the previous job
 [jobs.doc-open]
-command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"] 
-need_stdout = false 
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
 # You can run your application and have the result displayed in bacon,

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,64 @@
+# Initial bacon config file; edits and contributions welcome.
+
+default_job = "check"
+
+# PRQL additions
+[jobs.test-rust-fast]
+command = ['cargo', 'insta', 'test', '--accept', "--color=always", "-p=prql-compiler", "--lib"]
+[jobs.test-rust]
+command = ['cargo', 'insta', 'test', '--accept', "--color=always"]
+
+# Standard tasks
+
+[jobs.check]
+command = ["cargo", "check", "--color", "always"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.clippy]
+command = ["cargo", "clippy", "--all-targets", "--color", "always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.test]
+command = ["cargo", "test", "--color", "always"]
+need_stdout = true
+watch = ["tests"]
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# If the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"] 
+need_stdout = false 
+on_success = "back" # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate. You can run an example the same
+# way. Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+# If you want to pass options to your program, a `--` separator
+# will be needed.
+[jobs.run]
+allow_warnings = true
+command = ["cargo", "run", "--color", "always"]
+need_stdout = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal prefs.toml file instead.
+[keybindings]
+a = "job:check-all"
+c = "job:clippy"
+d = "job:doc-open"
+i = "job:initial"
+r = "job:run"
+t = "job:test"


### PR DESCRIPTION
I recently discovered `bacon`, which is great (thanks to @snth for the link), and replaces some of the `watchexec` and `task` watch tasks.

This is an initial config file; it'll get some updates as folks use it more. I'll also update `development.md` once I've used it more (unless anyone gets there first...).
