### PR TITLE
fix: Allow no `:` in timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Add a `--format` option to `prqlc parse` which can return the AST in YAML
   (@max-sixty, #1962)
 - Support for SQL parameters with similar syntax (#1957, @aljazerzen)
+- Allow `:` to be elided in timezones, such as `0800` in
+  `@2020-01-01T13:19:55-0800` (@max-sixty, #1991).
 
 **Fixes**:
 

--- a/book/src/language-features/dates-and-times.md
+++ b/book/src/language-features/dates-and-times.md
@@ -36,8 +36,8 @@ derive should_have_shipped_today = (order_time < @08:30)
 
 Timestamps are represented by `@{yyyy-mm-ddTHH:mm:ss.SSS±Z}` / `@{date}T{time}`,
 with any time parts not supplied being rounded to zero, including the timezone,
-which is represented by `+HH:mm`, `-HH:mm` or `Z`. This is `@` followed by the
-ISO8601 datetime format, which uses `T` to separate date & time.
+which is represented by `+HH:mm`, `-HH:mm` or `Z` (`:` is optional). This is `@`
+followed by the ISO8601 datetime format, which uses `T` to separate date & time.
 
 ```prql
 from commits
@@ -66,9 +66,9 @@ derive first_check_in = start + 10days
 
 Here's a fuller list of examples:
 
-- `@20221231` is forbidden — it must contain full punctuation (`-` and `:`),
+- `@20221231` is invalid — it must contain full punctuation (`-` and `:`),
 - `@2022-12-31` is a date
-- `@2022-12` or `@2022` are forbidden — SQL can't express a month, only a date
+- `@2022-12` or `@2022` are invalid — SQL can't express a month, only a date
 - `@16:54:32.123456` is a time
 - `@16:54:32`, `@16:54`, `@16` are all allowed, expressing `@16:54:32.000000`,
   `@16:54:00.000000`, `@16:00:00.000000` respectively
@@ -76,8 +76,8 @@ Here's a fuller list of examples:
 - `@2022-12-31T16:54:32.123456Z` is a timestamp in UTC
 - `@2022-12-31T16:54+02` is timestamp in UTC+2
 - `@2022-12-31T16:54+02:00` and `@2022-12-31T16:54+02` are datetimes in UTC+2
-- `@16:54+02` is forbidden — time is always local, so it cannot have a timezone
-- `@2022-12-31+02` is forbidden — date is always local, so it cannot have a
+- `@16:54+02` is invalid — time is always local, so it cannot have a timezone
+- `@2022-12-31+02` is invalid — date is always local, so it cannot have a
   timezone
 
 ## Roadmap

--- a/prql-compiler/src/parser/lexer.rs
+++ b/prql-compiler/src/parser/lexer.rs
@@ -230,9 +230,15 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
         .chain::<char, _, _>(
             one_of("-+")
                 .chain(
-                    digits(2)
-                        .chain(just(':'))
-                        .chain(digits(2))
+                    // TODO: This is repeated without the `:`~ with an `or`
+                    // because using `.or_not` triggers a request for
+                    // type hints, which seems difficult to provide... Is there
+                    // an easier way?
+                    //
+                    //   (digits(2).chain(just(':').or_not()).chain(digits(2)))
+                    //
+                    (digits(2).chain(just(':')).chain(digits(2)))
+                        .or(digits(2).chain(digits(2)))
                         .or(just('Z').map(|x| vec![x])),
                 )
                 .or_not()

--- a/prql-compiler/src/test.rs
+++ b/prql-compiler/src/test.rs
@@ -3331,21 +3331,19 @@ fn test_params() {
     );
 }
 
-// TODO: fix this based on https://github.com/PRQL/prql/pull/1818
 #[test]
-#[should_panic]
 fn test_datetime_parsing() {
     assert_display_snapshot!(compile(r#"
     from test_tables
     select [date = @2022-12-31, time = @08:30, timestamp = @2020-01-01T13:19:55-0800]
     "#).unwrap(),
         @r###"
-      SELECT
-        DATE '2022-12-31' AS date,
-        TIME '08:30' AS time,
-        TIMESTAMP '2020-01-01T13:19:55-0800' AS timestamp
-      FROM
-        test_table
+    SELECT
+      DATE '2022-12-31' AS date,
+      TIME '08:30' AS time,
+      TIMESTAMP '2020-01-01T13:19:55-0800' AS timestamp
+    FROM
+      test_tables
     "###
     );
 }


### PR DESCRIPTION
Fixes issue in #1818
