### PR TITLE
fix: Allow unicode in identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - `prqlc compile` returns a non-zero exit code for invalid queries. (@max-sixty,
   #1924)
+- Identifiers can contain any alphabetic unicode characters (@max-sixty, #2003)
 
 **Documentation**:
 

--- a/prql-compiler/src/parser/lexer.rs
+++ b/prql-compiler/src/parser/lexer.rs
@@ -115,11 +115,9 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, std::ops::Range<usize>)>, Error 
 }
 
 pub fn ident_part() -> impl Parser<char, String, Error = Cheap<char>> {
-    let plain = filter(|c: &char| c.is_ascii_alphabetic() || *c == '_')
+    let plain = filter(|c: &char| c.is_alphabetic() || *c == '_')
         .map(Some)
-        .chain::<char, Vec<_>, _>(
-            filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_').repeated(),
-        )
+        .chain::<char, Vec<_>, _>(filter(|c: &char| c.is_alphanumeric() || *c == '_').repeated())
         .collect();
 
     let backticks = just('`')

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -2214,6 +2214,22 @@ join s=salaries [==id]
     }
 
     #[test]
+    fn test_unicode() {
+        let source = "from tète";
+        assert_yaml_snapshot!(parse(source).unwrap(), @r###"
+        ---
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - from
+              args:
+                - Ident:
+                    - tète
+        "###);
+    }
+
+    #[test]
     fn test_error_unicode_string() {
         // Test various unicode strings successfully parse errors. We were
         // getting loops in the lexer before.


### PR DESCRIPTION
Closes #2003. Thanks to @vanillajonathan for the report.
