### PR TITLE
docs: update changelog about sql.any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - Float literals without fraction part are not allowed anymore (`1.`).
 - Add a `--format` option to `prqlc parse` which can return the AST in YAML
   (@max-sixty, #1962)
+- A new spacial compile target `"sql.any"`.
+  When `"sql.any"` is used as the target of the compile function's option,
+  the target contained in the query header will be used.
+  (@aljazerzen, #1995)
 - Support for SQL parameters with similar syntax (#1957, @aljazerzen)
 - Allow `:` to be elided in timezones, such as `0800` in
   `@2020-01-01T13:19:55-0800` (@max-sixty, #1991).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,9 @@
   - Float literals without fraction part are not allowed anymore (`1.`).
 - Add a `--format` option to `prqlc parse` which can return the AST in YAML
   (@max-sixty, #1962)
-- A new spacial compile target `"sql.any"`.
-  When `"sql.any"` is used as the target of the compile function's option,
-  the target contained in the query header will be used.
-  (@aljazerzen, #1995)
+- A new spacial compile target `"sql.any"`. When `"sql.any"` is used as the
+  target of the compile function's option, the target contained in the query
+  header will be used. (@aljazerzen, #1995)
 - Support for SQL parameters with similar syntax (#1957, @aljazerzen)
 - Allow `:` to be elided in timezones, such as `0800` in
   `@2020-01-01T13:19:55-0800` (@max-sixty, #1991).


### PR DESCRIPTION
The target priority (option of the compile function v.s. query header) and `"sql.any"` behavior is not fully explained in the book and prql-compiler documentation, so I think the documentation needs to be improved, but for now, only the changelog update is included in this PR.