### PR TITLE
build: add definitions for devcontainer base image

### DIFF
--- a/.devcontainer/base-image/Dockerfile
+++ b/.devcontainer/base-image/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/devcontainers/rust:0.203.7-1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        cmake \
+    && rm -rf /var/lib/apt/lists/* \
+    && sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
+# ========= Install cargo-tools for non-root user (vscode) =========
+COPY Taskfile.yml /tmp/Taskfile.yml
+WORKDIR /tmp
+USER vscode
+RUN task install-cargo-tools
+
+USER root

--- a/.devcontainer/base-image/Dockerfile
+++ b/.devcontainer/base-image/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
 # ========= Install cargo-tools for non-root user (vscode) =========
-COPY Taskfile.yml /tmp/Taskfile.yml
+COPY Taskfile.cargo-tools.yml /tmp/Taskfile.cargo-tools.yml
 WORKDIR /tmp
 USER vscode
-RUN task install-cargo-tools
+RUN task -t Taskfile.cargo-tools.yml install
 
 USER root

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,13 @@ updates:
     commit-message:
       prefix: "chore: "
 
+  - package-ecosystem: docker
+    directory: .devcontainer/base-image
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore: "
+
   # For actions (rather than workflows), we need to list each directory, ref
   # https://github.com/dependabot/dependabot-core/issues/5137, from https://github.com/dependabot/dependabot-core/issues/4178#issuecomment-1118492006
   - directory: ".github/actions/build-prql-js"

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -1,0 +1,63 @@
+name: devcontainer
+
+on:
+  push:
+    # ToDo: Add partial Taskfile (only include rust-tools)
+    paths:
+      - .devcontainer/base-image/Dockerfile
+  pull_request:
+    paths:
+      - .devcontainer/base-image/Dockerfile
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/prql-devcontainer-base
+          tags: |
+            type=raw,latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - id: set-platforms
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "platforms=linux/amd64,linux/arm64" >>$GITHUB_OUTPUT
+            echo "push=true" >>$GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64" >>$GITHUB_OUTPUT
+            echo "push=false" >>$GITHUB_OUTPUT
+          fi
+
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          file: "./.devcontainer/base-image/Dockerfile"
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ steps.set-platforms.outputs.platforms }}
+          push: ${{ steps.set-platforms.outputs.push }}
+          cache-from: |
+            ${{ env.IMAGE_NAME }}
+            type=gha
+          cache-to: |
+            type=inline
+            type=gha,mode=max

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -2,12 +2,13 @@ name: devcontainer
 
 on:
   push:
-    # ToDo: Add partial Taskfile (only include rust-tools)
     paths:
       - .devcontainer/base-image/Dockerfile
+      - Taskfile.cargo-tools.yml
   pull_request:
     paths:
       - .devcontainer/base-image/Dockerfile
+      - Taskfile.cargo-tools.yml
   workflow_dispatch:
 
 concurrency:

--- a/Taskfile.cargo-tools.yml
+++ b/Taskfile.cargo-tools.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://json.schemastore.org/taskfile.json
+
+version: 3
+
+tasks:
+  install:
+    # factored this out because it takes a long time to build
+    desc: Install cargo tools for PRQL development.
+    cmds:
+      # `--locked` installs from the underlying lock files (which is not the
+      # default?!)
+      - cargo install --locked bacon cargo-audit cargo-insta cargo-release
+        default-target mdbook mdbook-admonish mdbook-toc wasm-bindgen-cli
+        wasm-pack
+        # Can't install atm with `--locked`
+      - cargo install mdbook-footnote
+      - cmd: |
+          [ "$(which cargo-insta)" ] || echo "🔴 Can't find a binary that cargo just installed. Is the cargo bin path (generally at ~/.cargo/bin) on the \$PATH?"
+        silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,6 +52,17 @@ tasks:
           🟢 Setup complete! ✅🚀"
         silent: true
 
+  setup-devcontainer:
+    desc: Install tools for PRQL development (Rust, JS, Python).
+    cmds:
+      - task: install-maturin
+      - task: install-npm-dependencies
+      - task: install-cargo-tools
+      - cmd: |
+          echo "
+          🟢 Setup complete! ✅🚀"
+        silent: true
+
   install-cargo-tools:
     # factored this out because it takes a long time to build
     desc: Install cargo tools for PRQL development.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,9 @@
 
 version: "3"
 
+includes:
+  cargo-tools: ./Taskfile.cargo-tools.yml
+
 vars:
   # Keep in sync with .vscode/extensions.json
   vscode_extensions: |
@@ -38,7 +41,7 @@ tasks:
 
     desc: Install tools for PRQL development.
     cmds:
-      - task: install-cargo-tools
+      - task: cargo-tools:install
       - task: install-brew-dependencies
       - task: install-maturin
       - task: install-pre-commit
@@ -52,31 +55,11 @@ tasks:
           🟢 Setup complete! ✅🚀"
         silent: true
 
-  setup-devcontainer:
-    desc: Install tools for PRQL development (Rust, JS, Python).
-    cmds:
-      - task: install-maturin
-      - task: install-npm-dependencies
-      - task: install-cargo-tools
-      - cmd: |
-          echo "
-          🟢 Setup complete! ✅🚀"
-        silent: true
-
   install-cargo-tools:
     # factored this out because it takes a long time to build
-    desc: Install cargo tools for PRQL development.
-    cmds:
-      # `--locked` installs from the underlying lock files (which is not the
-      # default?!)
-      - cargo install --locked bacon cargo-audit cargo-insta cargo-release
-        default-target mdbook mdbook-admonish mdbook-toc wasm-bindgen-cli
-        wasm-pack
-        # Can't install atm with `--locked`
-      - cargo install mdbook-footnote
-      - cmd: |
-          [ "$(which cargo-insta)" ] || echo "🔴 Can't find a binary that cargo just installed. Is the cargo bin path (generally at ~/.cargo/bin) on the \$PATH?"
-        silent: true
+    desc: Alias of `cargo-tools:install`
+    deps:
+      - cargo-tools:install
 
   install-maturin:
     desc: Install maturin.


### PR DESCRIPTION
Split from #1893
Push a Docker image with the time-consuming cargo packages installed to GHCR.

Changes are also included to separate only the `install-cargo-tools` task in the Taskfile referenced in the Dockerfile into a separate Taskfile, from a Dokcer cache perspective.