### PR TITLE
build: fix concurrency of devcontainer.yaml

### DIFF
--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The workflow has been cancelled between multiple branches because of improper settings in #2025.