### PR TITLE
build: fix docker build workflows

### DIFF
--- a/.devcontainer/base-image/Dockerfile
+++ b/.devcontainer/base-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/rust:0.203.7-1
+FROM mcr.microsoft.com/devcontainers/rust:0.203.8-1-bullseye
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -52,7 +52,8 @@ jobs:
         with:
           file: "./.devcontainer/base-image/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/arm64
+          # TODO: add linux/arm64
+          platforms: linux/amd64
           push: ${{ steps.set-options.outputs.push }}
           cache-from: |
             ${{ env.IMAGE_NAME }}

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           file: "./.devcontainer/base-image/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: ${{ steps.set-options.outputs.push }}
           cache-from: |
             ${{ env.IMAGE_NAME }}

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -39,13 +39,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - id: set-platforms
+      - id: set-options
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "platforms=linux/amd64,linux/arm64" >>$GITHUB_OUTPUT
             echo "push=true" >>$GITHUB_OUTPUT
           else
-            echo "platforms=linux/amd64" >>$GITHUB_OUTPUT
             echo "push=false" >>$GITHUB_OUTPUT
           fi
 
@@ -54,8 +52,8 @@ jobs:
         with:
           file: "./.devcontainer/base-image/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: ${{ steps.set-platforms.outputs.platforms }}
-          push: ${{ steps.set-platforms.outputs.push }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.set-options.outputs.push }}
           cache-from: |
             ${{ env.IMAGE_NAME }}
             type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,10 @@ RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/loc
 
 # ========= Set up workdir & copy the taskfile =========
 WORKDIR /src
-COPY Taskfile.yml .
+COPY Taskfile.cargo-tools.yml .
 
 # ========= Install cargo-tools =========
-RUN task install-cargo-tools
+RUN task -t Taskfile.cargo-tools.yml install
 
 # TODO: currently this doesn't support doing things like running the playground,
 # since we don't install hugo & node. Default `apt` doesn't install up-to-date


### PR DESCRIPTION
Follow up #2025

Fix CI job failures after #2025 merge.
We have found that linux/arm64 builds do not succeed easily, so we will only push arm64 builds for now.