### PR TITLE
feat: Add man page for prqlc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,8 @@ jobs:
           mkdir -p .debpkg/usr/bin
           cp target/release/prqlc .debpkg/usr/bin/prqlc
           chmod +x .debpkg/usr/bin/prqlc
+          mkdir -p .rpmpkg/usr/share/man
+          cp prql-compiler/prqlc.1 .rpmpkg/usr/share/man
       - name: 📦 Build .deb package
         uses: jiro4989/build-deb-action@v2
         with:
@@ -63,6 +65,8 @@ jobs:
           mkdir -p .rpmpkg/usr/bin
           cp target/release/prqlc .rpmpkg/usr/bin/prqlc
           chmod +x .rpmpkg/usr/bin/prqlc
+          mkdir -p .rpmpkg/usr/share/man
+          cp prql-compiler/prqlc.1 .rpmpkg/usr/share/man
       - name: 📦 Build .rpm package
         uses: jiro4989/build-rpm-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
           cp target/release/prqlc .debpkg/usr/bin/prqlc
           chmod +x .debpkg/usr/bin/prqlc
           mkdir -p .rpmpkg/usr/share/man
-          cp prql-compiler/prqlc.1 .rpmpkg/usr/share/man
+          cp prql-compiler/prqlc/prqlc.1 .rpmpkg/usr/share/man
       - name: 📦 Build .deb package
         uses: jiro4989/build-deb-action@v2
         with:
@@ -66,7 +66,7 @@ jobs:
           cp target/release/prqlc .rpmpkg/usr/bin/prqlc
           chmod +x .rpmpkg/usr/bin/prqlc
           mkdir -p .rpmpkg/usr/share/man
-          cp prql-compiler/prqlc.1 .rpmpkg/usr/share/man
+          cp prql-compiler/prqlc/prqlc.1 .rpmpkg/usr/share/man
       - name: 📦 Build .rpm package
         uses: jiro4989/build-rpm-action@v2
         with:

--- a/prql-compiler/prqlc.1
+++ b/prql-compiler/prqlc.1
@@ -1,0 +1,83 @@
+.\" prqlc man page.
+.\"
+.\" PRQL is a modern language for transforming data — a simple, powerful,
+.\" pipelined SQL replacement.
+.\"
+.\" https://prql-lang.org/
+.Dt prqlc 1
+.Os Linux
+.Sh NAME
+.Nm prqlc,
+.Nd PRQL compiler.
+.Sh SYNOPSIS
+.Pp
+.SY prqlc
+parse
+.Op Ar input
+.Op Ar output
+.YS
+.Pp
+.SY prqlc
+fmt
+.Op Ar input
+.Op Ar output
+.YS
+.Pp
+.SY prqlc
+annotate
+.Op Ar input
+.Op Ar output
+.YS
+.Pp
+.SY prqlc
+debug
+.Op Ar input
+.Op Ar output
+.YS
+.Pp
+.SY prqlc
+resolve
+.Op Ar input
+.Op Ar output
+.YS
+.Pp
+.SY prqlc
+compile
+.Op Ar options
+.Op Ar input
+.Op Ar output
+.YS
+.Pp
+.SY prqlc
+watch
+.Op Ar options
+path
+.YS
+.Pp
+.SY prqlc
+help
+.YS
+.Pp
+.Sh DESCRIPTION
+PRQL is a modern language for transforming data — a simple, powerful,
+pipelined SQL replacement.
+.Pp
+Flags:
+.Bl -tag
+.It Fl h
+Print help
+.It Fl v
+Print version
+.El
+.Pp
+Flags for the compile option:
+.Bl -tag
+.It Fl -no-format
+do not format the output
+.It Fl -no-signature
+do not print the PRQL signature
+.El
+.Sh FILES                \" File used or created by the topic of the man page
+.Bl -tag -width "/Users/joeuser/Library/really_long_file_name" -compact
+.It Pa /usr/bin/prqlc
+The prqlc executable.

--- a/prql-compiler/prqlc/prqlc.1
+++ b/prql-compiler/prqlc/prqlc.1
@@ -8,7 +8,7 @@
 .Os Linux
 .Sh NAME
 .Nm prqlc
-.Nd PRQL compiler.
+.And PRQL compiler.
 .Sh SYNOPSIS
 .Pp
 .SY prqlc
@@ -85,7 +85,7 @@ The
 executable.
 .Sh DIAGNOSTICS
 .Nm
-returns zero on normal operation, 1 on error. 
+returns zero on normal operation, 1 on error.
 .Sh BUGS
 Report any  bugs on https://github.com/PRQL/prql/issues
 .Sh AUTHOR

--- a/prql-compiler/prqlc/prqlc.1
+++ b/prql-compiler/prqlc/prqlc.1
@@ -7,7 +7,7 @@
 .Dt prqlc 1
 .Os Linux
 .Sh NAME
-.Nm prqlc,
+.Nm prqlc
 .Nd PRQL compiler.
 .Sh SYNOPSIS
 .Pp
@@ -78,6 +78,15 @@ do not format the output
 do not print the PRQL signature
 .El
 .Sh FILES                \" File used or created by the topic of the man page
-.Bl -tag -width "/Users/joeuser/Library/really_long_file_name" -compact
+.Bl -tag
 .It Pa /usr/bin/prqlc
-The prqlc executable.
+The
+.Nm
+executable.
+.Sh DIAGNOSTICS
+.Nm
+returns zero on normal operation, 1 on error. 
+.Sh BUGS
+Report any  bugs on https://github.com/PRQL/prql/issues
+.Sh AUTHOR
+PRQL team


### PR DESCRIPTION
Man pages for Unix-like systems such as Linux, BSD and macOS.

    $ man prqlc

You can live preview this on https://roperzh.github.io/grapse/

Here is the documentation for `groff` which explains the syntax https://manpages.debian.org/testing/groff/groff_mdoc.7.en.html

I haven't written any manual pages before so I don't know if this is semantically idiomatic but it is a start.