### PR TITLE
docs: Move task docs out of devcontainers

### DIFF
--- a/book/src/contributing/developing-with-dev-containers.md
+++ b/book/src/contributing/developing-with-dev-containers.md
@@ -20,21 +20,3 @@ is on developing with VS Code in a container by
 To use a Dev Container on a local computer with VS Code, install the
 [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 and its system requirements. Then refer to the links above to get started.
-
-## Using PRQL in a Dev Container
-
-[Task](https://taskfile.dev/) is installed in the container for quick access to
-tasks defined on the `Taskfiles.yml`.
-
-Here are some useful commands available in the container.
-
-- `task -l` lists all the available tasks.
-- `task run-book` starts an `mdbook` server. As you edit the files of the
-  Language Book (in the `book` directory), `mdbook` rebuilds those pages.
-  (Port 3000)
-- `task run-website` starts a `hugo` server. As you edit the files (in the
-  `website` directory), `hugo` rebuilds those pages. (Port 1313)
-- `task run-playground` starts a Node server to build the Playground. As you
-  edit the files (in the `playground` directory), the server rebuilds those
-  pages. (Port 3000)
-- `task WHAT ELSE?` _Provide explanation of other useful commands._


### PR DESCRIPTION
These are good docs, but there's no reason for them to be here. They'd be good in the Taskfile, or very open to other suggestions

While I _really_ appreciate docs that we write (CC @richb-hanover ), it's important that they're focused, concise, and close to the code that they document -- because they also need to be maintained, and the project takes on that responsibility.

I really don't want to lose folks' generosity and ideas, but I'm going to start being a bit firmer on these sorts of things, because we're already starting to see some stale docs (#2044). There are other ways of writing things that have fewer guarantees of continued support -- blog posts, gists, etc.
