### PR TITLE
docs: Add a new policy for bindings support

### DIFF
--- a/book/src/bindings/README.md
+++ b/book/src/bindings/README.md
@@ -36,6 +36,7 @@ nascent.
 
 - [Java](./java.md)
 - [Elixir](./elixir.md)
+- `prql-lib`, the C bindings
 
 ## Nascent
 

--- a/book/src/bindings/README.md
+++ b/book/src/bindings/README.md
@@ -2,11 +2,44 @@
 
 PRQL has bindings for many languages. These include:
 
-- [Java](./java.md)
+We have three tiers of bindings:
+
+- Supported
+- Unsupported
+- Nascent
+
+## Supported
+
+Supported bindings require:
+
+- A maintainer.
+- Implementations of the
+  [core compile functions](https://docs.rs/prql-compiler/latest/prql_compiler/#functions).
+- Test coverage for these functions.
+- A published package to the language's standard package repository.
+- A script in `Taskfile.yml` to bootstrap a development environment.
+- Any dev tools, such as a linter & formatter, in pre-commit or MegaLinter.
+
 - [JavaScript](./javascript.md)
-- [.NET](./net.md)
-- [PHP](./php.md)
 - [Python](./python.md)
 - [R](./r.md)
 - [Rust](./rust.md)
+
+Most of these are in the main PRQL repo, and we gate any changes to the
+compiler's API on compatible changes to the bindings.
+
+## Unsupported
+
+Unsupported bindings work, but don't fulfil all of the above criteria. We don't
+gate changes to the compiler's API. If they stop working, we'll demote them to
+nascent.
+
+- [Java](./java.md)
 - [Elixir](./elixir.md)
+
+## Nascent
+
+Nascent bindings are in development, and may not yet fully work.
+
+- [.NET](./net.md)
+- [PHP](./php.md)


### PR DESCRIPTION
As discussed on Discord:
- I / we are very grateful for the contributions of folks such as @vanillajonathan & @linux-china & @kasvith for adding bindings to PRQL
- We're currently in a place where upgrading `prql-lib` is quite difficult, and @aljazerzen has spent lots of time on this in the last few days, because some of the bindings are initial early efforts
- It's great to have these initial early efforts — everything starts out small before it becomes big
- But we shouldn't gate the changes to PRQL on the compatibility of these yet, because it slows down PRQL development

So this establishes three tiers of support, and proposes to only gate PRQL changes on bindings that have sufficient support and tooling.

When we have more support & tooling, then we can promote these to "Supported"

Does this make sense to folks?