### PR TITLE
ci: Adjust logic to skip publish on forks v2

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -15,7 +15,8 @@ jobs:
   build-web:
     runs-on: ubuntu-latest
 
-    # Skip running workflow on forks
+    # Skip running workflow on forks. This still runs on PRs, but then below we
+    # disable it from attempting to publish.
     if: github.repository_owner == 'prql'
 
     steps:
@@ -65,12 +66,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Commenting out as I think it's duplicative with the check below; TODO:
-    # delete assuming everything works OK.
-    #
-    # Don't attempt to publish if on a fork (it'll fail the workflow even if it
-    # otherwise builds successfully)
-    # if: "!github.event.pull_request.head.repo.fork"
+    # Don't attempt to publish if on a fork, including a PR.
+    if: "!github.event.pull_request.head.repo.fork"
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -15,11 +15,8 @@ jobs:
   build-web:
     runs-on: ubuntu-latest
 
-    # Commenting out as I think it's duplicative with the check below; TODO:
-    # delete assuming everything works OK.
-    #
-    # # Skip running workflow on forks
-    # if: github.repository_owner == 'prql'
+    # Skip running workflow on forks
+    if: github.repository_owner == 'prql'
 
     steps:
       - name: Setup Pages
@@ -68,9 +65,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
+    # Commenting out as I think it's duplicative with the check below; TODO:
+    # delete assuming everything works OK.
+    #
     # Don't attempt to publish if on a fork (it'll fail the workflow even if it
     # otherwise builds successfully)
-    if: "!github.event.pull_request.head.repo.fork"
+    # if: "!github.event.pull_request.head.repo.fork"
 
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This failed on my fork (https://github.com/max-sixty/prql/actions/runs/4381956672/jobs/7670531376), so trying with the exclusion location swapped