### PR TITLE
refactor: Unify duplicated logic in book tests

### DIFF
--- a/book/src/lib.rs
+++ b/book/src/lib.rs
@@ -96,58 +96,68 @@ impl Preprocessor for ComparisonPreprocessor {
     }
 }
 
+pub fn code_block_lang<'a>(event: &'a Event) -> Option<&'a str> {
+    if let Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(lang))) = event {
+        Some(lang.as_ref())
+    } else {
+        None
+    }
+}
+
 fn replace_examples(text: &str) -> Result<String> {
     let mut parser = Parser::new_ext(text, Options::all());
     let mut cmark_acc = vec![];
 
     while let Some(event) = parser.next() {
-        match event.clone() {
-            // Duplicative repetitive logic here and in
-            // [snapshot.rs/collect_book_examples]; could we unify?
-            Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(lang)))
-                if lang.starts_with("prql") =>
-            {
-                let Some(Event::Text(text)) = parser.next()
-                else {
-                    bail!("Expected text after PRQL code block")
-                };
-                let prql = text.to_string();
-                let options = prql_compiler::Options::default().no_signature();
-                let result = &compile(&prql, &options);
-                match lang.to_string().as_str() {
-                    "prql" | "prql_no_fmt" => cmark_acc.push(Event::Html(
-                        table_of_comparison(
-                            &prql,
-                            result
-                                .clone()
-                                .unwrap_or_else(|_| {
-                                    panic!("{}", format!("Query raised an error: {prql}"))
-                                })
-                                .as_str(),
-                        )
-                        .into(),
-                    )),
-                    "prql_error" => cmark_acc.push(Event::Html(
-                        table_of_error(
-                            &prql,
-                            result
-                                .clone()
-                                .expect_err(
-                                    &format!("Query was labeled to raise an error, but succeeded.\n {prql}").to_string(),
-                                )
-                                .to_string()
-                                .as_str(),
-                        )
-                        .into(),
-                    )),
-                    "prql_no_test" => {}
-                    _ => bail!("Unknown code block language: {}", lang),
-                };
+        if let Some(lang) = code_block_lang(&event) {
+            let Some(Event::Text(text)) = parser.next()
+            else {
+                bail!("Expected text within code block")
+            };
+            let prql = text.to_string();
+            let options = prql_compiler::Options::default().no_signature();
+            let result = compile(&prql, &options);
 
-                // Skip ending tag
-                parser.next();
-            }
-            _ => cmark_acc.push(event.to_owned()),
+            match lang {
+                "prql" | "prql_no_fmt" => cmark_acc.push(Event::Html(
+                    table_of_comparison(
+                        &prql,
+                        result
+                            .unwrap_or_else(|_| {
+                                panic!("{}", format!("Query raised an error:\n\n {prql}\n\n"))
+                            })
+                            .as_str(),
+                    )
+                    .into(),
+                )),
+                "prql_error" => cmark_acc.push(Event::Html(
+                    table_of_error(
+                        &prql,
+                        result
+                            .expect_err(
+                                &format!(
+                                    "Query was labeled to raise an error, but succeeded.\n {prql}\n\n"
+                                )
+                                .to_string(),
+                            )
+                            .to_string()
+                            .as_str(),
+                    )
+                    .into(),
+                )),
+                "prql_no_test" => {}
+                _ => {
+                    if lang.starts_with("prql") {
+                        bail!("Unknown code block language: {}", lang)
+                    } else {
+                        cmark_acc.push(event.to_owned())
+                    }
+                }
+            };
+            // Skip ending tag
+            parser.next();
+        } else {
+            cmark_acc.push(event.to_owned())
         }
     }
     let mut buf = String::new();


### PR DESCRIPTION
It's not some super elegant abstraction, but pulls the complicated match into a function
