### PR TITLE
web: Remove underline from logo

### DIFF
--- a/website/themes/prql-theme/static/style.css
+++ b/website/themes/prql-theme/static/style.css
@@ -155,8 +155,9 @@ pre ::-webkit-scrollbar-thumb:hover {
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
 }
 
-#header .logo img {
+#header .logo {
   max-height: 50px;
+  text-decoration: none;
 }
 
 #header .logo h1 {


### PR DESCRIPTION
Ref https://github.com/PRQL/prql/pull/1667. Even if we want it for the headings, it's not the logo. We could replace the logo with an image of the text (which we have available) if we want to be strict about text links having underline?
