### PR TITLE
chore(ci): Bump cache keys

### DIFF
--- a/.github/workflows/test-lib.yaml
+++ b/.github/workflows/test-lib.yaml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-lib:
     runs-on: ubuntu-latest
     steps:
       - name: 📂 Checkout code
@@ -22,12 +22,13 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ inputs.target_option }}
+          key: 0.6.0-${{ inputs.target_option }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build
         uses: richb-hanover/cargo@v1.1.0
         with:
           command: build
+          # Currently requires a release build; would be useful to allow a debug build.
           args: --release -p prql-lib
       - name: Run basic C example
         working-directory: prql-lib/examples/minimal-c

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -13,7 +13,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  test-rust:
     runs-on: ${{ inputs.os }}
     steps:
       - name: 📂 Checkout code
@@ -25,8 +25,7 @@ jobs:
           # reset the cache. If necessary, we could do this on each release and
           # have this update automatically (there's no variable that contains
           # the current version unfortunately, though).
-          prefix-key: "0.5.2"
-          key: ${{ inputs.target_option }}
+          key: 0.6.0-${{ inputs.target_option }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: baptiste0928/cargo-install@next
         with:
@@ -54,9 +53,11 @@ jobs:
       - uses: baptiste0928/cargo-install@next
         with:
           crate: cargo-insta
-      # Only check unreferenced snapshots on the default target tests on ubuntu (maybe
-      # there's a nicer approach where we can parameterize one step rather than
-      # have two different ones; we welcome a change to simplify this)
+      # Only check unreferenced snapshots on the default target tests on ubuntu
+      #
+      # (Maybe there's a nicer approach where we can parameterize one step
+      # rather than have two different ones? We welcome a change to simplify
+      # this.)
       - name: 📋 Test
         uses: richb-hanover/cargo@v1.1.0
         if:

--- a/prql-lib/examples/minimal-c/Makefile
+++ b/prql-lib/examples/minimal-c/Makefile
@@ -3,6 +3,7 @@ PRQL_PROJECT=../../..
 build-prql:
 	cargo build -p prql-lib --release
 
+# TODO: would be helpful to allow running with a debug build too.
 build: main.c build-prql
 	gcc main.c -o main.out \
 		-I${PRQL_PROJECT}/prql-lib \


### PR DESCRIPTION
Currently we've run out of cache space and are going to start churning soon. `prql-lib` is taking up 1.3GB; going to try bumping that and seeing if it still needs that much.
