### PR TITLE
ci: Ensure we don't cache dependencies of binaries

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -31,11 +31,6 @@ jobs:
       - name: Setup hugo
         uses: peaceiris/actions-hugo@v2.6.0
 
-      # Book setup, duplicated from `pull-request.yaml`
-      - name: 💰 Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/web' }}
       - uses: baptiste0928/cargo-install@next
         with:
           crate: mdbook
@@ -45,6 +40,11 @@ jobs:
       - uses: baptiste0928/cargo-install@next
         with:
           crate: mdbook-admonish
+      # Book setup, duplicated from `pull-request.yaml`
+      - name: 💰 Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/web' }}
 
       - uses: ./.github/actions/build-prql-js
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -42,10 +42,6 @@ jobs:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
         # Duplicated in `publish-web.yaml`
-      - name: 💰 Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: baptiste0928/cargo-install@next
         with:
           crate: mdbook
@@ -55,6 +51,10 @@ jobs:
       - uses: baptiste0928/cargo-install@next
         with:
           crate: mdbook-admonish
+      - name: 💰 Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: 🔨 Build
         run: mdbook build
         working-directory: book/

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -66,6 +66,8 @@ jobs:
         uses: actions/checkout@v3
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -18,6 +18,13 @@ jobs:
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@next
+        with:
+          crate: wasm-bindgen-cli
+        if: inputs.target_option == '--target=wasm32-unknown-unknown'
+      - uses: baptiste0928/cargo-install@next
+        with:
+          crate: cargo-insta
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -27,10 +34,6 @@ jobs:
           # the current version unfortunately, though).
           key: 0.6.0-${{ inputs.target_option }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: baptiste0928/cargo-install@next
-        with:
-          crate: wasm-bindgen-cli
-        if: inputs.target_option == '--target=wasm32-unknown-unknown'
       - name: 📎 Clippy
         uses: richb-hanover/cargo@v1.1.0
         with:
@@ -50,9 +53,6 @@ jobs:
         with:
           command: test
           args: ${{ inputs.target_option }} --no-run --locked
-      - uses: baptiste0928/cargo-install@next
-        with:
-          crate: cargo-insta
       # Only check unreferenced snapshots on the default target tests on ubuntu
       #
       # (Maybe there's a nicer approach where we can parameterize one step


### PR DESCRIPTION
This moves the Cache step to _after_ the `cargo install` steps
