### PR TITLE
chore(prql-php): Add PHPStan configuration file

### DIFF
--- a/bindings/prql-php/phpstan.neon
+++ b/bindings/prql-php/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    ignoreErrors:
+        - '#^Call to an undefined method FFI::compile\(\)\.$#'
+        - '#^Call to an undefined method FFI::prql_to_pl\(\)\.$#'
+        - '#^Call to an undefined method FFI::pl_to_rq\(\)\.$#'
+        - '#^Call to an undefined method FFI::rq_to_sql\(\)\.$#'
+        - '#^Cannot access property \$format on FFI\\CData\|null\.$#'
+        - '#^Cannot access property \$signature_comment on FFI\\CData\|null\.$#'
+        - '#^Cannot access property \$target on FFI\\CData\|null\.$#'

--- a/bindings/prql-php/phpstan.neon
+++ b/bindings/prql-php/phpstan.neon
@@ -1,9 +1,13 @@
 parameters:
+    level: 9
+    paths:
+        - src
+        - tests
     ignoreErrors:
-        - '#^Call to an undefined method FFI::compile\(\)\.$#'
-        - '#^Call to an undefined method FFI::prql_to_pl\(\)\.$#'
-        - '#^Call to an undefined method FFI::pl_to_rq\(\)\.$#'
-        - '#^Call to an undefined method FFI::rq_to_sql\(\)\.$#'
-        - '#^Cannot access property \$format on FFI\\CData\|null\.$#'
-        - '#^Cannot access property \$signature_comment on FFI\\CData\|null\.$#'
-        - '#^Cannot access property \$target on FFI\\CData\|null\.$#'
+        - '#Call to an undefined method FFI::compile\(\)\.#'
+        - '#Call to an undefined method FFI::prql_to_pl\(\)\.#'
+        - '#Call to an undefined method FFI::pl_to_rq\(\)\.#'
+        - '#Call to an undefined method FFI::rq_to_sql\(\)\.#'
+        - '#Cannot access property \$format on FFI\\CData\|null\.#'
+        - '#Cannot access property \$signature_comment on FFI\\CData\|null\.#'
+        - '#Cannot access property \$target on FFI\\CData\|null\.#'

--- a/bindings/prql-php/phpstan.neon
+++ b/bindings/prql-php/phpstan.neon
@@ -4,6 +4,7 @@ parameters:
         - src
         - tests
     ignoreErrors:
+    # Since [PHPStan](https://phpstan.org/) doesn't know about the existence of the functions in libprql, it complains since they get dynamically invoked on the FFI object instance without being statically defined, so they're unknown.
         - '#Call to an undefined method FFI::compile\(\)\.#'
         - '#Call to an undefined method FFI::prql_to_pl\(\)\.#'
         - '#Call to an undefined method FFI::pl_to_rq\(\)\.#'

--- a/bindings/prql-php/phpstan.neon
+++ b/bindings/prql-php/phpstan.neon
@@ -4,7 +4,9 @@ parameters:
         - src
         - tests
     ignoreErrors:
-    # Since [PHPStan](https://phpstan.org/) doesn't know about the existence of the functions in libprql, it complains since they get dynamically invoked on the FFI object instance without being statically defined, so they're unknown.
+        # Since PHPStan doesn't know about the existence of the functions in libprql,
+        # it complains since they get dynamically invoked on the FFI object instance
+        # without being statically defined, so they're unknown.
         - '#Call to an undefined method FFI::compile\(\)\.#'
         - '#Call to an undefined method FFI::prql_to_pl\(\)\.#'
         - '#Call to an undefined method FFI::pl_to_rq\(\)\.#'


### PR DESCRIPTION
Since [PHPStan](https://phpstan.org/) doesn't know about the existence of the functions in libprql it complains since they get dynamically invoked on the FFI object instance without being statically defined so they're unknown.

https://phpstan.org/config-reference