### PR TITLE
chore(prql-php): Cache the FFI

### DIFF
--- a/bindings/prql-php/README.md
+++ b/bindings/prql-php/README.md
@@ -23,7 +23,7 @@ use Prql\Compiler\Compiler;
 $prql = new Compiler();
 $result = $prql->compile("from employees");
 
-echo($result->output);
+echo $result->output;
 ```
 
 ## Development


### PR DESCRIPTION
Declare the private FFI instance  as static in order to avoid the expensive reinitialization of the FFI on every class instantiation.

A bit like in the example at:
https://www.php.net/manual/en/ffi.examples-complete.php

From the docs:
> FFI definition parsing and shared library loading may take significant time. It is not useful to do it on each HTTP request in a Web environment. However, it is possible to preload FFI definitions and libraries at PHP startup, and to instantiate FFI objects when necessary. 

https://www.php.net/manual/en/class.ffi.php