### PR TITLE
refactor: Move `snap` to `packages` path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,8 @@ jobs:
         uses: actions/checkout@v3
       - name: 📦 Build Snap
         uses: snapcore/action-build@v1
+        with:
+          path: packages/
       - name: 🆙 Publish Snap
         uses: snapcore/action-publish@v1
         env:

--- a/packages/snap/snapcraft.yaml
+++ b/packages/snap/snapcraft.yaml
@@ -14,12 +14,12 @@ website: https://prql-lang.org/
 license: Apache-2.0
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict
-icon: website/themes/prql-theme/static/icon.svg
+icon: ../web/website/themes/prql-theme/static/icon.svg
 
 parts:
   prqlc:
     plugin: rust
-    source: .
+    source: ..
     rust-path: [prql-compiler/prqlc]
 
 apps:


### PR DESCRIPTION
...in line with the broader refactor.

I'm not sure of the best way of testing this; our current `release.yaml` isn't really set up to test things. Possibly we wait until the next release and fix if it's broken -- not ideal but maybe the lowest cost approach?
