### PR TITLE
ci: Run `publish-web` on releases

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - web
+  # Even though releases push to `web` branch, that doesn't cause this workflow
+  # to run, because GHA can't start workflows itself. So we also run on
+  # releases.
+  release:
+    types: [released]
   # Called by pull-request when specifically requested
   workflow_call:
 
@@ -15,8 +20,9 @@ jobs:
   build-web:
     runs-on: ubuntu-latest
 
-    # Skip running workflow on forks. This still runs on PRs, but then below we
-    # disable it from attempting to publish.
+    # Skip running workflow on forks. Checking the repository owner still allows
+    # this to be run on PRs, and then below we disable it from attempting to
+    # publish.
     if: github.repository_owner == 'prql'
 
     steps:


### PR DESCRIPTION
Notes inline.

---

A quick reflection (CC @aljazerzen @snth @mklopets) — I don't think we made the correct tradeoff on this `stable` / `web` branch concept in https://github.com/PRQL/prql/issues/1507 .

This is one of a dozen small issues that have come up, and we're still short https://github.com/PRQL/prql/issues/2122, and having problems like https://github.com/PRQL/prql/pull/2144 as a result. It's been lots of finicky work, mostly falling on me (better than it falling on @aljazerzen , but still getting in the way of critical-path work). I maintain just releasing quicker would have got us most of the benefits.

More generally, I think we should be very wary of taking on anything that slows the development velocity. That includes language features, or code to support (https://github.com/PRQL/prql/pull/2062), as well as devops practices like this. 

Even if the initial work seems minimal, a long tail of issues will come up. And if those issues are critical for the project — such as deploying the website, or being able to change an API, or removing bugs in the compiler — then it's going to obligate us to allocate away from other work.

I put some more weight on that final comment in #1507 — having a contribution-weighted vote is fine for a one-off decision. But for things like this that are critical and will need maintenance, we also need to find someone enthusiastic to own them.

---

I'm torn on whether I propose we revert this branch model and go back to the old model of just being on `main`, at least until we feel a more pressing need from users. On balance, given that most of it is working OK, I think we should probably leave it as-is for a while and see how it goes.