### PR TITLE
ci: Add back taskfile test

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -59,6 +59,9 @@ jobs:
   test-lib:
     uses: ./.github/workflows/test-lib.yaml
 
+  test-taskfile:
+    uses: ./.github/workflows/test-taskfile.yaml
+
   measure-code-cov:
     # Currently disabled due to https://github.com/actions-rs/tarpaulin/issues/21
     if: false

--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - Taskfile.yml
       - .github/workflows/test-taskfile.yaml
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-taskfile


### PR DESCRIPTION
This was mistakenly removed from `test-all`

It does take ages, so we could move it to nightly if needed. But adding back for the moment
