### PR TITLE
build(prql-js): Run `npm run build` as part of `npm install`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,9 +144,6 @@ jobs:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm run build
-        working-directory: bindings/prql-js
-
       - name: Publish package on npm
         run: npm publish
         working-directory: bindings/prql-js/

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -32,7 +32,5 @@ jobs:
         with:
           crate: wasm-pack
 
-      - run: npm run build
-        working-directory: bindings/prql-js
       - run: npm cit
         working-directory: bindings/prql-js

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -242,9 +242,8 @@ tasks:
         website/public/playground/playground
 
   test-js:
-    dir: prql-js
+    dir: bindings/prql-js
     cmds:
-      - npm run build
       - npm cit
 
   # Currently disabled; see prql-elixir/README.md for details

--- a/bindings/prql-js/package.json
+++ b/bindings/prql-js/package.json
@@ -21,6 +21,7 @@
     "build:bundler": "wasm-pack build --target bundler --release --out-dir dist/bundler && rm dist/bundler/.gitignore",
     "build:node": "wasm-pack build --target nodejs --release --out-dir dist/node && rm dist/node/.gitignore",
     "build:web": "wasm-pack build --target no-modules --release --out-dir dist/web && rm dist/web/.gitignore",
+    "preinstall": "npm run build",
     "test": "mocha tests"
   },
   "types": "dist/node/prql_js.d.ts",

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -29,6 +29,7 @@
     },
     "../../bindings/prql-js": {
       "version": "0.6.1",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.6",


### PR DESCRIPTION
This means everything is in a single command. If it slows down development, we can revert
