### PR TITLE
docs: Fix Playground sidebar

### DIFF
--- a/web/playground/src/sidebar/Sidebar.css
+++ b/web/playground/src/sidebar/Sidebar.css
@@ -14,8 +14,13 @@ section h1 {
 section h2 {
   text-transform: uppercase;
   font-weight: bold;
-  font-size: 12px;
+  font-size: 14px;
   margin: 0;
+}
+
+.fileRow::before {
+  content: "\00a0"; /* non-breaking space to indent fileRows */
+  margin-right: 5px;
 }
 .fileRow:hover {
   cursor: pointer;
@@ -32,16 +37,17 @@ section h2 {
 }
 
 .folderRow::before {
-  content: "\1F892 ";
+  /* disclosure triangle to show hierarchy */
+  content: "\00a0\00a0\25b7"; /* two non-breaking spaces and a white right triangle */
+  font-size: 0.75em; /* a little smaller */
   margin-right: 5px;
   display: inline-block;
   transition: transform 0.3s ease;
   transform-origin: center;
-  transform: scale(1.25, 1.25);
 }
 
 .folderRow.open::before {
-  transform: scale(1.25, 1.25) rotate(90deg);
+  transform: rotate(90deg);
 }
 
 section h1,

--- a/web/playground/src/sidebar/Sidebar.js
+++ b/web/playground/src/sidebar/Sidebar.js
@@ -70,22 +70,24 @@ function Sidebar({ library, onLoadFile }) {
       </section>
       <section>
         <h2>External links</h2>
-        <a
-          className="fileRow"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://prql-lang.org"
-        >
-          PRQL Website &#8599;
-        </a>
-        <a
-          className="fileRow"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://prql-lang.org/book/"
-        >
-          Book &#8599;
-        </a>
+        <div className="fileRow">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://prql-lang.org"
+          >
+            PRQL Website &#8599;
+          </a>
+        </div>
+        <div className="fileRow">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://prql-lang.org/book/"
+          >
+            Book &#8599;
+          </a>
+        </div>
       </section>
 
       {sections}


### PR DESCRIPTION
Fix disclosure ("twisty") triangles in Playground
Make section headings larger to match file names
Use white right-facing triangle - U+25b7 
Make the triangle a little smaller than the text
Put a non-breaking space in front of "fileRow" to indent them 
Wrap the PRQL website and Book links in a .fileRow div to indent them 
