### PR TITLE
build: Speed up playground build slightly

### DIFF
--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "npm run genBook && react-scripts build",
     "eject": "npm run genBook && react-scripts eject",
-    "preinstall": "cp -r ../../prql-compiler/tests/integration/data public && cd ../../bindings/prql-js && npm run build:bundler",
+    "preinstall": "cp -r ../../prql-compiler/tests/integration/data public",
     "start": "npm run genBook && react-scripts start",
     "test": "npm run genBook && react-scripts test",
     "genBook": "node generateBook.js"


### PR DESCRIPTION
We no longer need to run a build command in the playground on `prql-js`, since the command is now part of `prql-js`'s `preinstall`.

This givs us some speedup — 23s down from 32s — but most of the time is still taken up by re-running `wasm-opt`.

There's an issue for this in https://github.com/rustwasm/wasm-pack/issues/1152. But probably `wasm-opt` should be run by `build.rs` which knows whether it requires re-running based on changed input files https://doc.rust-lang.org/cargo/reference/build-scripts.html

I think the current state is probably OK — we still get instant feedback when developming the playground; this is only required when _starting_ the playground or changing `prql-js`
