### PR TITLE
chore: revert temporary megalinter settings from #2234

### DIFF
--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -41,9 +41,8 @@ jobs:
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
-          # VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref
-          #   == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Override with true if you always want to lint all sources
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref
+            == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Override with true if you always want to lint all sources
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
           # DISABLE: COPYPASTE,SPELL # Uncomment to disable copy-paste and spell checks


### PR DESCRIPTION
Revert settings changes from #2234.
It would be easier to see if only the Linter associated with the file changed in PR is displayed in the results.