### PR TITLE
feat: Add option to output colors

### DIFF
--- a/bindings/prql-elixir/native/prql/src/lib.rs
+++ b/bindings/prql-elixir/native/prql/src/lib.rs
@@ -78,7 +78,7 @@ impl From<CompileOptions> for prql_compiler::Options {
             target: target_from_atom(o.target),
             signature_comment: o.signature_comment,
             // TODO: add support for this
-            use_colors: false,
+            color: false,
         }
     }
 }

--- a/bindings/prql-elixir/native/prql/src/lib.rs
+++ b/bindings/prql-elixir/native/prql/src/lib.rs
@@ -77,6 +77,8 @@ impl From<CompileOptions> for prql_compiler::Options {
             format: o.format,
             target: target_from_atom(o.target),
             signature_comment: o.signature_comment,
+            // TODO: add support for this
+            use_colors: false,
         }
     }
 }

--- a/bindings/prql-java/src/lib.rs
+++ b/bindings/prql-java/src/lib.rs
@@ -27,6 +27,8 @@ pub extern "system" fn Java_org_prql_prql4j_PrqlCompiler_toSql(
         format: format != 0,
         target: prql_dialect,
         signature_comment: signature != 0,
+        // TODO: add support for this
+        use_colors: false,
     };
     let result = prql_compiler::compile(&prql_query, &opt);
     java_string_with_exception(result, &env)

--- a/bindings/prql-java/src/lib.rs
+++ b/bindings/prql-java/src/lib.rs
@@ -28,7 +28,7 @@ pub extern "system" fn Java_org_prql_prql4j_PrqlCompiler_toSql(
         target: prql_dialect,
         signature_comment: signature != 0,
         // TODO: add support for this
-        use_colors: false,
+        color: false,
     };
     let result = prql_compiler::compile(&prql_query, &opt);
     java_string_with_exception(result, &env)

--- a/bindings/prql-js/src/lib.rs
+++ b/bindings/prql-js/src/lib.rs
@@ -110,6 +110,8 @@ impl From<CompileOptions> for prql_compiler::Options {
             format: o.format,
             target,
             signature_comment: o.signature_comment,
+            // TODO: offer this option in the API
+            use_colors: false,
         }
     }
 }

--- a/bindings/prql-js/src/lib.rs
+++ b/bindings/prql-js/src/lib.rs
@@ -111,7 +111,7 @@ impl From<CompileOptions> for prql_compiler::Options {
             target,
             signature_comment: o.signature_comment,
             // TODO: offer this option in the API
-            use_colors: false,
+            color: false,
         }
     }
 }

--- a/bindings/prql-lib/src/lib.rs
+++ b/bindings/prql-lib/src/lib.rs
@@ -324,6 +324,6 @@ fn convert_options(o: &Options) -> Result<prql_compiler::Options, prql_compiler:
         target,
         signature_comment: o.signature_comment,
         // TODO: add support for this
-        use_colors: false,
+        color: false,
     })
 }

--- a/bindings/prql-lib/src/lib.rs
+++ b/bindings/prql-lib/src/lib.rs
@@ -323,5 +323,7 @@ fn convert_options(o: &Options) -> Result<prql_compiler::Options, prql_compiler:
         format: o.format,
         target,
         signature_comment: o.signature_comment,
+        // TODO: add support for this
+        use_colors: false,
     })
 }

--- a/bindings/prql-python/src/lib.rs
+++ b/bindings/prql-python/src/lib.rs
@@ -103,7 +103,7 @@ fn convert_options(
         target,
         signature_comment: o.signature_comment,
         // TODO: offer support
-        use_colors: false,
+        color: false,
     })
 }
 

--- a/bindings/prql-python/src/lib.rs
+++ b/bindings/prql-python/src/lib.rs
@@ -102,7 +102,7 @@ fn convert_options(
         format: o.format,
         target,
         signature_comment: o.signature_comment,
-        // TOOD: offer support
+        // TODO: offer support
         use_colors: false,
     })
 }

--- a/bindings/prql-python/src/lib.rs
+++ b/bindings/prql-python/src/lib.rs
@@ -102,6 +102,8 @@ fn convert_options(
         format: o.format,
         target,
         signature_comment: o.signature_comment,
+        // TOOD: offer support
+        use_colors: false,
     })
 }
 

--- a/prql-compiler/README.md
+++ b/prql-compiler/README.md
@@ -27,7 +27,8 @@ let prql = "from employees | select [name, age]";
 let opts = &Options {
     format: false,
     target: Target::Sql(Some(Dialect::SQLite)),
-    signature_comment: false
+    signature_comment: false,
+    use_colors: false,
 };
 let sql = compile(&prql, opts).unwrap();
 assert_eq!("SELECT name, age FROM employees", sql);

--- a/prql-compiler/README.md
+++ b/prql-compiler/README.md
@@ -28,7 +28,7 @@ let opts = &Options {
     format: false,
     target: Target::Sql(Some(Dialect::SQLite)),
     signature_comment: false,
-    use_colors: false,
+    color: false,
 };
 let sql = compile(&prql, opts).unwrap();
 assert_eq!("SELECT name, age FROM employees", sql);

--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -63,7 +63,7 @@ enum Command {
         input: Input,
         #[clap(value_parser, default_value = "-")]
         output: Output,
-        #[arg(value_enum, long)]
+        #[arg(value_enum, long, default_value = "yaml")]
         format: Format,
     },
 

--- a/prql-compiler/prqlc/src/watch.rs
+++ b/prql-compiler/prqlc/src/watch.rs
@@ -28,7 +28,7 @@ pub fn run(command: &mut WatchArgs) -> Result<()> {
         target: prql_compiler::Target::Sql(None),
         signature_comment: !command.no_signature,
         // TODO: potentially offer this as an arg?
-        use_colors: false,
+        color: false,
     };
     let path = Path::new(&command.path);
 

--- a/prql-compiler/prqlc/src/watch.rs
+++ b/prql-compiler/prqlc/src/watch.rs
@@ -27,6 +27,8 @@ pub fn run(command: &mut WatchArgs) -> Result<()> {
         format: !command.no_format,
         target: prql_compiler::Target::Sql(None),
         signature_comment: !command.no_signature,
+        // TODO: potentially offer this as an arg?
+        use_colors: false,
     };
     let path = Path::new(&command.path);
 

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -112,7 +112,8 @@ pub static PRQL_VERSION: Lazy<Version> =
 /// let opts = Options {
 ///     format: false,
 ///     target: Target::Sql(Some(Dialect::SQLite)),
-///     signature_comment: false
+///     signature_comment: false,
+///     use_colors: false,
 /// };
 /// let sql = compile(&prql, &opts).unwrap();
 /// println!("PRQL: {}\nSQLite: {}", prql, &sql);

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -125,7 +125,7 @@ pub fn compile(prql: &str, options: &Options) -> Result<String, ErrorMessages> {
         .and_then(semantic::resolve)
         .and_then(|rq| sql::compile(rq, options))
         .map_err(error::downcast)
-        .map_err(|e| e.composed("", prql, false))
+        .map_err(|e| e.composed("", prql, options.use_colors))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,6 +188,9 @@ pub struct Options {
     ///
     /// Defaults to true.
     pub signature_comment: bool,
+
+    /// Whether to use ANSI colors in error messages.
+    pub use_colors: bool,
 }
 
 impl Default for Options {
@@ -196,6 +199,7 @@ impl Default for Options {
             format: true,
             target: Target::Sql(None),
             signature_comment: true,
+            use_colors: false,
         }
     }
 }
@@ -218,6 +222,11 @@ impl Options {
 
     pub fn some(self) -> Option<Self> {
         Some(self)
+    }
+
+    pub fn with_colors(mut self, use_colors: bool) -> Self {
+        self.use_colors = use_colors;
+        self
     }
 }
 

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -113,7 +113,7 @@ pub static PRQL_VERSION: Lazy<Version> =
 ///     format: false,
 ///     target: Target::Sql(Some(Dialect::SQLite)),
 ///     signature_comment: false,
-///     use_colors: false,
+///     color: false,
 /// };
 /// let sql = compile(&prql, &opts).unwrap();
 /// println!("PRQL: {}\nSQLite: {}", prql, &sql);
@@ -126,7 +126,7 @@ pub fn compile(prql: &str, options: &Options) -> Result<String, ErrorMessages> {
         .and_then(semantic::resolve)
         .and_then(|rq| sql::compile(rq, options))
         .map_err(error::downcast)
-        .map_err(|e| e.composed("", prql, options.use_colors))
+        .map_err(|e| e.composed("", prql, options.color))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -191,7 +191,7 @@ pub struct Options {
     pub signature_comment: bool,
 
     /// Whether to use ANSI colors in error messages.
-    pub use_colors: bool,
+    pub color: bool,
 }
 
 impl Default for Options {
@@ -200,7 +200,7 @@ impl Default for Options {
             format: true,
             target: Target::Sql(None),
             signature_comment: true,
-            use_colors: false,
+            color: false,
         }
     }
 }
@@ -225,8 +225,8 @@ impl Options {
         Some(self)
     }
 
-    pub fn with_colors(mut self, use_colors: bool) -> Self {
-        self.use_colors = use_colors;
+    pub fn with_color(mut self, color: bool) -> Self {
+        self.color = color;
         self
     }
 }


### PR DESCRIPTION
This moves #1355 forward, and enables a PR to add colors to the book. The main thing to review is whether the proposed structure and naming of the options is reasonable.

~On the names — it's not that consistent — we have `signature_comment` — should this just be `colors` rather than `use_colors`? Or does `signature_comment` suggest it contains an actual comment? I've generally tried to make bools self-describing, but possible an options struct can be more implicit.~ 

Edit: this is now just a `color` property and `.with_color(self, color)` method, consistent with something like https://github.com/zesterer/ariadne/blob/ccd465160129d2546d67f7ee78727a4098a64330/src/lib.rs#L81. Possibly we should standardize around something like that

---

It's slightly different from the proposal in #1355  — it doesn't introduce another layer of options.
- I think possibly the code has changed slightly since then, since there was a discussion on whether to pass an `Options` struct to the `compile` function, which we now already do. 
- And I would vote to lean towards having a flatter, simpler, structure until we have lots of confidence in the eventual structure. 
  - (Separate point, ref #1840 — possibly that would have also made the initial contribution easier, which was well-described in #1355 but was a decent amount of work? Possibly we should be trying to make the initial contributions as tiny as possible, even at the cost of them requiring later refactorings?)

---

I'm not completely clear how we support colors in `prqlc` now...
- We're currently [passing `false` to the `composed` method](https://github.com/PRQL/prql/compare/main...max-sixty:prql:colors?expand=1#diff-d8cf470395314450935c363c0f82ef23888873d109e7df81e131728c66265e84L128-R128), which is passed through to ariadne [here](https://github.com/PRQL/prql/blob/107f3d71a56805c59fa217090d3d213a50711f8b/prql-compiler/src/error.rs#L246)
- But we are getting colors! 
  <img width="514" alt="image" src="https://user-images.githubusercontent.com/5635139/226216182-d554a3d1-35f9-49bb-8b4f-457b42069929.png">
- Possibly some combination of [Ariadne's features](https://github.com/zesterer/ariadne#cargo-features) and our [`color_eyre::install` usage](https://github.com/PRQL/prql/blob/79e5529413fecc66b824d1936e89ac3889f248fb/prql-compiler/prqlc/src/cli.rs#L20) auto configures it?
  - Though then how would we implement #1355 if passing `false` doesn't pass through to ariadne?

---

This doesn't implement support in bindings yet.