### PR TITLE
docs: Suggest following releases, rather than #1

### DIFF
--- a/web/book/src/contributing/README.md
+++ b/web/book/src/contributing/README.md
@@ -3,11 +3,13 @@
 If you're interested in joining the community to build a better SQL, here are
 ways to start:
 
-- Star this repo.
+- Star the [repo](https://github.com/PRQL/prql).
 - Send a link to PRQL to a couple of people whose opinion you respect.
-- Subscribe to [Issue #1](https://github.com/PRQL/prql/issues/1) for updates.
-- Join our [Discord](https://discord.gg/eQcfaCmsNc).
+- Subscribe to
+  [new releases](https://www.jessesquires.com/blog/2020/07/30/github-tip-watching-releases/)
+  for updates.
 - Follow us on [Twitter](https://twitter.com/prql_lang).
+- Join our [Discord](https://discord.gg/eQcfaCmsNc).
 - Find an issue labeled
   [Good First Issue](https://github.com/prql/prql/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
   and start contributing to the code.

--- a/web/book/src/contributing/development.md
+++ b/web/book/src/contributing/development.md
@@ -399,10 +399,7 @@ Currently we release in a semi-automated way:
 4. From there, both the tag and release is created and all packages are
    published automatically based on our
    [release workflow](https://github.com/PRQL/prql/blob/main/.github/workflows/release.yaml).
-5. Update Issue <https://github.com/PRQL/prql/issues/1> so that people will be
-   notified of the change.
-
-6. Add in the sections for a new Changelog:
+5. Add in the sections for a new Changelog:
 
    ```md
    ## 0.6.X — [unreleased]
@@ -421,5 +418,8 @@ Currently we release in a semi-automated way:
 
    **New Contributors**:
    ```
+
+6. Check whether there are [milestones](https://github.com/PRQL/prql/milestones)
+   that need to be pushed out.
 
 We may make this more automated in future; e.g. automatic changelog creation.


### PR DESCRIPTION
I haven't been successful at keeping #1 up-to-date, and it's better to not have something decayed here.

Also adds a suggestion to check milestones when doing releases
