### PR TITLE
web: Update links to Contributing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -761,8 +761,7 @@ Thank you!
 ## 0.2.2 - 2022-07-10
 
 We're a couple of weeks since our 0.2.0 release. Thanks for the surge in
-interest and contributions! 0.2.2[^1] has some fixes & some internal
-improvements:
+interest and contributions! 0.2.2 has some fixes & some internal improvements:
 
 - We now test against SQLite & DuckDB on every commit, to ensure we're producing
   correct SQL. (@aljazerzen )
@@ -786,9 +785,7 @@ We're planning to continue collecting bugs & feature requests from users, as
 well as working on some of the bigger features, like type-inference.
 
 For those interesting in joining, we also have a new
-[Contributing page](https://github.com/PRQL/prql/blob/main/CONTRIBUTING.md).
-
-[^1]: Think of 0.2.1 like C+ :)
+[Contributing page](https://github.com/PRQL/prql/blob/main/.github/CONTRIBUTING.md).
 
 ## 0.2.0 - 2022-06-27
 
@@ -838,10 +835,11 @@ Keep in touch with PRQL by following the project on
 [Discord](https://discord.gg/eQcfaCmsNc), starring the
 [repo](https://github.com/PRQL/prql).
 
-[Contribute](https://github.com/PRQL/prql/blob/main/CONTRIBUTING.md) to the
-project — we're a really friendly community, whether you're a recent SQL user or
-an advanced Rust programmer. We need bug reports, documentation tweaks & feature
-requests — just as much as we need compiler improvements written in Rust.
+[Contribute](https://github.com/PRQL/prql/blob/main/.github/CONTRIBUTING.md) to
+the project — we're a really friendly community, whether you're a recent SQL
+user or an advanced Rust programmer. We need bug reports, documentation tweaks &
+feature requests — just as much as we need compiler improvements written in
+Rust.
 
 ---
 

--- a/web/website/config.yml
+++ b/web/website/config.yml
@@ -42,23 +42,22 @@ params:
           PRQL? Send them a link to PRQL.
       - text:
           "Know Rust (or want to learn!)? [Contribute to our
-          compiler](https://github.com/PRQL/prql/blob/main/CONTRIBUTING.md#compiler)"
+          compiler](https://prql-lang.org/book/contributing/index.html#compiler)"
       - text:
           "Familiar with web? Spot a mistake? [Improve the website design or
-          copy](https://github.com/PRQL/prql/blob/main/CONTRIBUTING.md#integrations)"
+          copy](https://prql-lang.org/book/contributing/index.html#marketing)"
       - text:
-          "Interested in helping people explore their data? [Kick off our push
-          to improve our
-          playground](https://github.com/PRQL/prql/blob/main/CONTRIBUTING.md#ide)"
+          "Interested in helping people explore their data? [Help improve the
+          playground](https://github.com/PRQL/prql/tree/main/web/playground)"
       - text:
           "Is SQL your mother-tongue? [Show us SQL queries which translate well
           /
-          badly](https://github.com/PRQL/prql/blob/main/CONTRIBUTING.md#language-design).
+          badly](https://prql-lang.org/book/contributing/index.html#language-design).
           We are looking for any use-cases that expose a poor design choice, a
           need of a feature, or a sharp edge of the language."
     button:
       text: Contribute
-      link: https://github.com/PRQL/prql/blob/main/CONTRIBUTING.md
+      link: https://prql-lang.org/book/contributing/index.html
   follow:
     subtitle: "Follow us:"
     list:


### PR DESCRIPTION
Found this because of the move of `Compiler.md` with https://github.com/PRQL/prql/actions/runs/4471137034/jobs/7855612888?pr=2258, but actually these hadn't worked for a while. I think possibly the link checker isn't picking up these links in YAML that are split over multiple lines...
