### PR TITLE
chore: Add link to changelog for #2197

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 **Web**:
 
-- Added the PRQL-snippets from the book to the
-  [Playground](https://prql-lang.org/playground/)
+- Added the PRQL snippets from the book to the
+  [Playground](https://prql-lang.org/playground/) (@jelenkee, #2197)
 
 **Integrations**:
 


### PR DESCRIPTION
@Jelenkee generally we put the author & a link — I'm guessing this was an oversight — but if you prefer not to have this lmk, otherwise it'll merge. Hope that's OK.