### PR TITLE
internal: Enable all examples to serialize to YAML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,6 +1634,7 @@ dependencies = [
  "pulldown-cmark-to-cmark",
  "semver",
  "serde_json",
+ "serde_yaml",
  "similar",
  "walkdir",
 ]
@@ -2135,6 +2136,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sqlformat",
  "sqlparser",
  "strum",

--- a/prql-compiler/Cargo.toml
+++ b/prql-compiler/Cargo.toml
@@ -23,8 +23,11 @@ log = "0.4.17"
 once_cell = "1.17.0"
 regex = "1.7.0"
 semver = {version = "1.0.14", features = ["serde"]}
+# We could put `serde` behind a feature if needed, particularly `yaml`, which
+# isn't used in the main library.
 serde = {version = "1.0.137", features = ["derive"]}
 serde_json = "1.0.81"
+serde_yaml = "0.9"
 sqlformat = "0.2.0"
 sqlparser = {version = "0.32.0", features = ["serde"]}
 strum = {version = "0.24.0", features = ["std", "derive"]}# for converting enum variants to string

--- a/prql-compiler/src/ast/rq/expr.rs
+++ b/prql-compiler/src/ast/rq/expr.rs
@@ -15,6 +15,9 @@ pub struct Expr {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, EnumAsInner)]
 pub enum ExprKind {
     ColumnRef(CId),
+    // https://github.com/dtolnay/serde-yaml/issues/363
+    // We should repeat this if we encounter any other nested enums.
+    #[serde(with = "serde_yaml::with::singleton_map")]
     Literal(Literal),
 
     // TODO: convert this into built-in function

--- a/web/book/Cargo.toml
+++ b/web/book/Cargo.toml
@@ -24,6 +24,7 @@ pulldown-cmark = "0.9.1"
 pulldown-cmark-to-cmark = "10.0.1"
 semver = "1.0.9"
 serde_json = "1.0.81"
+serde_yaml = "0.9"
 similar = "2.2.0"
 walkdir = "2.3.2"
 

--- a/web/book/tests/snapshot.rs
+++ b/web/book/tests/snapshot.rs
@@ -131,3 +131,17 @@ The original PRQL was:
 
     Ok(())
 }
+
+#[test]
+fn test_rq_serialize() -> Result<(), ErrorMessages> {
+    for (_, prql) in collect_book_examples()? {
+        if prql.contains("# Error expected") {
+            continue;
+        }
+        let rq = prql_to_pl(&prql).map(|pl| pl_to_rq(pl))?;
+        // Serialize to YAML
+        assert!(serde_yaml::to_string(&rq).is_ok());
+    }
+
+    Ok(())
+}

--- a/web/book/tests/snapshot.rs
+++ b/web/book/tests/snapshot.rs
@@ -138,7 +138,7 @@ fn test_rq_serialize() -> Result<(), ErrorMessages> {
         if prql.contains("# Error expected") {
             continue;
         }
-        let rq = prql_to_pl(&prql).map(|pl| pl_to_rq(pl))?;
+        let rq = prql_to_pl(&prql).map(pl_to_rq)?;
         // Serialize to YAML
         assert!(serde_yaml::to_string(&rq).is_ok());
     }


### PR DESCRIPTION
This uses `serde_yaml::with::singleton_map` to workaround https://github.com/dtolnay/serde-yaml/issues/363. It also tests all the examples can serialize.

(thanks a lot for the suggestion @dtolnay)