### PR TITLE
ci: Ensure consistent web deployments

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -10,6 +10,11 @@ on:
     types: [released]
   # Called by pull-request when specifically requested
   workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-web:


### PR DESCRIPTION
If a workflow starts later, cancel the earlier one, otherwise the last to complete wins. Currently the footer links are not up-to-date on the website as a result.
