### PR TITLE
chore(prql-dotnet): Copy library to output directory

### DIFF
--- a/bindings/prql-dotnet/PrqlCompiler/PrqlCompiler.csproj
+++ b/bindings/prql-dotnet/PrqlCompiler/PrqlCompiler.csproj
@@ -25,4 +25,16 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="libprql_lib.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="libprql_lib.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="libprql_lib.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Copy the PRQL library to the output directory if it exist.