### PR TITLE
feat: Add MessageKind to Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 - _Breaking_: The `compile` function's `Options` now includes a `color` member,
   which determines whether error messages use ANSI color codes. This is
   technically a breaking change to the API. (@max-sixty, #2251)
-- The `Error` struct now exposes the `MessageKind` enum. (@vanillajonathan, #2307)
+- The `Error` struct now exposes the `MessageKind` enum. (@vanillajonathan,
+  #2307)
 
 **New Contributors**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - _Breaking_: The `compile` function's `Options` now includes a `color` member,
   which determines whether error messages use ANSI color codes. This is
   technically a breaking change to the API. (@max-sixty, #2251)
+- The `Error` struct now exposes the `MessageKind` enum. (@vanillajonathan, #2307)
 
 **New Contributors**:
 

--- a/prql-compiler/src/error.rs
+++ b/prql-compiler/src/error.rs
@@ -14,6 +14,8 @@ pub struct Span {
 
 #[derive(Debug, Clone)]
 pub struct Error {
+    /// Message kind. Currently only Error is implemented.
+    pub kind: MessageKind,
     pub span: Option<Span>,
     pub reason: Reason,
     pub help: Option<String>,
@@ -32,6 +34,14 @@ pub struct SourceLocation {
     pub start: (usize, usize),
 
     pub end: (usize, usize),
+}
+
+/// Compile message kind. Currently only Error is implemented.
+#[derive(Clone, Debug, Serialize)]
+pub enum MessageKind {
+    Error,
+    Warning,
+    Lint,
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +64,7 @@ pub enum Reason {
 impl Error {
     pub fn new(reason: Reason) -> Self {
         Error {
+            kind: MessageKind::Error,
             span: None,
             reason,
             help: None,
@@ -83,6 +94,8 @@ impl Error {
 
 #[derive(Clone, Serialize)]
 pub struct ErrorMessage {
+    /// Message kind. Currently only Error is implemented.
+    pub kind: MessageKind,
     /// Machine-readable identifier of the error
     pub code: Option<String>,
     /// Plain text of the error
@@ -91,7 +104,6 @@ pub struct ErrorMessage {
     pub hint: Option<String>,
     /// Character offset of error origin within a source file
     pub span: Option<Span>,
-
     /// Annotated code, containing cause and hints.
     pub display: Option<String>,
     /// Line and column number of error origin within a source file
@@ -205,6 +217,7 @@ pub fn downcast(error: anyhow::Error) -> ErrorMessages {
 
     ErrorMessage {
         code,
+        kind: MessageKind::Error,
         reason,
         hint,
         span,

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -308,6 +308,7 @@ mod tests_lib {
         assert_debug_snapshot!(Target::from_str("sql.poostgres"), @r###"
         Err(
             Error {
+                kind: Error,
                 span: None,
                 reason: NotFound {
                     name: "\"sql.poostgres\"",

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -322,6 +322,7 @@ mod tests_lib {
         assert_debug_snapshot!(Target::from_str("postgres"), @r###"
         Err(
             Error {
+                kind: Error,
                 span: None,
                 reason: NotFound {
                     name: "\"postgres\"",

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -2248,6 +2248,7 @@ join s=salaries [==id]
         Errors(
             [
                 Error {
+                    kind: Error,
                     span: Some(
                         span-chars-22-23,
                     ),
@@ -2258,6 +2259,7 @@ join s=salaries [==id]
                     code: None,
                 },
                 Error {
+                    kind: Error,
                     span: Some(
                         span-chars-35-36,
                     ),
@@ -2268,6 +2270,7 @@ join s=salaries [==id]
                     code: None,
                 },
                 Error {
+                    kind: Error,
                     span: Some(
                         span-chars-37-38,
                     ),
@@ -2288,6 +2291,7 @@ join s=salaries [==id]
         Errors(
             [
                 Error {
+                    kind: Error,
                     span: Some(
                         span-chars-6-7,
                     ),


### PR DESCRIPTION
Add the `MessageKind` enum to the `Error` struct.