### PR TITLE
fix: Loop in MySQL

### DIFF
--- a/prql-compiler/src/sql/gen_query.rs
+++ b/prql-compiler/src/sql/gen_query.rs
@@ -417,8 +417,9 @@ fn sql_of_loop(pipeline: Vec<SqlTransform>, ctx: &mut Context) -> Result<Vec<Sql
     let step = anchor_split(&mut ctx.anchor, initial, step);
     let from = step.first().unwrap().as_super().unwrap().as_from().unwrap();
 
+    let table_name = "_loop";
     let initial = ctx.anchor.table_decls.get_mut(&from.source).unwrap();
-    initial.name = Some("loop".to_string());
+    initial.name = Some(table_name.to_string());
     let initial_relation = initial.relation.take().unwrap();
 
     let initial = initial_relation.kind.into_preprocessed_pipeline().unwrap();
@@ -436,7 +437,7 @@ fn sql_of_loop(pipeline: Vec<SqlTransform>, ctx: &mut Context) -> Result<Vec<Sql
 
     // build CTE and it's SELECT
     let cte = sql_ast::Cte {
-        alias: simple_table_alias(Ident::new("loop")),
+        alias: simple_table_alias(Ident::new(table_name)),
         query: Box::new(default_query(SetExpr::SetOperation {
             op: sql_ast::SetOperator::Union,
             set_quantifier: sql_ast::SetQuantifier::All,
@@ -456,7 +457,7 @@ fn sql_of_loop(pipeline: Vec<SqlTransform>, ctx: &mut Context) -> Result<Vec<Sql
             )],
             from: vec![TableWithJoins {
                 relation: TableFactor::Table {
-                    name: sql_ast::ObjectName(vec![Ident::new("loop")]),
+                    name: sql_ast::ObjectName(vec![Ident::new(table_name)]),
                     alias: None,
                     args: None,
                     with_hints: Vec::new(),

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -3235,7 +3235,7 @@ fn test_loop() {
         1 AS n
     ),
     table_6 AS (
-      WITH RECURSIVE loop AS (
+      WITH RECURSIVE _loop AS (
         SELECT
           n - 2 AS _expr_0
         FROM
@@ -3249,7 +3249,7 @@ fn test_loop() {
             SELECT
               _expr_0 + 1 AS _expr_1
             FROM
-              loop AS table_2
+              _loop AS table_2
           ) AS table_3
         WHERE
           _expr_1 < 5
@@ -3257,7 +3257,7 @@ fn test_loop() {
       SELECT
         *
       FROM
-        loop
+        _loop
     )
     SELECT
       _expr_0 * 2 AS n

--- a/web/book/tests/snapshots/snapshot__tests__prql__language-features__standard-library__loop-0.prql.snap
+++ b/web/book/tests/snapshots/snapshot__tests__prql__language-features__standard-library__loop-0.prql.snap
@@ -1,5 +1,5 @@
 ---
-source: book/tests/snapshot.rs
+source: web/book/tests/snapshot.rs
 expression: "from_text format:json '[{\"n\": 1 }]'\nloop (\n    filter n<4\n    select n = n+1\n)\n\n# returns [1, 2, 3, 4]\n"
 ---
 WITH table_0 AS (
@@ -7,7 +7,7 @@ WITH table_0 AS (
     1 AS n
 ),
 table_4 AS (
-  WITH RECURSIVE loop AS (
+  WITH RECURSIVE _loop AS (
     SELECT
       n
     FROM
@@ -17,14 +17,14 @@ table_4 AS (
     SELECT
       n + 1
     FROM
-      loop AS table_2
+      _loop AS table_2
     WHERE
       n < 4
   )
   SELECT
     *
   FROM
-    loop
+    _loop
 )
 SELECT
   n


### PR DESCRIPTION
`loop` is a keyword in MySQL. So it throws an error when executing.
I renamed it to `_loop` in the generated SQL