### PR TITLE
internal: Reduce cloning in `Ident::starts_with`

### DIFF
--- a/prql-compiler/src/ast/pl/ident.rs
+++ b/prql-compiler/src/ast/pl/ident.rs
@@ -45,32 +45,16 @@ impl Ident {
         self
     }
 
-    fn into_vec(self) -> Vec<String> {
-        self.path.into_iter().chain(Some(self.name)).collect()
+    pub fn iter(&self) -> impl Iterator<Item = &String> {
+        self.path.iter().chain(std::iter::once(&self.name))
     }
 
     pub fn starts_with(&self, prefix: &Ident) -> bool {
-        self.clone()
-            .into_vec()
-            .starts_with(&prefix.clone().into_vec())
+        prefix
+            .iter()
+            .zip(self.iter())
+            .all(|(prefix_component, self_component)| prefix_component == self_component)
     }
-}
-
-#[test]
-fn test_starts_with() {
-    // Over-testing, from co-pilot, can remove some of them.
-    let a = Ident::from_path(vec!["a", "b", "c"]);
-    let b = Ident::from_path(vec!["a", "b"]);
-    let c = Ident::from_path(vec!["a", "b", "c", "d"]);
-    let d = Ident::from_path(vec!["a", "b", "d"]);
-    let e = Ident::from_path(vec!["a", "c"]);
-    let f = Ident::from_path(vec!["b", "c"]);
-    assert!(a.starts_with(&b));
-    assert!(a.starts_with(&a));
-    assert!(!a.starts_with(&c));
-    assert!(!a.starts_with(&d));
-    assert!(!a.starts_with(&e));
-    assert!(!a.starts_with(&f));
 }
 
 impl std::fmt::Display for Ident {
@@ -150,4 +134,21 @@ pub fn display_ident_part(f: &mut std::fmt::Formatter, s: &str) -> Result<(), st
     } else {
         write!(f, "{s}")
     }
+}
+
+#[test]
+fn test_starts_with() {
+    // Over-testing, from co-pilot, can remove some of them.
+    let a = Ident::from_path(vec!["a", "b", "c"]);
+    let b = Ident::from_path(vec!["a", "b"]);
+    let c = Ident::from_path(vec!["a", "b", "c", "d"]);
+    let d = Ident::from_path(vec!["a", "b", "d"]);
+    let e = Ident::from_path(vec!["a", "c"]);
+    let f = Ident::from_path(vec!["b", "c"]);
+    assert!(a.starts_with(&b));
+    assert!(a.starts_with(&a));
+    assert!(!a.starts_with(&c));
+    assert!(!a.starts_with(&d));
+    assert!(!a.starts_with(&e));
+    assert!(!a.starts_with(&f));
 }

--- a/prql-compiler/src/ast/pl/ident.rs
+++ b/prql-compiler/src/ast/pl/ident.rs
@@ -50,6 +50,9 @@ impl Ident {
     }
 
     pub fn starts_with(&self, prefix: &Ident) -> bool {
+        if prefix.path.len() > self.path.len() {
+            return false;
+        }
         prefix
             .iter()
             .zip(self.iter())


### PR DESCRIPTION
Now that we're keeping the current `Ident` design. Also adds an `.iter` method.
