### PR TITLE
chore: Fix markdownlinkcheck

### DIFF
--- a/web/website/content/faq.md
+++ b/web/website/content/faq.md
@@ -203,6 +203,8 @@ because of a strong convention around lowercase, but everywhere else we use
 
 {{< faq "Where can I find the logos?" >}}
 
-See the [press material](../press-material).
+<!-- TODO: unsure why a relative link such as `/press-material` doesn't pass the markdownlinkcheck? Would be good to resolve -->
+
+See the [press material](https://prql-lang.org/press-material/).
 
 {{</ faq >}}


### PR DESCRIPTION
Not sure why this is interacting with the linter badly. It's now an external reference, not a huge deal though.

CC @vanillajonathan for info, no need to prioritize