### PR TITLE
docs(website): fix link in hugo

### DIFF
--- a/web/website/content/faq.md
+++ b/web/website/content/faq.md
@@ -203,8 +203,6 @@ because of a strong convention around lowercase, but everywhere else we use
 
 {{< faq "Where can I find the logos?" >}}
 
-<!-- TODO: unsure why a relative link such as `/press-material` doesn't pass the markdownlinkcheck? Would be good to resolve -->
-
-See the [press material](https://prql-lang.org/press-material/).
+See the [press material]({{< ref "/press-material" >}}).
 
 {{</ faq >}}


### PR DESCRIPTION
Follow up #2319, related to #2330

Hugo generates websites with a different structure than the hierarchical structure of the source code (Markdown), so Markdown link syntax should not be used here.