### PR TITLE
ci: make megalinter always validate all codebase

### DIFF
--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -41,8 +41,7 @@ jobs:
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref
-            == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Override with true if you always want to lint all sources
+          VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
           # DISABLE: COPYPASTE,SPELL # Uncomment to disable copy-paste and spell checks

--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -10,6 +10,7 @@ DISABLE_LINTERS:
   - SPELL_CSPELL
   - CSS_STYLELINT
   - PHP_PSALM
+  - PHP_PHPSTAN # Disabled for now as we couldn't figure out how to prevent false positives. #2069
 DISABLE_ERRORS_LINTERS:
   - COPYPASTE_JSCPD
   - REPOSITORY_TRIVY

--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -10,7 +10,6 @@ DISABLE_LINTERS:
   - SPELL_CSPELL
   - CSS_STYLELINT
   - PHP_PSALM
-  - PHP_PHPSTAN # Disabled for now as we couldn't figure out how to prevent false positives. #2069
 DISABLE_ERRORS_LINTERS:
   - COPYPASTE_JSCPD
   - REPOSITORY_TRIVY


### PR DESCRIPTION
Related to #1994

Given that ~~`phpstan` (https://github.com/PRQL/prql/pull/2069#issuecomment-1462334893) and~~ `dustilock` (https://github.com/PRQL/prql/pull/2319#issuecomment-1485619219) do not work properly with checks against only modified files, it seems that it may make sense to always inspect all code.

Edit: Running `phpstan` against the entire code base within this PR produced an error, so I will not be activating `phpstan`.