### PR TITLE
ci: Add `cargo bench` to nightly CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -29,6 +29,16 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Maybe add to test-all?
+  cargo-bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: richb-hanover/cargo@v1.1.0
+        with:
+          command: bench
+          args: --timings --all-targets
+
   check-links:
     # We run on modified files only in PR, so do another check of all files here.
     runs-on: ubuntu-latest


### PR DESCRIPTION
Also acts as a test that these work. There's no great way of tracking the results at this point, though
