### PR TITLE
chore(test): bind mount read only in compose file for testing

### DIFF
--- a/prql-compiler/tests/integration-rdbms/conf/my.cnf
+++ b/prql-compiler/tests/integration-rdbms/conf/my.cnf
@@ -1,2 +1,2 @@
 [mysqld]
-secure-file-priv= /tmp/chinook/
+secure-file-priv = ""

--- a/prql-compiler/tests/integration-rdbms/docker-compose.yml
+++ b/prql-compiler/tests/integration-rdbms/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
     volumes: &vol
-      - ../integration/data/chinook:/tmp/chinook
+      - ../integration/data/chinook:/tmp/chinook:ro
   mysql:
     # No arm64 image available; remove when one does become available
     platform: linux/amd64
@@ -19,8 +19,8 @@ services:
       MYSQL_DATABASE: dummy
       MYSQL_ROOT_PASSWORD: root
     volumes:
-      - ./conf:/etc/mysql/conf.d
-      - ../integration/data/chinook:/tmp/chinook
+      - ./conf:/etc/mysql/conf.d:ro
+      - ../integration/data/chinook:/tmp/chinook:ro
   #  db2:
   #    image: 'icr.io/db2_community/db2'
   #    ports:

--- a/prql-compiler/tests/integration-rdbms/docker-compose.yml
+++ b/prql-compiler/tests/integration-rdbms/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       MYSQL_DATABASE: dummy
       MYSQL_ROOT_PASSWORD: root
     volumes:
-      - ./conf:/etc/mysql/conf.d:ro
+      - ./conf/my.cnf:/etc/mysql/conf.d/my.cnf:ro
       - ../integration/data/chinook:/tmp/chinook:ro
   #  db2:
   #    image: 'icr.io/db2_community/db2'


### PR DESCRIPTION
https://github.com/PRQL/prql/pull/2286#discussion_r1152689595

It is safer to do bind mounts with read only to prevent file permissions from being changed from the containers.