### PR TITLE
chore(test): set MySQL's `secure-file-priv=""` option in the command instead of conf file

### DIFF
--- a/prql-compiler/tests/integration-rdbms/conf/my.cnf
+++ b/prql-compiler/tests/integration-rdbms/conf/my.cnf
@@ -1,2 +1,0 @@
-[mysqld]
-secure-file-priv = ""

--- a/prql-compiler/tests/integration-rdbms/docker-compose.yml
+++ b/prql-compiler/tests/integration-rdbms/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     environment:
       MYSQL_DATABASE: dummy
       MYSQL_ROOT_PASSWORD: root
+    command: --secure-file-priv=""
     volumes: *vol
   #  db2:
   #    image: 'icr.io/db2_community/db2'

--- a/prql-compiler/tests/integration-rdbms/docker-compose.yml
+++ b/prql-compiler/tests/integration-rdbms/docker-compose.yml
@@ -18,9 +18,7 @@ services:
     environment:
       MYSQL_DATABASE: dummy
       MYSQL_ROOT_PASSWORD: root
-    volumes:
-      - ./conf/my.cnf:/etc/mysql/conf.d/my.cnf:ro
-      - ../integration/data/chinook:/tmp/chinook:ro
+    volumes: *vol
   #  db2:
   #    image: 'icr.io/db2_community/db2'
   #    ports:


### PR DESCRIPTION
`secure-file-priv=""` needs to be set in the mysql container, but since it can be set with the command used when the container is created without using the configuration file, so remove the configuration file and the command is specified in the compose file.