### PR TITLE
docs(changelog): fix typo and tweak some items related to breaking chage of 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -796,9 +796,9 @@ We also have new features in the
 0.2.5 is a very small release following 0.2.4 yesterday. It includes:
 
 - Add the ability to represent single brackets in an s-string, with two brackets
-  (#752, @max-sixty )
+  (#752, @max-sixty)
 - Fix the "Copy to Clipboard" command in the Playground, for Firefox (#880,
-  @mklopets )
+  @mklopets)
 
 ## 0.2.4 - 2022-07-28
 
@@ -808,11 +808,11 @@ includes:
 - Enrich our CLI, adding commands to get different stages of the compilation
   process (@aljazerzen , #863)
 - Fix multiple `take n` statements in a query, leading to duplicate proxy
-  columns in generated SQL (@charlie-sanders )
-- Fix BigQuery quoting of identifiers in `SELECT` statements (@max-sixty )
-- Some internal changes — reorganize top-level functions (@aljazerzen ), add a
-  workflow to track our Rust compilation time (@max-sixty ), simplify our simple
-  prql-to-sql tests (@max-sixty )
+  columns in generated SQL (@charlie-sanders)
+- Fix BigQuery quoting of identifiers in `SELECT` statements (@max-sixty)
+- Some internal changes — reorganize top-level functions (@aljazerzen), add a
+  workflow to track our Rust compilation time (@max-sixty), simplify our simple
+  prql-to-sql tests (@max-sixty)
 
 Thanks to @ankane, `prql-compiler` is now available from homebrew core;
 `brew install prql-compiler`[^1].
@@ -828,23 +828,22 @@ mid-sized features to the language, and made a bunch of internal improvements.
 
 The 0.2.3 release includes:
 
-- Allow for escaping otherwise-invalid identifiers (@aljazerzen & @max-sixty )
-- Fix a bug around operator precedence (@max-sixty )
-- Add a section the book on the language bindings (@charlie-sanders )
+- Allow for escaping otherwise-invalid identifiers (@aljazerzen & @max-sixty)
+- Fix a bug around operator precedence (@max-sixty)
+- Add a section the book on the language bindings (@charlie-sanders)
 - Add tests for our `Display` representation while fixing some existing bugs.
-  This is gradually becoming our code formatter (@arrizalamin )
-- Add a "copy to clipboard" button in the Playground (@mklopets )
+  This is gradually becoming our code formatter (@arrizalamin)
+- Add a "copy to clipboard" button in the Playground (@mklopets)
 - Add lots of guidance to our `CONTRIBUTING.md` around our tests and process for
-  merging (@max-sixty )
-- Add a `prql!` macro for parsing a prql query at compile time (@aljazerzen )
-- Add tests for `prql-js` (@charlie-sanders )
-- Add a `from_json` method for transforming json to a PRQL string (@arrizalamin
-  )
-- Add a workflow to release `prql-java` to Maven (@doki23 )
+  merging (@max-sixty)
+- Add a `prql!` macro for parsing a prql query at compile time (@aljazerzen)
+- Add tests for `prql-js` (@charlie-sanders)
+- Add a `from_json` method for transforming json to a PRQL string (@arrizalamin)
+- Add a workflow to release `prql-java` to Maven (@doki23)
 - Enable running all tests from a PR by adding a `pr-run-all-tests` label
-  (@max-sixty )
-- Have `cargo-release` to bump all crate & npm versions (@max-sixty )
-- Update `prql-js` to use the bundler build of `prql-js` (@mklopets )
+  (@max-sixty)
+- Have `cargo-release` to bump all crate & npm versions (@max-sixty)
+- Update `prql-js` to use the bundler build of `prql-js` (@mklopets)
 
 As well as those contribution changes, thanks to those who've reported issues,
 such as @mklopets @huw @mm444 @ajfriend.
@@ -869,17 +868,17 @@ We're a couple of weeks since our 0.2.0 release. Thanks for the surge in
 interest and contributions! 0.2.2 has some fixes & some internal improvements:
 
 - We now test against SQLite & DuckDB on every commit, to ensure we're producing
-  correct SQL. (@aljazerzen )
-- We have the beginning of Java bindings! (@doki23 )
-- Idents surrounded by backticks are passed through to SQL (@max-sixty )
+  correct SQL. (@aljazerzen)
+- We have the beginning of Java bindings! (@doki23)
+- Idents surrounded by backticks are passed through to SQL (@max-sixty)
 - More examples on homepage; e.g. `join` & `window`, lots of small docs
   improvements
-- Automated releases to homebrew (@roG0d )
+- Automated releases to homebrew (@roG0d)
 - [prql-js](https://github.com/PRQL/prql/tree/main/bindings/prql-js) is now a
-  single package for Node, browsers & webpack (@charlie-sanders )
+  single package for Node, browsers & webpack (@charlie-sanders)
 - Parsing has some fixes, including `>=` and leading underscores in idents
-  (@mklopets )
-- Ranges receive correct syntax highlighting (@max-sixty )
+  (@mklopets)
+- Ranges receive correct syntax highlighting (@max-sixty)
 
 Thanks to Aljaž Mur Eržen @aljazerzen , George Roldugin @roldugin , Jasper
 McCulloch @Jaspooky , Jie Han @doki23 , Marko Klopets @mklopets , Maximilian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ This release has 108 commits from 11 contributors. Selected changes:
 
   If you're interested in dbt integration, subscribe or 👍 to
   <https://github.com/dbt-labs/dbt-core/pull/5982>.
+
 - A new compile target `"sql.any"`. When `"sql.any"` is used as the target of
   the compile function's option, the target contained in the query header will
   be used. (@aljazerzen, #1995)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -818,8 +818,8 @@ Thanks to @ankane, `prql-compiler` is now available from homebrew core;
 `brew install prql-compiler`[^2].
 
 [^2]:
-    we still need to update docs and add a release workflow for this:
-    <https://github.com/PRQL/prql/issues/866>
+  we still need to update docs and add a release workflow for this:
+  <https://github.com/PRQL/prql/issues/866>
 
 ## 0.2.3 - 2022-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -817,8 +817,9 @@ includes:
 Thanks to @ankane, `prql-compiler` is now available from homebrew core;
 `brew install prql-compiler`[^1].
 
-[^1]: we still need to update docs and add a release workflow for this:
-  <https://github.com/PRQL/prql/issues/866>
+[^1]:
+    we still need to update docs and add a release workflow for this:
+    <https://github.com/PRQL/prql/issues/866>
 
 ## 0.2.3 - 2022-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -815,9 +815,9 @@ includes:
   prql-to-sql tests (@max-sixty )
 
 Thanks to @ankane, `prql-compiler` is now available from homebrew core;
-`brew install prql-compiler`[^2].
+`brew install prql-compiler`[^1].
 
-[^2]:
+[^1]:
   we still need to update docs and add a release workflow for this:
   <https://github.com/PRQL/prql/issues/866>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -818,8 +818,9 @@ Thanks to @ankane, `prql-compiler` is now available from homebrew core;
 `brew install prql-compiler`[^1].
 
 [^1]:
-  we still need to update docs and add a release workflow for this:
-  <https://github.com/PRQL/prql/issues/866>
+
+we still need to update docs and add a release workflow for this:
+<https://github.com/PRQL/prql/issues/866>
 
 ## 0.2.3 - 2022-07-24
 
@@ -953,9 +954,8 @@ I especially want to give [Aljaž Mur Eržen](https://github.com/aljazerzen)
 difficult work of building out the compiler. Much credit also goes to
 [Charlie Sanders](https://github.com/charlie-sanders) (@charlie-sanders), one of
 PRQL's earliest supporters and the author of PyPrql, and
-[Ryan Patterson-Cross](https://github.com/rbpatt2019)
-(@rbpatt2019), who built the Jupyter integration among other Python
-contributions.
+[Ryan Patterson-Cross](https://github.com/rbpatt2019) (@rbpatt2019), who built
+the Jupyter integration among other Python contributions.
 
 Other contributors who deserve a special mention include: @roG0d, @snth,
 @kwigley

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 **New Contributors**:
 
-## 0.7.0 — 2023-24-01
+## 0.7.0 — 2023-04-01
 
 0.7.0 is a fairly small release in terms of new features, with lots of internal
 improvements, such as integration tests with a whole range of DBs, a blog post

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,32 @@ This release has 108 commits from 11 contributors. Selected changes:
   - Float literals without fraction part are not allowed anymore (`1.`).
 - Add a `--format` option to `prqlc parse` which can return the AST in YAML
   (@max-sixty, #1962)
+- Add a new subcommand `prqlc jinja`. (@aljazerzen, #1722)
+- _Breaking_: prql-compiler no longer passes text containing `{{` & `}}` through
+  to the output. (@aljazerzen, #1722)
+
+  For example, the following PRQL query
+
+  ```prql no-eval
+  from {{foo}}
+  ```
+
+  was compiled to the following SQL previously, but now it raises an error.
+
+  ```sql
+  SELECT
+    *
+  FROM
+    {{ foo }}
+  ```
+
+  This pass-through feature existed for integration with dbt.
+
+  we're again considering how to best integrate with dbt, and this change is
+  based on the idea that the jinja macro should run before the PRQL compiler.
+
+  If you're interested in dbt integration, subscribe or 👍 to
+  <https://github.com/dbt-labs/dbt-core/pull/5982>.
 - A new compile target `"sql.any"`. When `"sql.any"` is used as the target of
   the compile function's option, the target contained in the query header will
   be used. (@aljazerzen, #1995)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -817,10 +817,8 @@ includes:
 Thanks to @ankane, `prql-compiler` is now available from homebrew core;
 `brew install prql-compiler`[^1].
 
-[^1]:
-
-we still need to update docs and add a release workflow for this:
-<https://github.com/PRQL/prql/issues/866>
+[^1]: we still need to update docs and add a release workflow for this:
+  <https://github.com/PRQL/prql/issues/866>
 
 ## 0.2.3 - 2022-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -953,7 +953,7 @@ I especially want to give [Aljaž Mur Eržen](https://github.com/aljazerzen)
 difficult work of building out the compiler. Much credit also goes to
 [Charlie Sanders](https://github.com/charlie-sanders) (@charlie-sanders), one of
 PRQL's earliest supporters and the author of PyPrql, and
-[Ryan Patterson-Cross](https://github.com/orgs/prql/people/rbpatt2019)
+[Ryan Patterson-Cross](https://github.com/rbpatt2019)
 (@rbpatt2019), who built the Jupyter integration among other Python
 contributions.
 

--- a/web/book/src/language-features/case.md
+++ b/web/book/src/language-features/case.md
@@ -4,6 +4,10 @@
 `case` is currently experimental and may change behavior in the near future
 ```
 
+```admonish info
+`case` was previously (PRQL 0.4 to 0.5) called `switch` and renamed to `case` in PRQL 0.6.0.
+```
+
 PRQL uses `case` for both SQL's `CASE` and `IF` statements. Here's an example:
 
 ```prql no-fmt


### PR DESCRIPTION
Related to #2104

A set of some minor fixes that I noticed when I looked at the Changelog that is now included in the Book.

- Fix some typos.
- Added some info on some of breaking changes
  - Pass through jinja template (`{{` and `}}`).
  - `switch` -> `case`

I tried to include the admonish note about the change of name from `switch` to `case` in the changelog, but it didn't work (bug?).
So I add it to the `case` page.