### PR TITLE
docs: update descriptions of integrations

### DIFF
--- a/web/book/src/integrations/jupyter.md
+++ b/web/book/src/integrations/jupyter.md
@@ -1,139 +1,45 @@
 # Jupyter
 
-> Original docs at <https://pyprql.readthedocs.io/en/latest/magic_readme.html>
+[pyprql](https://pypi.org/project/pyprql/) contains `pyprql.magic`, a thin wrapper of [`JupySQL`](https://pypi.org/project/jupysql/)'s SQL IPython magics.
+This allows us to run PRQL interactively on Jupyter/IPython.
 
-Work with pandas and PRQL in an IPython terminal or Jupyter notebook.
+Check out <https://pyprql.readthedocs.io/> for more context.
 
-## Implementation
+## Installation
 
-This is a thin wrapper around the fantastic [IPython-sql][ipysql] magic. Roughly
-speaking, all we do is parse PRQL to SQL and pass that through to `ipython-sql`.
-A full documentation of the supported features is available at their
-[repository][ipysql]. Here, we document those places where we differ from them,
-plus those features we think you are mostly likely to find useful.
-
-## Usage
-
-### Installation
-
-If you have already installed PyPRQL into your environment, then you should be
-could to go! We bundle in `IPython` and `pandas`, though you'll need to install
-`Jupyter` separately. If you haven't installed PyPRQL, that's as simple as:
-
-```shell
+```sh
 pip install pyprql
 ```
 
-### Set up
+## Usage
 
-Open up either an `IPython` terminal or `Jupyter` notebook. First, we need to
-load the extension and connect to a database.
+When installing pyprql, the [duckdb-engine](https://pypi.org/project/duckdb-engine/) package is also installed with it, so we can start using PRQL immediately to query CSV and Parquet files.
+
+For example, running [the example from the JupySQL documentation](https://jupysql.ploomber.io/en/latest/quick-start.html) on IPython:
 
 ```python
 In [1]: %load_ext pyprql.magic
 
-```
+In [2]: !curl -sL https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv -o penguins.csv
 
-#### Connecting a database
+In [3]: %prql duckdb://
 
-We have two options for connecting a database
+In [4]: %prql from `penguins.csv` | take 3
+Out[4]: 
+  species     island  bill_length_mm  bill_depth_mm  flipper_length_mm  body_mass_g     sex
+0  Adelie  Torgersen            39.1           18.7                181         3750    MALE
+1  Adelie  Torgersen            39.5           17.4                186         3800  FEMALE
+2  Adelie  Torgersen            40.3           18.0                195         3250  FEMALE
 
-1. Create an in-memory DB. This is the easiest way to get started.
-
-   ```python
-   In [2]: %prql duckdb:///:memory:
-   ```
-
-   However, in-memory databases start off empty! So, we need to add some data.
-   We have a two options:
-
-   - We can easily add a [pandas][pandas] dataframe to the `DuckDB` database
-     like so:
-
-     ```python
-     In [3]: %prql --persist df
-     ```
-
-     where `df` is a pandas dataframe. This adds a table named `df` to the
-     in-memory `DuckDB` instance.
-
-   - Or download a CSV and query it directly, with DuckDB:
-
-     ```python
-     !wget https://github.com/graphql-compose/graphql-compose-examples/blob/master/examples/northwind/data/csv/products.csv
-     ```
-
-     ...and then `from products.csv` will work.
-
-2. Connect to an existing database
-
-   When connecting to a database, pass the connection string as an argument to
-   the line magic `%prql`. The connection string needs to be in [SQLAlchemy
-   format][conn_str], so any connection supported by `SQLAlchemy` is supported
-   by the magic. Additional connection parameters can be passed as a dictionary
-   using the `--connection_arguments` flag to the the `%prql` line magic. We
-   ship with the necessary extensions to use [DuckDB][duckdb] as the backend,
-   and here connect to an in-memory database.
-
-### Querying
-
-Now, let's do a query! By default, `PRQLMagic` always returns the results as
-dataframe, and always prints the results. The results of the previous query are
-accessible in the `_` variable.
-
-These examples are based on the `products.csv` example above.
-
-```python
-
-
-In [4]: %%prql
-   ...: from p = products.csv
-   ...: filter supplierID == 1
-
-Done.
-Returning data to local variable _
-   productID    productName  supplierID  categoryID      quantityPerUnit  unitPrice  unitsInStock  unitsOnOrder  reorderLevel  discontinued
-0          1           Chai           1           1   10 boxes x 20 bags       18.0            39             0            10             0
-1          2          Chang           1           1   24 - 12 oz bottles       19.0            17            40            25             0
-2          3  Aniseed Syrup           1           2  12 - 550 ml bottles       10.0            13            70            25             0
-```
-
-```python
 In [5]: %%prql
-   ...: from p = products.csv
-   ...: group categoryID (
-   ...:   aggregate [average unitPrice]
-   ...: )
-
-Done.
-Returning data to local variable _
-   categoryID  avg("unitPrice")
-0           1         37.979167
-1           2         23.062500
-2           7         32.370000
-3           6         54.006667
-4           8         20.682500
-5           4         28.730000
-6           3         25.160000
-7           5         20.250000
+   ...: from `penguins.csv`
+   ...: filter bill_length_mm > 40
+   ...: take 3
+   ...: 
+   ...: 
+Out[5]: 
+  species     island  bill_length_mm  bill_depth_mm  flipper_length_mm  body_mass_g     sex
+0  Adelie  Torgersen            40.3           18.0                195         3250  FEMALE
+1  Adelie  Torgersen            42.0           20.2                190         4250    None
+2  Adelie  Torgersen            41.1           17.6                182         3200  FEMALE
 ```
-
-We can capture the results into a different variable like so:
-
-```python
-In [6]: %%prql results <<
-   ...: from p = products.csv
-   ...: aggregate [min unitsInStock, max unitsInStock]
-
-Done.
-Returning data to local variable results
-   min("unitsInStock")  max("unitsInStock")
-0                    0                  125
-```
-
-Now, the output of the query is saved to `results`.
-
-[ipysql]: https://github.com/catherinedevlin/ipython-sql
-[conn_str]: https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
-[duckdb]: https://duckdb.org
-[pandas]: https://pandas.pydata.org

--- a/web/book/src/integrations/jupyter.md
+++ b/web/book/src/integrations/jupyter.md
@@ -1,6 +1,7 @@
 # Jupyter
 
-[pyprql](https://pypi.org/project/pyprql/) contains `pyprql.magic`, a thin wrapper of [`JupySQL`](https://pypi.org/project/jupysql/)'s SQL IPython magics.
+[pyprql](https://pypi.org/project/pyprql/) contains `pyprql.magic`, a thin
+wrapper of [`JupySQL`](https://pypi.org/project/jupysql/)'s SQL IPython magics.
 This allows us to run PRQL interactively on Jupyter/IPython.
 
 Check out <https://pyprql.readthedocs.io/> for more context.
@@ -13,9 +14,14 @@ pip install pyprql
 
 ## Usage
 
-When installing pyprql, the [duckdb-engine](https://pypi.org/project/duckdb-engine/) package is also installed with it, so we can start using PRQL immediately to query CSV and Parquet files.
+When installing pyprql, the
+[duckdb-engine](https://pypi.org/project/duckdb-engine/) package is also
+installed with it, so we can start using PRQL immediately to query CSV and
+Parquet files.
 
-For example, running [the example from the JupySQL documentation](https://jupysql.ploomber.io/en/latest/quick-start.html) on IPython:
+For example, running
+[the example from the JupySQL documentation](https://jupysql.ploomber.io/en/latest/quick-start.html)
+on IPython:
 
 ```python
 In [1]: %load_ext pyprql.magic
@@ -25,7 +31,7 @@ In [2]: !curl -sL https://raw.githubusercontent.com/mwaskom/seaborn-data/master/
 In [3]: %prql duckdb://
 
 In [4]: %prql from `penguins.csv` | take 3
-Out[4]: 
+Out[4]:
   species     island  bill_length_mm  bill_depth_mm  flipper_length_mm  body_mass_g     sex
 0  Adelie  Torgersen            39.1           18.7                181         3750    MALE
 1  Adelie  Torgersen            39.5           17.4                186         3800  FEMALE
@@ -35,9 +41,9 @@ In [5]: %%prql
    ...: from `penguins.csv`
    ...: filter bill_length_mm > 40
    ...: take 3
-   ...: 
-   ...: 
-Out[5]: 
+   ...:
+   ...:
+Out[5]:
   species     island  bill_length_mm  bill_depth_mm  flipper_length_mm  body_mass_g     sex
 0  Adelie  Torgersen            40.3           18.0                195         3250  FEMALE
 1  Adelie  Torgersen            42.0           20.2                190         4250    None

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -372,11 +372,10 @@ tools_section:
       text:
         "Online in-browser playground that compiles PRQL to SQL as you type."
 
-    - link: https://github.com/prql/PyPrql
+    - link: https://pyprql.readthedocs.io/
       label: "PyPrql"
       text: |
-        Python TUI for connecting to databases.
-        Provides a native interactive console with auto-complete for column names and Jupyter/IPython cell magic.
+        Provides Jupyter/IPython cell magic and Pandas accessor.
 
         `pip install pyprql`
 
@@ -385,7 +384,7 @@ tools_section:
       text: |
         A CLI for PRQL compiler, written in Rust.
 
-        `cargo install prqlc`
+        `cargo install prqlc`  
         `brew install prql/PRQL/prqlc`
 
 integrations_section:
@@ -410,13 +409,6 @@ integrations_section:
     - label: "DuckDB"
       link: https://github.com/ywelsch/duckdb-prql
       text: A DuckDB extension to execute PRQL
-
-    - label: dbt
-      link: https://github.com/prql/dbt-prql
-      text:
-        Allows writing PRQL in dbt models. This combines the benefits of PRQL's
-        power & simplicity within queries; with dbt's version control, lineage &
-        testing across queries.
 
 bindings_section:
   enable: true

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -384,7 +384,7 @@ tools_section:
       text: |
         A CLI for PRQL compiler, written in Rust.
 
-        `cargo install prqlc`  
+        `cargo install prqlc`
         `brew install prql/PRQL/prqlc`
 
 integrations_section:

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -385,6 +385,7 @@ tools_section:
         A CLI for PRQL compiler, written in Rust.
 
         `cargo install prqlc`
+
         `brew install prql/PRQL/prqlc`
 
 integrations_section:


### PR DESCRIPTION
- Remove dbt from top page of website
- Remove description of pyprql's TUI (already removed from pyprql)
- Completely rewrite the page about Jupyter integration.
  We will need to check the pyprql documentation for complete documentation (to avoid coping the page)