### PR TITLE
revert: #2202

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,6 +145,9 @@ jobs:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
 
+      - run: npm run build
+        working-directory: bindings/prql-js
+
       - name: Publish package on npm
         run: npm publish
         working-directory: bindings/prql-js/

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -32,5 +32,7 @@ jobs:
         with:
           crate: wasm-pack
 
+      - run: npm run build
+        working-directory: bindings/prql-js
       - run: npm cit
         working-directory: bindings/prql-js

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -248,8 +248,9 @@ tasks:
         website/public/playground/playground
 
   test-js:
-    dir: bindings/prql-js
+    dir: prql-js
     cmds:
+      - npm run build
       - npm cit
 
   # Currently disabled; see prql-elixir/README.md for details

--- a/bindings/prql-js/package.json
+++ b/bindings/prql-js/package.json
@@ -21,7 +21,6 @@
     "build:bundler": "wasm-pack build --target bundler --release --out-dir dist/bundler && rm dist/bundler/.gitignore",
     "build:node": "wasm-pack build --target nodejs --release --out-dir dist/node && rm dist/node/.gitignore",
     "build:web": "wasm-pack build --target no-modules --release --out-dir dist/web && rm dist/web/.gitignore",
-    "preinstall": "npm run build",
     "test": "mocha tests"
   },
   "types": "dist/node/prql_js.d.ts",

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -29,7 +29,6 @@
     },
     "../../bindings/prql-js": {
       "version": "0.6.1",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.6",


### PR DESCRIPTION
I think #2202 causing this failure: https://github.com/PRQL/prql-vscode/actions/runs/4600865002/jobs/8128008789?pr=170 — `prql-js` is trying to run `wasm-pack` even when it's installed as a dependency.

Possibly there's a better way of doing this where it runs `wasm-pack` when building from scratch, but not when installing as a dependency. I can look more later, unless anyone knows off-hand