### PR TITLE
build: Bump `prql-playground` versions

### DIFF
--- a/bindings/prql-js/Cargo.toml
+++ b/bindings/prql-js/Cargo.toml
@@ -64,4 +64,12 @@ search = '(\s+"prql-js",)\n(\s+"version": )"[\d\.]+"'
 exactly = 1
 file = "../../web/playground/package-lock.json"
 replace = '''$1"{{version}}"'''
-search = '(    "../prql-js": \{\n      "version": )"[\d\.]+"'
+search = '(    "../../bindings/prql-js": \{\n      "version": )"[\d\.]+"'
+
+[[package.metadata.release.pre-release-replacements]]
+exactly = 2
+file = "package-lock.json"
+replace = '''
+$1
+$2"{{version}}"'''
+search = '(\s+"prql-playground",)\n(\s+"version": )"[\d\.]+"'


### PR DESCRIPTION
We don't publish this, but may as well keep it updated
