### PR TITLE
fix: re-export `MessageKind`

### DIFF
--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -86,7 +86,9 @@ pub mod sql;
 mod tests;
 mod utils;
 
-pub use error::{downcast, Error, ErrorMessage, ErrorMessages, MessageKind, Reason, SourceLocation, Span};
+pub use error::{
+    downcast, Error, ErrorMessage, ErrorMessages, MessageKind, Reason, SourceLocation, Span,
+};
 
 use once_cell::sync::Lazy;
 use semver::Version;

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -86,7 +86,7 @@ pub mod sql;
 mod tests;
 mod utils;
 
-pub use error::{downcast, Error, ErrorMessage, ErrorMessages, Reason, SourceLocation, Span};
+pub use error::{downcast, Error, ErrorMessage, ErrorMessages, MessageKind, Reason, SourceLocation, Span};
 
 use once_cell::sync::Lazy;
 use semver::Version;


### PR DESCRIPTION
Re-export the `MessageKind` enum so it becomes visible outside the crate.