### PR TITLE
refactor: SRQ, sql:preprocess and sql:anchor

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -67,8 +67,13 @@ enum Command {
         format: Format,
     },
 
+    /// Parse, resolve, lower into RQ & preprocess SRQ
+    #[command(name = "sql:preprocess")]
+    SQLPreprocess(IoArgs),
+
     /// Parse, resolve, lower into RQ & compile to SQL
-    Compile {
+    #[command(name = "compile", alias = "sql:compile")]
+    SQLCompile {
         #[command(flatten)]
         io_args: IoArgs,
         #[arg(long, default_value = "true")]
@@ -179,7 +184,7 @@ impl Command {
                     Format::Yaml => serde_yaml::to_string(&ir)?.into_bytes(),
                 }
             }
-            Command::Compile {
+            Command::SQLCompile {
                 include_signature_comment,
                 ..
             } => compile(
@@ -193,6 +198,14 @@ impl Command {
             )?
             .as_bytes()
             .to_vec(),
+
+            Command::SQLPreprocess { .. } => {
+                let ast = prql_to_pl(source)?;
+                let rq = semantic::resolve(ast)?;
+                let srq = prql_compiler::sql::internal::preprocess(rq)?;
+                format!("{srq:#?}").as_bytes().to_vec()
+            }
+
             Command::Watch(_) => unreachable!(),
         })
     }
@@ -204,9 +217,10 @@ impl Command {
         // quite reasonable?
         use Command::*;
         let mut input = match self {
-            Parse { io_args, .. } | Resolve { io_args, .. } | Compile { io_args, .. } => {
-                io_args.input.clone()
-            }
+            Parse { io_args, .. }
+            | Resolve { io_args, .. }
+            | SQLCompile { io_args, .. }
+            | SQLPreprocess(io_args) => io_args.input.clone(),
             Format(io) | Debug(io) | Annotate(io) => io.input.clone(),
             Watch(_) => unreachable!(),
         };
@@ -226,9 +240,10 @@ impl Command {
     fn write_output(&mut self, data: &[u8]) -> std::io::Result<()> {
         use Command::*;
         let mut output = match self {
-            Parse { io_args, .. } | Resolve { io_args, .. } | Compile { io_args, .. } => {
-                io_args.output.to_owned()
-            }
+            Parse { io_args, .. }
+            | Resolve { io_args, .. }
+            | SQLCompile { io_args, .. }
+            | SQLPreprocess(io_args) => io_args.output.to_owned(),
             Format(io) | Debug(io) | Annotate(io) => io.output.to_owned(),
             Watch(_) => unreachable!(),
         };
@@ -357,7 +372,7 @@ group a_column (take 10 | sort b_column | derive [the_number = rank, last = lag 
         .apply();
 
         let result = Command::execute(
-            &Command::Compile {
+            &Command::SQLCompile {
                 io_args: IoArgs::default(),
                 include_signature_comment: true,
             },

--- a/prql-compiler/src/sql/anchor.rs
+++ b/prql-compiler/src/sql/anchor.rs
@@ -5,13 +5,11 @@ use std::collections::{HashMap, HashSet};
 use crate::ast::rq::{
     self, fold_transform, CId, Compute, Expr, RelationColumn, RqFold, TableRef, Transform,
 };
+use crate::sql::ast_srq::{SqlRelation, SqlRelationKind};
 use crate::sql::context::SqlTableDecl;
-use crate::sql::preprocess::{SqlRelation, SqlRelationKind};
 
-use super::{
-    context::{AnchorContext, ColumnDecl},
-    preprocess::{SqlFold, SqlTransform},
-};
+use super::ast_srq::{SqlFold, SqlTransform};
+use super::context::{AnchorContext, ColumnDecl};
 
 /// Splits pipeline into two parts, such that the second part contains
 /// maximum number of transforms while "fitting" into a SELECT query.

--- a/prql-compiler/src/sql/ast_srq.rs
+++ b/prql-compiler/src/sql/ast_srq.rs
@@ -9,6 +9,7 @@
 use anyhow::Result;
 use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
+use serde::Serialize;
 
 use crate::ast::rq::{Relation, RelationColumn, RelationKind, RqFold, TableRef, Transform};
 
@@ -24,7 +25,7 @@ pub struct SqlRelation {
     pub columns: Vec<RelationColumn>,
 }
 
-#[derive(Debug, Clone, EnumAsInner, strum::AsRefStr)]
+#[derive(Debug, Clone, EnumAsInner, strum::AsRefStr, Serialize)]
 pub enum SqlTransform {
     Super(Transform),
     Distinct,

--- a/prql-compiler/src/sql/ast_srq.rs
+++ b/prql-compiler/src/sql/ast_srq.rs
@@ -1,0 +1,90 @@
+//! Sql Relational Query AST
+//!
+//! This in an internal intermediate representation that wraps RQ nodes to extend possible node values.
+//!
+//! For example, RQ does not have a separate node for DISTINCT, but uses [crate::ast::rq::Take] 1 with
+//! `partition`. In [super::preprocess] module, [crate::ast::rq::Transform] take is wrapped into
+//! [SqlTransform], which does have [SqlTransform::Distinct].
+
+use anyhow::Result;
+use enum_as_inner::EnumAsInner;
+use itertools::Itertools;
+
+use crate::ast::rq::{Relation, RelationColumn, RelationKind, RqFold, TableRef, Transform};
+
+#[derive(Debug, Clone, EnumAsInner)]
+pub enum SqlRelationKind {
+    Super(RelationKind),
+    PreprocessedPipeline(Vec<SqlTransform>),
+}
+
+#[derive(Debug, Clone)]
+pub struct SqlRelation {
+    pub kind: SqlRelationKind,
+    pub columns: Vec<RelationColumn>,
+}
+
+#[derive(Debug, Clone, EnumAsInner, strum::AsRefStr)]
+pub enum SqlTransform {
+    Super(Transform),
+    Distinct,
+    Except { bottom: TableRef, distinct: bool },
+    Intersect { bottom: TableRef, distinct: bool },
+    Union { bottom: TableRef, distinct: bool },
+    Loop(Vec<SqlTransform>),
+}
+
+impl SqlTransform {
+    pub fn as_str(&self) -> &str {
+        match self {
+            SqlTransform::Super(t) => t.as_ref(),
+            _ => self.as_ref(),
+        }
+    }
+
+    pub fn into_super_and<T, F: FnOnce(Transform) -> Result<T, Transform>>(
+        self,
+        f: F,
+    ) -> Result<T, SqlTransform> {
+        self.into_super()
+            .and_then(|t| f(t).map_err(SqlTransform::Super))
+    }
+}
+
+impl From<Relation> for SqlRelation {
+    fn from(rel: Relation) -> Self {
+        SqlRelation {
+            kind: SqlRelationKind::Super(rel.kind),
+            columns: rel.columns,
+        }
+    }
+}
+
+pub trait SqlFold: RqFold {
+    fn fold_sql_transforms(&mut self, transforms: Vec<SqlTransform>) -> Result<Vec<SqlTransform>> {
+        transforms
+            .into_iter()
+            .map(|t| self.fold_sql_transform(t))
+            .try_collect()
+    }
+
+    fn fold_sql_transform(&mut self, transform: SqlTransform) -> Result<SqlTransform> {
+        Ok(match transform {
+            SqlTransform::Super(t) => SqlTransform::Super(self.fold_transform(t)?),
+            SqlTransform::Distinct => SqlTransform::Distinct,
+            SqlTransform::Union { bottom, distinct } => SqlTransform::Union {
+                bottom: self.fold_table_ref(bottom)?,
+                distinct,
+            },
+            SqlTransform::Except { bottom, distinct } => SqlTransform::Except {
+                bottom: self.fold_table_ref(bottom)?,
+                distinct,
+            },
+            SqlTransform::Intersect { bottom, distinct } => SqlTransform::Intersect {
+                bottom: self.fold_table_ref(bottom)?,
+                distinct,
+            },
+            SqlTransform::Loop(pipeline) => SqlTransform::Loop(self.fold_sql_transforms(pipeline)?),
+        })
+    }
+}

--- a/prql-compiler/src/sql/context.rs
+++ b/prql-compiler/src/sql/context.rs
@@ -14,7 +14,7 @@ use crate::ast::rq::{
 };
 use crate::utils::{IdGenerator, NameGenerator};
 
-use super::preprocess::{SqlRelation, SqlTransform};
+use super::ast_srq::{SqlRelation, SqlTransform};
 
 #[derive(Default, Debug)]
 pub struct AnchorContext {

--- a/prql-compiler/src/sql/gen_query.rs
+++ b/prql-compiler/src/sql/gen_query.rs
@@ -15,7 +15,6 @@ use sqlparser::ast::{
 use crate::ast::pl::{BinOp, JoinSide, Literal, RelationLiteral};
 use crate::ast::rq::{CId, Expr, ExprKind, Query, RelationKind, TableRef, Transform};
 use crate::sql::anchor::anchor_split;
-use crate::sql::preprocess::SqlRelationKind;
 use crate::utils::{BreakUp, Pluck};
 
 use crate::Target;
@@ -23,7 +22,8 @@ use crate::Target;
 use super::context::AnchorContext;
 use super::gen_expr::*;
 use super::gen_projection::*;
-use super::preprocess::{self, SqlRelation, SqlTransform};
+use super::preprocess;
+use super::ast_srq::{SqlRelation, SqlRelationKind, SqlTransform};
 use super::{anchor, Context, Dialect};
 
 pub fn translate_query(query: Query, dialect: Option<Dialect>) -> Result<sql_ast::Query> {
@@ -68,15 +68,7 @@ fn sql_query_of_sql_relation(
         // base case
         SqlRelationKind::Super(Pipeline(pipeline)) => {
             // preprocess
-            let pipeline = Ok(pipeline)
-                .map(preprocess::normalize)
-                .map(preprocess::prune_inputs)
-                .map(preprocess::wrap)
-                .and_then(|p| preprocess::distinct(p, ctx))
-                .map(preprocess::union)
-                .and_then(|p| preprocess::except(p, ctx))
-                .and_then(|p| preprocess::intersect(p, ctx))
-                .map(preprocess::reorder)?;
+            let pipeline = preprocess::preprocess(pipeline, ctx)?;
 
             // load names of output columns
             ctx.anchor.load_names(&pipeline, sql_relation.columns);
@@ -116,7 +108,7 @@ fn table_factor_of_table_ref(table_ref: TableRef, ctx: &mut Context) -> Result<T
 
     // ensure that the table is declared
     if let Some(sql_relation) = decl.relation.take() {
-        // if we cannot use CTEs
+        // if we cannot use CTEs (probably because we are within RECURSIVE)
         if !ctx.query.allow_ctes {
             // restore relation for other references
             decl.relation = Some(sql_relation.clone());

--- a/prql-compiler/src/sql/gen_query.rs
+++ b/prql-compiler/src/sql/gen_query.rs
@@ -19,11 +19,11 @@ use crate::utils::{BreakUp, Pluck};
 
 use crate::Target;
 
+use super::ast_srq::{SqlRelation, SqlRelationKind, SqlTransform};
 use super::context::AnchorContext;
 use super::gen_expr::*;
 use super::gen_projection::*;
 use super::preprocess;
-use super::ast_srq::{SqlRelation, SqlRelationKind, SqlTransform};
 use super::{anchor, Context, Dialect};
 
 pub fn translate_query(query: Query, dialect: Option<Dialect>) -> Result<sql_ast::Query> {
@@ -520,7 +520,10 @@ fn sql_of_sample_data(data: RelationLiteral, ctx: &Context) -> Result<sql_ast::Q
 
 /// Extract last part of pipeline that is able to "fit" into a single SELECT statement.
 /// Remaining proceeding pipeline is declared as a table and stored in AnchorContext.
-fn extract_atomic(pipeline: Vec<SqlTransform>, ctx: &mut AnchorContext) -> Vec<SqlTransform> {
+pub(super) fn extract_atomic(
+    pipeline: Vec<SqlTransform>,
+    ctx: &mut AnchorContext,
+) -> Vec<SqlTransform> {
     let (preceding, atomic) = anchor::split_off_back(pipeline, ctx);
 
     if let Some(preceding) = preceding {

--- a/prql-compiler/src/sql/mod.rs
+++ b/prql-compiler/src/sql/mod.rs
@@ -60,21 +60,43 @@ pub fn compile(query: Query, options: &Options) -> Result<String> {
 /// This module gives access to internal machinery that gives no stability guarantees.
 pub mod internal {
     use super::*;
-    use crate::ast::rq::{Query, RelationKind};
+    use crate::ast::rq::{Query, Transform};
 
     pub use super::ast_srq::SqlTransform;
 
-    /// Applies preprocessing to the main relation in RQ. Meant for debugging purposes.
-    pub fn preprocess(query: Query) -> Result<Option<Vec<SqlTransform>>> {
+    fn init(query: Query) -> Result<(Vec<Transform>, Context)> {
         let (ctx, relation) = AnchorContext::of(query);
-        let mut ctx = Context::new(dialect::Dialect::Generic.handler(), ctx);
+        let ctx = Context::new(dialect::Dialect::Generic.handler(), ctx);
 
-        match relation.kind {
-            RelationKind::Pipeline(pipeline) => {
-                Ok(Some(preprocess::preprocess(pipeline, &mut ctx)?))
+        let pipeline = (relation.kind.into_pipeline())
+            .map_err(|_| anyhow::anyhow!("Main RQ relation is not a pipeline."))?;
+        Ok((pipeline, ctx))
+    }
+
+    /// Applies preprocessing to the main relation in RQ. Meant for debugging purposes.
+    pub fn preprocess(query: Query) -> Result<Vec<SqlTransform>> {
+        let (pipeline, mut ctx) = init(query)?;
+
+        preprocess::preprocess(pipeline, &mut ctx)
+    }
+
+    /// Applies preprocessing and anchoring to the main relation in RQ. Meant for debugging purposes.
+    pub fn anchor(query: Query) -> Result<Vec<Vec<SqlTransform>>> {
+        let (pipeline, mut ctx) = init(query)?;
+        let mut pipeline = preprocess::preprocess(pipeline, &mut ctx)?;
+
+        let mut atomics = Vec::new();
+        loop {
+            let (preceding, last) = anchor::split_off_back(pipeline, &mut ctx.anchor);
+            atomics.push(last);
+            if let Some(preceding) = preceding {
+                pipeline = preceding;
+            } else {
+                break;
             }
-            _ => Ok(None),
         }
+
+        Ok(atomics)
     }
 }
 

--- a/prql-compiler/src/sql/preprocess.rs
+++ b/prql-compiler/src/sql/preprocess.rs
@@ -17,11 +17,14 @@ use super::ast_srq::*;
 use super::Context;
 
 /// Converts RQ AST into SqlRQ AST and applies a few preprocessing operations.
+///
+/// Note that some SQL translation mechanisms depend on behavior of some of these
+/// functions (i.e. reorder).
 pub(super) fn preprocess(
     pipeline: Vec<Transform>,
     ctx: &mut Context,
 ) -> Result<Vec<SqlTransform>, anyhow::Error> {
-    Ok(Ok(pipeline)
+    Ok(pipeline)
         .map(normalize)
         .map(prune_inputs)
         .map(wrap)
@@ -29,7 +32,7 @@ pub(super) fn preprocess(
         .map(union)
         .and_then(|p| except(p, ctx))
         .and_then(|p| intersect(p, ctx))
-        .map(reorder)?)
+        .map(reorder)
 }
 
 // This function was disabled because it changes semantics of the pipeline in some cases.


### PR DESCRIPTION
- refactor SRQ AST
- prqlc sql:preprocess
- prqlc sql:anchor

I've formalized the fact that I've already introduced an intermediate AST representation in `prql_compiler::sql` module. This IR is named "Sql Relation Query" or SRQ.

With this realization it made sense to add cli commands that make it easy to run compiler passes on the AST:

```
$ cargo run -p prqlc -- sql:preprocess _a.prql
$ cargo run -p prqlc -- sql:anchor _a.prql
$ cargo run -p prqlc -- sql:compile _a.prql     # alias for compile
```

Makes work on #2079 and #2244 much easier I think.