### PR TITLE
devops: fix cache volume mounts of dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,13 +19,6 @@
       ]
     }
   },
-  "mounts": [
-    {
-      "source": "devcontainer-cargo-cache",
-      "target": "/usr/local/cargo",
-      "type": "volume"
-    }
-  ],
   "postCreateCommand": {
     "install-maturin": "task install-maturin",
     "install-npm-dependencies": "task install-npm-dependencies"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
   },
   "mounts": [
     {
-      "source": "devcontainer-cargo-cache",
+      "source": "devcontainer-cargo-cache-${devcontainerId}",
       "target": "/usr/local/cargo/registry",
       "type": "volume"
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,13 @@
       ]
     }
   },
+  "mounts": [
+    {
+      "source": "devcontainer-cargo-cache",
+      "target": "/usr/local/cargo/registry",
+      "type": "volume"
+    }
+  ],
   "postCreateCommand": {
     "install-maturin": "task install-maturin",
     "install-npm-dependencies": "task install-npm-dependencies"


### PR DESCRIPTION
@eitsupi — should we be mounting this? When it's mounted, none of the cargo tools work out of the box for me, such as `cargo insta`.

(This is more of a question than a pull-request — I thought it was easiest to show the diff — but great if we have a solution that means we can close this)