### PR TITLE
build: Fix build for linux-aarch64 target

### DIFF
--- a/bindings/prql-lib/src/lib.rs
+++ b/bindings/prql-lib/src/lib.rs
@@ -141,7 +141,7 @@ pub struct Options {
 /// Result of compilation.
 #[repr(C)]
 pub struct CompileResult {
-    pub output: *const i8,
+    pub output: *const libc::c_char,
     pub messages: *const Message,
     pub messages_len: size_t,
 }
@@ -164,16 +164,16 @@ pub struct Message {
     /// Message kind. Currently only Error is implemented.
     pub kind: MessageKind,
     /// Machine-readable identifier of the error
-    pub code: *const *const i8,
+    pub code: *const *const libc::c_char,
     /// Plain text of the error
-    pub reason: *const i8,
+    pub reason: *const libc::c_char,
     /// A list of suggestions of how to fix the error
-    pub hint: *const *const i8,
+    pub hint: *const *const libc::c_char,
     /// Character offset of error origin within a source file
     pub span: *const Span,
 
     /// Annotated code, containing cause and hints.
-    pub display: *const *const i8,
+    pub display: *const *const libc::c_char,
     /// Line and column number of error origin within a source file
     pub location: *const SourceLocation,
 }
@@ -215,20 +215,20 @@ pub unsafe extern "C" fn result_destroy(res: CompileResult) {
         let e = &*res.messages.add(i);
 
         if !e.code.is_null() {
-            drop(CString::from_raw(*e.code as *mut i8));
-            drop(Box::from_raw(e.code as *mut *const i8));
+            drop(CString::from_raw(*e.code as *mut libc::c_char));
+            drop(Box::from_raw(e.code as *mut *const libc::c_char));
         }
-        drop(CString::from_raw(e.reason as *mut i8));
+        drop(CString::from_raw(e.reason as *mut libc::c_char));
         if !e.hint.is_null() {
-            drop(CString::from_raw(*e.hint as *mut i8));
-            drop(Box::from_raw(e.hint as *mut *const i8));
+            drop(CString::from_raw(*e.hint as *mut libc::c_char));
+            drop(Box::from_raw(e.hint as *mut *const libc::c_char));
         }
         if !e.span.is_null() {
             drop(Box::from_raw(e.span as *mut Span));
         }
         if !e.display.is_null() {
-            drop(CString::from_raw(*e.display as *mut i8));
-            drop(Box::from_raw(e.display as *mut *const i8));
+            drop(CString::from_raw(*e.display as *mut libc::c_char));
+            drop(Box::from_raw(e.display as *mut *const libc::c_char));
         }
         if !e.location.is_null() {
             drop(Box::from_raw(e.location as *mut SourceLocation));
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn result_destroy(res: CompileResult) {
         res.messages_len,
         res.messages_len,
     ));
-    drop(CString::from_raw(res.output as *mut i8));
+    drop(CString::from_raw(res.output as *mut libc::c_char));
 }
 
 unsafe fn result_into_c_str(result: Result<String, ErrorMessages>) -> CompileResult {
@@ -281,7 +281,7 @@ fn option_to_ptr<T>(o: Option<T>) -> *const T {
     }
 }
 
-fn convert_string(x: String) -> *const i8 {
+fn convert_string(x: String) -> *const libc::c_char {
     CString::new(x).unwrap_or_default().into_raw()
 }
 


### PR DESCRIPTION
Seems to be the same issue as https://github.com/remacs/remacs/issues/1393

Found when trying to build in the devcontainer.

Until there are GitHub Actions runners on ARM, this isn't easy to test. I'm not sure why the pointer representation is different between linux & mac or ARM...
