### PR TITLE
docs(prqlc): Update prqlc README.md to correct `SELECT *`

### DIFF
--- a/prql-compiler/prqlc/README.md
+++ b/prql-compiler/prqlc/README.md
@@ -26,7 +26,7 @@ brew install prql/prql/prql-compiler
 $ echo "from employees | filter has_dog | select salary" | prqlc compile
 
 SELECT
-  *
+  salary
 FROM
   employees
 WHERE


### PR DESCRIPTION
On a manual run I get

```
SELECT
  salary
FROM
  employees
WHERE
  has_dog
```
as output. 

`SELECT *` gives a bad first impression because it can be inefficient.