### PR TITLE
test: Run insta tests faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ version = "0.7.1"
 [profile.release.package.prql-js]
 # Tell `rust-js` to optimize for small code size.
 opt-level = "s"
+# Insta runs faster this way, ref https://insta.rs/docs/quickstart/
+[profile.dev.package.insta]
+opt-level = 3
+[profile.dev.package.similar]
+opt-level = 3
 
 [workspace.metadata.release]
 allow-branch = ["*"]


### PR DESCRIPTION
As our tests now take a bit longer, this allows the insta tests to run faster, at the cost of some initial (but cached) compile time. The reference is inline
