### PR TITLE
docs: Add `&&` & `||` to syntax table

### DIFF
--- a/web/book/src/syntax/README.md
+++ b/web/book/src/syntax/README.md
@@ -14,7 +14,7 @@ A summary of PRQL syntax:
 | `=`                              | [Assigns](../transforms/select.md) & [Aliases](../transforms/join.md)   | `from e = employees` <br> `derive total = (sum salary)` |
 | `:`                              | [Named args & Parameters](../queries/functions.md)                      | `interp low:0 1600 sat_score`                           |
 | `[]`                             | [Lists](./lists.md)                                                     | `select [id, amount]`                                   |
-| <code>! && \|\| <= +</code>, etc | [Expressions & Operators](./expressions-and-operators.md)               | <code>filter a == b + c \|\| d >= e</code>              |
+| <code>! && \|\| == +</code>, etc | [Expressions & Operators](./expressions-and-operators.md)               | <code>filter a == b + c \|\| d >= e</code>              |
 | `()`                             | [Precedence & Parentheses](./precedence-and-parentheses.md)             | `derive celsius = (fahrenheit - 32) / 1.8`              |
 | `''`, `""`                       | [Strings](../language-features/strings.md)                              | `derive name = 'Mary'`                                  |
 | `` ` ` ``                        | [Quoted identifiers](./quoted-identifiers.md)                           | `` select `first name`  ``                              |

--- a/web/book/src/syntax/README.md
+++ b/web/book/src/syntax/README.md
@@ -8,23 +8,23 @@ A summary of PRQL syntax:
 
 <!-- TODO: assigns links to select, aliases to join, potentially we should have explicit sections for them?  -->
 
-| Syntax                                      | Usage                                                                   | Example                                                 |
-| ------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------- |
-| <code>\|</code>                             | [Pipelines](../queries/pipelines.md)                                    | <code>from employees \| select first_name</code>        |
-| `=`                                         | [Assigns](../transforms/select.md) & [Aliases](../transforms/join.md)   | `from e = employees` <br> `derive total = (sum salary)` |
-| `:`                                         | [Named args & Parameters](../queries/functions.md)                      | `interp low:0 1600 sat_score`                           |
-| `[]`                                        | [Lists](./lists.md)                                                     | `select [id, amount]`                                   |
-| `!`, `&&`, <code>\|\|</code>, `+`, `-`, etc | [Expressions & Operators](./expressions-and-operators.md)               | <code>filter a == b + c \|\| d >= e</code>              |
-| `()`                                        | [Precedence & Parentheses](./precedence-and-parentheses.md)             | `derive celsius = (fahrenheit - 32) / 1.8`              |
-| `''`, `""`                                  | [Strings](../language-features/strings.md)                              | `derive name = 'Mary'`                                  |
-| `` ` ` ``                                   | [Quoted identifiers](./quoted-identifiers.md)                           | `` select `first name`  ``                              |
-| `#`                                         | [Comments](./comments.md)                                               | `# A comment`                                           |
-| `@`                                         | [Dates & Times](../language-features/dates-and-times.md#dates--times)   | `@2021-01-01`                                           |
-| `==`                                        | [Self-equality in `join`](../transforms/join.md#self-equality-operator) | `join s=salaries [==id]`                                |
-| `->`                                        | [Function definitions](../queries/functions.md)                         | `func add a b -> a + b`                                 |
-| `=>`                                        | [Case statement](../language-features/case.md)                          | `case [a==1 => c, a==2 => d ]`                          |
-| `+`/`-`                                     | [Sort order](../transforms/sort.md)                                     | `sort [-amount, +date]`                                 |
-| `??`                                        | [Coalesce](../language-features/coalesce.md)                            | `amount ?? 0`                                           |
+| Syntax                           | Usage                                                                   | Example                                                 |
+| -------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------- |
+| <code>\|</code>                  | [Pipelines](../queries/pipelines.md)                                    | <code>from employees \| select first_name</code>        |
+| `=`                              | [Assigns](../transforms/select.md) & [Aliases](../transforms/join.md)   | `from e = employees` <br> `derive total = (sum salary)` |
+| `:`                              | [Named args & Parameters](../queries/functions.md)                      | `interp low:0 1600 sat_score`                           |
+| `[]`                             | [Lists](./lists.md)                                                     | `select [id, amount]`                                   |
+| <code>! && \|\| <= +</code>, etc | [Expressions & Operators](./expressions-and-operators.md)               | <code>filter a == b + c \|\| d >= e</code>              |
+| `()`                             | [Precedence & Parentheses](./precedence-and-parentheses.md)             | `derive celsius = (fahrenheit - 32) / 1.8`              |
+| `''`, `""`                       | [Strings](../language-features/strings.md)                              | `derive name = 'Mary'`                                  |
+| `` ` ` ``                        | [Quoted identifiers](./quoted-identifiers.md)                           | `` select `first name`  ``                              |
+| `#`                              | [Comments](./comments.md)                                               | `# A comment`                                           |
+| `@`                              | [Dates & Times](../language-features/dates-and-times.md#dates--times)   | `@2021-01-01`                                           |
+| `==`                             | [Self-equality in `join`](../transforms/join.md#self-equality-operator) | `join s=salaries [==id]`                                |
+| `->`                             | [Function definitions](../queries/functions.md)                         | `func add a b -> a + b`                                 |
+| `=>`                             | [Case statement](../language-features/case.md)                          | `case [a==1 => c, a==2 => d ]`                          |
+| `+`/`-`                          | [Sort order](../transforms/sort.md)                                     | `sort [-amount, +date]`                                 |
+| `??`                             | [Coalesce](../language-features/coalesce.md)                            | `amount ?? 0`                                           |
 
 <!--
 | `<type>`        | Annotations                                           |  `@2021-01-01<datetime>`                                |

--- a/web/book/src/syntax/README.md
+++ b/web/book/src/syntax/README.md
@@ -8,23 +8,23 @@ A summary of PRQL syntax:
 
 <!-- TODO: assigns links to select, aliases to join, potentially we should have explicit sections for them?  -->
 
-| Syntax          | Usage                                                                   | Example                                                 |
-| --------------- | ----------------------------------------------------------------------- | ------------------------------------------------------- |
-| <code>\|</code> | [Pipelines](../queries/pipelines.md)                                    | <code>from employees \| select first_name</code>        |
-| `=`             | [Assigns](../transforms/select.md) & [Aliases](../transforms/join.md)   | `from e = employees` <br> `derive total = (sum salary)` |
-| `:`             | [Named args & Parameters](../queries/functions.md)                      | `interp low:0 1600 sat_score`                           |
-| `[]`            | [Lists](./lists.md)                                                     | `select [id, amount]`                                   |
-| `+ - * /`       | [Expressions & Operators](./expressions-and-operators.md)               | `filter a == b && c != d && e > f`                      |
-| `()`            | [Precedence & Parentheses](./precedence-and-parentheses.md)             | `derive celsius = (fahrenheit - 32) / 1.8`              |
-| `''` & `""`     | [Strings](../language-features/strings.md)                              | `derive name = 'Mary'`                                  |
-| `` ` ` ``       | [Quoted identifiers](./quoted-identifiers.md)                           | `` select `first name`  ``                              |
-| `#`             | [Comments](./comments.md)                                               | `# A comment`                                           |
-| `@`             | [Dates & Times](../language-features/dates-and-times.md#dates--times)   | `@2021-01-01`                                           |
-| `==`            | [Self-equality in `join`](../transforms/join.md#self-equality-operator) | `join s=salaries [==id]`                                |
-| `->`            | [Function definitions](../queries/functions.md)                         | `func add a b -> a + b`                                 |
-| `=>`            | [Case statement](../language-features/case.md)                          | `case [a==1 => c, a==2 => d ]`                          |
-| `+`/`-`         | [Sort order](../transforms/sort.md)                                     | `sort [-amount, +date]`                                 |
-| `??`            | [Coalesce](../language-features/coalesce.md)                            | `amount ?? 0`                                           |
+| Syntax                                      | Usage                                                                   | Example                                                 |
+| ------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------- |
+| <code>\|</code>                             | [Pipelines](../queries/pipelines.md)                                    | <code>from employees \| select first_name</code>        |
+| `=`                                         | [Assigns](../transforms/select.md) & [Aliases](../transforms/join.md)   | `from e = employees` <br> `derive total = (sum salary)` |
+| `:`                                         | [Named args & Parameters](../queries/functions.md)                      | `interp low:0 1600 sat_score`                           |
+| `[]`                                        | [Lists](./lists.md)                                                     | `select [id, amount]`                                   |
+| `!`, `&&`, <code>\|\|</code>, `+`, `-`, etc | [Expressions & Operators](./expressions-and-operators.md)               | <code>filter a == b + c \|\| d >= e</code>              |
+| `()`                                        | [Precedence & Parentheses](./precedence-and-parentheses.md)             | `derive celsius = (fahrenheit - 32) / 1.8`              |
+| `''`, `""`                                  | [Strings](../language-features/strings.md)                              | `derive name = 'Mary'`                                  |
+| `` ` ` ``                                   | [Quoted identifiers](./quoted-identifiers.md)                           | `` select `first name`  ``                              |
+| `#`                                         | [Comments](./comments.md)                                               | `# A comment`                                           |
+| `@`                                         | [Dates & Times](../language-features/dates-and-times.md#dates--times)   | `@2021-01-01`                                           |
+| `==`                                        | [Self-equality in `join`](../transforms/join.md#self-equality-operator) | `join s=salaries [==id]`                                |
+| `->`                                        | [Function definitions](../queries/functions.md)                         | `func add a b -> a + b`                                 |
+| `=>`                                        | [Case statement](../language-features/case.md)                          | `case [a==1 => c, a==2 => d ]`                          |
+| `+`/`-`                                     | [Sort order](../transforms/sort.md)                                     | `sort [-amount, +date]`                                 |
+| `??`                                        | [Coalesce](../language-features/coalesce.md)                            | `amount ?? 0`                                           |
 
 <!--
 | `<type>`        | Annotations                                           |  `@2021-01-01<datetime>`                                |

--- a/web/book/src/syntax/expressions-and-operators.md
+++ b/web/book/src/syntax/expressions-and-operators.md
@@ -19,6 +19,8 @@ This table gives formal description of operator precedence. Because function
 calls have the lowest precedence, nested function calls or arguments that start
 or end with an operator require parentheses.
 
+<!-- markdownlint-disable MD033 — the `|` characters need to be escaped, and surrounded with tags rather than backticks   -->
+
 | Group          | Operators         | Precedence | Associativity |
 | -------------- | ----------------- | ---------- | ------------- |
 | identifier dot | `.`               | 1          |               |
@@ -29,5 +31,5 @@ or end with an operator require parentheses.
 | compare        | `== != <= >= < >` | 6          | left-to-right |
 | coalesce       | `??`              | 7          | left-to-right |
 | and            | `&&`              | 8          | left-to-right |
-| or             | \|\|              | 9          | left-to-right |
+| or             | <code>\|\|</code> | 9          | left-to-right |
 | function call  |                   | 10         |               |


### PR DESCRIPTION
The diff is bigger than it looks, rendered comparison forthcoming
