### PR TITLE
chore: Clean up some more `and` & `or` refs

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -64,7 +64,7 @@ Op_bin { Op_bin_only | Op_unary }
   Number { number_part "."? number_part? }
   space { " "+ }
   Comment { "#" ![\n]* }
-  Op_bin_only { "*" | "/" | "%" | "!=" | ">=" | "<=" | ">" | "<" | "??" | "and" | "or" }
+  Op_bin_only { "*" | "/" | "%" | "!=" | ">=" | "<=" | ">" | "<" | "??" | "&&" | "||" }
   Op_unary { "-" | "+" | "==" }
   end { @eof }
   newline { "\n" }

--- a/prql-compiler/src/parser/lexer.rs
+++ b/prql-compiler/src/parser/lexer.rs
@@ -395,8 +395,8 @@ impl std::fmt::Display for Token {
             Self::Ne => f.write_str("!="),
             Self::Gte => f.write_str(">="),
             Self::Lte => f.write_str("<="),
-            Self::And => f.write_str("and"),
-            Self::Or => f.write_str("or"),
+            Self::And => f.write_str("&&"),
+            Self::Or => f.write_str("||"),
             Self::Coalesce => f.write_str("??"),
 
             Self::Param(id) => write!(f, "${id}"),

--- a/web/playground/src/workbench/prql-syntax.js
+++ b/web/playground/src/workbench/prql-syntax.js
@@ -16,19 +16,12 @@ const TRANSFORMS = [
 const BUILTIN_FUNCTIONS = ["case"]; // "in", "as"
 const KEYWORDS = ["func", "let", "prql"];
 const LITERALS = ["null", "true", "false"];
-const OPERATORS = ["and", "or"]; // "not"
 
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
 
-  keywords: [
-    ...TRANSFORMS,
-    ...BUILTIN_FUNCTIONS,
-    ...KEYWORDS,
-    ...LITERALS,
-    ...OPERATORS,
-  ],
+  keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
 
   operators: [
     "-",
@@ -45,6 +38,8 @@ const def = {
     "<",
     ">=",
     "<=",
+    "&&",
+    "||",
     "??",
   ],
 


### PR DESCRIPTION
Found by searching for `"and"`
