### PR TITLE
test: Force amd64 image for mssql image

### DIFF
--- a/prql-compiler/tests/integration/docker-compose.yml
+++ b/prql-compiler/tests/integration/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   postgres:
+    # These aren't tagged yet, since there's no dependabot support for
+    # docker-compose yet: https://github.com/dependabot/dependabot-core/issues/390
     image: "postgres:alpine"
     ports:
       - "5432:5432"
@@ -32,9 +34,11 @@ services:
   #      REPODB: false
   #      IS_OSXFS: false
   mssql:
-    image: "mcr.microsoft.com/mssql/server:latest"
+    image: "mcr.microsoft.com/mssql/server"
     ports:
       - "1433:1433"
+    # https://github.com/microsoft/mssql-docker/issues/668#issuecomment-1436802153
+    platform: linux/amd64
     environment:
       ACCEPT_EULA: Y
       MSSQL_PID: Developer


### PR DESCRIPTION
No arm64 available, so this fails on arm64 machines.

Also add a comments re the tags
