### PR TITLE
internal: Add TODO re `run_query` method

### DIFF
--- a/prql-compiler/tests/integration/connection.rs
+++ b/prql-compiler/tests/integration/connection.rs
@@ -29,6 +29,10 @@ pub struct MysqlConnection(pub mysql::Pool);
 pub struct MssqlConnection(pub tiberius::Client<Compat<TcpStream>>);
 
 pub trait DBConnection {
+    // TODO: possibly this should return a Result instead of panicking on
+    // errors, and the caller can then state which dialect and query is being
+    // run. Currently the errors in CI are a bit confusing (though it's possible
+    // to use the line number, so not woeful).
     fn run_query(&mut self, sql: &str, runtime: &Runtime) -> Vec<Row>;
 
     fn import_csv(&mut self, csv_name: &str, runtime: &Runtime);


### PR DESCRIPTION
Not quite substanitve enough for an issue, too salient to ignore, so adding a TODO
