### PR TITLE
fix: Add PartialEq to MessageKind enum

### DIFF
--- a/prql-compiler/src/error.rs
+++ b/prql-compiler/src/error.rs
@@ -37,7 +37,7 @@ pub struct SourceLocation {
 }
 
 /// Compile message kind. Currently only Error is implemented.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum MessageKind {
     Error,
     Warning,

--- a/prql-compiler/src/error.rs
+++ b/prql-compiler/src/error.rs
@@ -37,7 +37,7 @@ pub struct SourceLocation {
 }
 
 /// Compile message kind. Currently only Error is implemented.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum MessageKind {
     Error,
     Warning,


### PR DESCRIPTION
The `PartialEq` trait is needed in order to able to compare `MessageKind`.

Without this you get:
> error[[E0369]](https://doc.rust-lang.org/stable/error_codes/E0369.html): binary operation `==` cannot be applied to type `MessageKind`