### PR TITLE
fix(prql-compiler): allow `SELECT\n` in s-strings representing a table

### DIFF
--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -400,13 +400,14 @@ pub(super) fn translate_query_sstring(
 ) -> Result<sql_ast::Query> {
     let string = translate_sstring(items, context)?;
 
+    let re = Regex::new(r"(?i)^SELECT(\s|\n|\r)").unwrap();
     let prefix = if let Some(string) = string.trim().get(0..7) {
         string
     } else {
         ""
     };
 
-    if prefix.eq_ignore_ascii_case("SELECT ") {
+    if re.is_match(prefix) {
         if let Some(string) = string.trim().strip_prefix(prefix) {
             return Ok(sql_ast::Query {
                 body: Box::new(sql_ast::SetExpr::Select(Box::new(sql_ast::Select {

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -1747,6 +1747,12 @@ fn test_bare_s_string() {
     FROM
       a
     "###);
+
+    assert_display_snapshot!(compile(r###"
+    from s"SELECTfoo"
+    "###).unwrap_err(), @r###"
+    Error: s-strings representing a table must start with `SELECT `
+    "###);
 }
 
 #[test]
@@ -2655,12 +2661,6 @@ fn test_table_s_string() {
       table_0 AS table_1
     "###
     );
-
-    assert_display_snapshot!(compile(r###"
-    from s"SELECTfoo"
-    "###).unwrap_err(), @r###"
-    Error: s-strings representing a table must start with `SELECT `
-    "###);
 }
 
 #[test]

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -1716,7 +1716,7 @@ fn test_bare_s_string() {
     "###
     );
 
-    // Check SLECT\n.
+    // Check SELECT\n.
     let query = r###"
     let a = s"
     SELECT

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -1715,6 +1715,38 @@ fn test_bare_s_string() {
       a
     "###
     );
+
+    // Check SLECT\n.
+    let query = r###"
+    let a = s"
+    SELECT
+      foo
+    FROM
+      bar"
+
+    from a
+    "###;
+
+    let sql = compile(query).unwrap();
+    assert_display_snapshot!(sql,
+      @r###"
+    WITH table_0 AS (
+      SELECT
+        foo
+      FROM
+        bar
+    ),
+    a AS (
+      SELECT
+        *
+      FROM
+        table_0 AS table_1
+    )
+    SELECT
+      *
+    FROM
+      a
+    "###);
 }
 
 #[test]
@@ -2623,6 +2655,12 @@ fn test_table_s_string() {
       table_0 AS table_1
     "###
     );
+
+    assert_display_snapshot!(compile(r###"
+    from s"SELECTfoo"
+    "###).unwrap_err(), @r###"
+    Error: s-strings representing a table must start with `SELECT `
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
Fix #2430