### PR TITLE
test: Add prqlc test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
 dependencies = [
- "anstyle",
+ "anstyle 0.3.5",
  "anstyle-parse",
  "anstyle-wincon",
  "concolor-override",
@@ -94,6 +94,12 @@ name = "anstyle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
@@ -110,7 +116,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
 dependencies = [
- "anstyle",
+ "anstyle 0.3.5",
  "windows-sys 0.45.0",
 ]
 
@@ -292,6 +298,21 @@ dependencies = [
  "arrow-select",
  "regex",
  "regex-syntax 0.6.28",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
+dependencies = [
+ "anstyle 1.0.0",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -663,7 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
 dependencies = [
  "anstream",
- "anstyle",
+ "anstyle 0.3.5",
  "bitflags 1.3.2",
  "clap_lex 0.4.1",
  "once_cell",
@@ -1128,6 +1149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1164,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "duckdb"
@@ -1351,6 +1384,15 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2302,6 +2344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,6 +2766,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle 1.0.0",
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty-hex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,6 +2934,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "ariadne",
+ "assert_cmd",
  "atty",
  "clap 4.2.0",
  "clio",
@@ -2866,6 +2946,7 @@ dependencies = [
  "itertools",
  "minijinja",
  "notify",
+ "predicates",
  "prql-compiler",
  "regex",
  "serde",
@@ -3642,6 +3723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,6 +4135,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
 dependencies = [
- "anstyle 0.3.5",
+ "anstyle",
  "anstyle-parse",
  "anstyle-wincon",
  "concolor-override",
@@ -94,12 +94,6 @@ name = "anstyle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
-
-[[package]]
-name = "anstyle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
@@ -116,7 +110,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
 dependencies = [
- "anstyle 0.3.5",
+ "anstyle",
  "windows-sys 0.45.0",
 ]
 
@@ -298,21 +292,6 @@ dependencies = [
  "arrow-select",
  "regex",
  "regex-syntax 0.6.28",
-]
-
-[[package]]
-name = "assert_cmd"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
-dependencies = [
- "anstyle 1.0.0",
- "bstr",
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
 ]
 
 [[package]]
@@ -684,7 +663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
 dependencies = [
  "anstream",
- "anstyle 0.3.5",
+ "anstyle",
  "bitflags 1.3.2",
  "clap_lex 0.4.1",
  "once_cell",
@@ -1149,12 +1128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,12 +1137,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "duckdb"
@@ -1384,15 +1351,6 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1824,6 +1782,17 @@ dependencies = [
  "similar",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "insta-cmd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cb631fa6f0f228ef5c5d05cc66b3c2455c398536b97621a0f0316621bbae47"
+dependencies = [
+ "insta",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2344,12 +2313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "notify"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,37 +2729,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "predicates"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
-dependencies = [
- "anstyle 1.0.0",
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "pretty-hex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,7 +2866,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "ariadne",
- "assert_cmd",
  "atty",
  "clap 4.2.0",
  "clio",
@@ -2943,10 +2874,10 @@ dependencies = [
  "concolor-clap",
  "env_logger",
  "insta",
+ "insta-cmd",
  "itertools",
  "minijinja",
  "notify",
- "predicates",
  "prql-compiler",
  "regex",
  "serde",
@@ -3723,12 +3654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,15 +4060,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/prql-compiler/prqlc/Cargo.toml
+++ b/prql-compiler/prqlc/Cargo.toml
@@ -12,7 +12,7 @@ version.workspace = true
 anyhow = {version = "1.0.57"}
 ariadne = "0.2.0"
 atty = "0.2.14"
-clap = {version = "4.2.0", features = ["derive", "env"]}
+clap = {version = "4.2.0", features = ["derive", "env", "wrap_help"]}
 clio = {version = "0.2.4", features = ['clap-parse']}
 color-eyre = "0.6.1"
 concolor = "0.1.0"

--- a/prql-compiler/prqlc/Cargo.toml
+++ b/prql-compiler/prqlc/Cargo.toml
@@ -20,7 +20,7 @@ concolor-clap = {version = "0.1.0", features = ["api"]}
 env_logger = {version = "0.10.0", features = ["color"]}
 itertools = "0.10.3"
 notify = "^5.1.0"
-prql-compiler = {path = '..', version = "0.8.0" }
+prql-compiler = {path = '..', version = "0.8.0"}
 regex = {version = "1.8.1", features = ["std", "unicode"]}
 serde = "^1"
 serde_json = "1.0.81"
@@ -32,4 +32,6 @@ walkdir = "^2.3.2"
 minijinja = {version = "=0.31.0", features = ["unstable_machinery"]}
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
+assert_cmd = "2.0.11"
 insta = {version = "1.29", features = ["colors", "glob", "yaml"]}
+predicates = "3.0.3"

--- a/prql-compiler/prqlc/Cargo.toml
+++ b/prql-compiler/prqlc/Cargo.toml
@@ -32,6 +32,5 @@ walkdir = "^2.3.2"
 minijinja = {version = "=0.31.0", features = ["unstable_machinery"]}
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
-assert_cmd = "2.0.11"
 insta = {version = "1.29", features = ["colors", "glob", "yaml"]}
-predicates = "3.0.3"
+insta-cmd = "0.2.0"

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -4,6 +4,9 @@ use insta_cmd::assert_cmd_snapshot;
 use insta_cmd::get_cargo_bin;
 use std::process::Command;
 
+// Windows has slightly different outputs (e.g. `prqlc.exe` instead of `prqlc`),
+// so we exclude.
+#[cfg(not(target_family = "windows"))]
 #[test]
 fn test_help() {
     assert_cmd_snapshot!(Command::new(get_cargo_bin("prqlc")).arg("--help"), @r###"

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -1,20 +1,58 @@
 #![cfg(not(target_family = "wasm"))]
 
-use prql_compiler::Target;
+use insta_cmd::assert_cmd_snapshot;
+use insta_cmd::get_cargo_bin;
+use std::process::Command;
 
 #[test]
-fn get_targets() {
-    use assert_cmd;
-    let n_targets = Target::names().len();
+fn test_help() {
+    assert_cmd_snapshot!(Command::new(get_cargo_bin("prqlc")).arg("--help"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Usage: prqlc [OPTIONS] <COMMAND>
 
-    assert_cmd::Command::cargo_bin("prqlc")
-        .unwrap()
-        .args(["get-targets"])
-        .assert()
-        .success()
-        .stdout(
-            predicates::str::is_match(r"sql\.[a-z]+\n")
-                .unwrap()
-                .count(n_targets),
-        );
+    Commands:
+      parse           Parse into PL AST
+      fmt             Parse & generate PRQL code back
+      annotate        Parse, resolve & combine source with comments annotating relation type
+      debug           Parse & resolve, but don't lower into RQ
+      resolve         Parse, resolve & lower into RQ
+      sql:preprocess  Parse, resolve, lower into RQ & preprocess SRQ
+      sql:anchor      Parse, resolve, lower into RQ & preprocess & anchor SRQ
+      compile         Parse, resolve, lower into RQ & compile to SQL
+      watch           Watch a directory and compile .prql files to .sql files
+      get-targets     Show available compile target names
+      help            Print this message or the help of the given subcommand(s)
+
+    Options:
+          --color <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
+      -h, --help          Print help
+      -V, --version       Print version
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
+fn test_get_targets() {
+    assert_cmd_snapshot!(Command::new(get_cargo_bin("prqlc")).arg("get-targets"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    sql.any
+    sql.ansi
+    sql.bigquery
+    sql.clickhouse
+    sql.duckdb
+    sql.generic
+    sql.hive
+    sql.mssql
+    sql.mysql
+    sql.postgres
+    sql.sqlite
+    sql.snowflake
+
+    ----- stderr -----
+    "###);
 }

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -1,0 +1,20 @@
+#![cfg(not(target_family = "wasm"))]
+
+use prql_compiler::Target;
+
+#[test]
+fn get_targets() {
+    use assert_cmd;
+    let n_targets = Target::names().len();
+
+    assert_cmd::Command::cargo_bin("prqlc")
+        .unwrap()
+        .args(["get-targets"])
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::is_match(r"sql\.[a-z]+\n")
+                .unwrap()
+                .count(n_targets),
+        );
+}

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -26,7 +26,8 @@ fn test_help() {
       help            Print this message or the help of the given subcommand(s)
 
     Options:
-          --color <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
+          --color <WHEN>  Controls when to use color [default: auto] [possible values: auto, always,
+                          never]
       -h, --help          Print help
       -V, --version       Print version
 


### PR DESCRIPTION
~This is code from #2488. It passes locally, I wanted to see whether it passed in CI too.~

Two points:
- I _think_ the key is to add this as an integration test, not a unit test. The existing method works
- While CI tests were running I changed to use `insta-cmd`'s `get_cargo_bin` function. But actually I think it works without that — the original `assert_cmd` tests passed (and regardless we could use it with that.

Would close #177

What do folks think? @eitsupi ? Would you prefer the `assert_cmd`? It does have more following. But the snapshots do seem like good tests?