### PR TITLE
chore: Rename CLI `list-targets`

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -95,8 +95,8 @@ enum Command {
     Watch(watch::WatchArgs),
 
     /// Show available compile target names
-    #[command(name = "get-targets")]
-    GetTargets,
+    #[command(name = "list-targets")]
+    ListTargets,
 }
 
 #[derive(clap::Args, Default, Debug, Clone)]
@@ -123,14 +123,14 @@ impl Command {
     pub fn run(&mut self) -> Result<()> {
         match self {
             Command::Watch(command) => watch::run(command),
-            Command::GetTargets => self.get_targets(),
+            Command::ListTargets => self.list_targets(),
             _ => self.run_io_command(),
         }
     }
 
-    fn get_targets(&self) -> std::result::Result<(), anyhow::Error> {
+    fn list_targets(&self) -> std::result::Result<(), anyhow::Error> {
         let res: Result<std::string::String, anyhow::Error> = Ok(match self {
-            Command::GetTargets => Target::names().join("\n"),
+            Command::ListTargets => Target::names().join("\n"),
             _ => unreachable!(),
         });
 

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -25,7 +25,7 @@ fn test_help() {
       sql:anchor      Parse, resolve, lower into RQ & preprocess & anchor SRQ
       compile         Parse, resolve, lower into RQ & compile to SQL
       watch           Watch a directory and compile .prql files to .sql files
-      get-targets     Show available compile target names
+      list-targets    Show available compile target names
       help            Print this message or the help of the given subcommand(s)
 
     Options:
@@ -40,7 +40,7 @@ fn test_help() {
 
 #[test]
 fn test_get_targets() {
-    assert_cmd_snapshot!(Command::new(get_cargo_bin("prqlc")).arg("get-targets"), @r###"
+    assert_cmd_snapshot!(Command::new(get_cargo_bin("prqlc")).arg("list-targets"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
I don't want to be intruding on others' work, and totally fine to reject this if it feels like an imposition.

On reflection, because this is an interface, it'll be difficult to change it later. And I would think it's better to be consistent with idioms than internally consistent...
