### PR TITLE
build: Bump `prql-js` in playground

### DIFF
--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "../../bindings/prql-js": {
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.6",


### PR DESCRIPTION
Our auto-bumping seems not to have worked, I'll check that out
