### PR TITLE
build: Add missing release replacement

### DIFF
--- a/bindings/prql-js/Cargo.toml
+++ b/bindings/prql-js/Cargo.toml
@@ -55,10 +55,10 @@ search = '(  "version": )"(\d+\.\d+\.\d+)"'
 [[package.metadata.release.pre-release-replacements]]
 exactly = 2
 file = "package-lock.json"
-replace = '''
-$1
-$2"{{version}}"'''
-search = '(\s+"prql-js",)\n(\s+"version": )"[\d\.]+"'
+replace = '$1"{{version}}"'
+search = '''
+(".*/prql-js": \{
+\s+"version": )"[\d\.]+"'''
 
 [[package.metadata.release.pre-release-replacements]]
 exactly = 1
@@ -69,7 +69,15 @@ search = '(  "version": )"(\d+\.\d+\.\d+)"'
 [[package.metadata.release.pre-release-replacements]]
 exactly = 2
 file = "../../web/playground/package-lock.json"
-replace = '''
-$1
-$2"{{version}}"'''
-search = '(\s+"prql-playground",)\n(\s+"version": )"[\d\.]+"'
+replace = '$1"{{version}}"'
+search = '''
+(\s+"prql-playground",
+\s+"version": )"[\d\.]+"'''
+
+[[package.metadata.release.pre-release-replacements]]
+exactly = 1
+file = "../../web/playground/package-lock.json"
+replace = '$1"{{version}}"'
+search = '''
+(".*/bindings/prql-js": \{
+\s+"version": )"[\d\.]+"'''


### PR DESCRIPTION
Also simplifies the existing ones slightly (but also amybe there are better ways to do this — partly this is just text-editing because of the rust <> JS coherence mismatch...)
