### PR TITLE
web: Add `run-web` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -255,7 +255,7 @@ tasks:
       # prql-lang.org/playground with an iframe containing the playground.
       # Possibly there's a more elegant way of doing this...
       - rsync -ai --checksum --delete playground/build/
-        website/public/playground/playground
+        website/public/playground/playground/
 
   test-js:
     dir: bindings/prql-js
@@ -277,6 +277,17 @@ tasks:
     dir: web/website
     cmds:
       - hugo server
+
+  run-web:
+    desc: Build & serve the website & playground.
+    summary:
+      Note that this only live-reloads the static website; and requires
+      rerunning to pick up playground & book changes.
+    dir: web/website
+    cmds:
+      - task: build-web
+      # Then start web server with rendering to disk, so it picks up the playground files.
+      - hugo server --renderToDisk
 
   run-book:
     desc: Build & serve the book.

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "npm run genBook && react-scripts build",
     "eject": "npm run genBook && react-scripts eject",
-    "preinstall": "cp -r ../../prql-compiler/tests/integration/data public",
+    "preinstall": "rsync -ai --checksum --delete ../../prql-compiler/tests/integration/data/ public/data/",
     "start": "npm run genBook && react-scripts start",
     "test": "npm run genBook && react-scripts test",
     "genBook": "node generateBook.js"


### PR DESCRIPTION
And use `cp` rather than `rsync` so we can ensure we get the same semantics (could also use `cp -T`. `rsync` slightly faster for repeated runs.)
