### PR TITLE
fix: incorrect "or" syntax in examples.js

### DIFF
--- a/web/playground/src/examples.js
+++ b/web/playground/src/examples.js
@@ -37,7 +37,7 @@ derive db_version = s"version()" # S-string, escape hatch to SQL
 
 let high_energy = (
   from genres
-  filter name == 'Rock And Roll' or name == 'Hip Hop/Rap'
+  filter name == 'Rock And Roll' || name == 'Hip Hop/Rap'
 )
 
 from t=tracks


### PR DESCRIPTION
Not sure if small changes like this are welcome. Feel free to close and fix elsewhere.