### PR TITLE
internal: Move `translate_regex` into dialect

### DIFF
--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -12,15 +12,10 @@
 //! As a consequence, generated SQL may be verbose, since it will avoid newer or less adopted SQL
 //! constructs. The upside is much less complex translator.
 
-
-
 use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::{
-    self as sql_ast, Function, FunctionArg, FunctionArgExpr,
-    ObjectName,
-};
+use sqlparser::ast::{self as sql_ast, Function, FunctionArg, FunctionArgExpr, ObjectName};
 use std::any::{Any, TypeId};
 use strum::{EnumMessage, IntoEnumIterator};
 

--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -12,8 +12,15 @@
 //! As a consequence, generated SQL may be verbose, since it will avoid newer or less adopted SQL
 //! constructs. The upside is much less complex translator.
 
+
+
 use core::fmt::Debug;
+
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::{
+    self as sql_ast, Function, FunctionArg, FunctionArgExpr,
+    ObjectName,
+};
 use std::any::{Any, TypeId};
 use strum::{EnumMessage, IntoEnumIterator};
 
@@ -170,6 +177,43 @@ pub(super) trait DialectHandler: Any + Debug {
 
     fn regex_function(&self) -> Option<&'static str> {
         Some("REGEXP")
+    }
+
+    fn translate_regex(
+        &self,
+        search: sql_ast::Expr,
+        target: sql_ast::Expr,
+    ) -> anyhow::Result<sql_ast::Expr> {
+        // When
+        // https://github.com/sqlparser-rs/sqlparser-rs/issues/863#issuecomment-1537272570
+        // is fixed, we can implement the infix for the other dialects. Until
+        // then, we still only have the `regex_function` implementations. (But
+        // I'd done the work to allow any Expr to be created before realizing
+        // sqlparser-rs didn't support custom operators, so may as well leave it
+        // in for when they do / we find another approach.)
+
+        let Some(regex_function) = self.regex_function() else {
+            // TODO: name the dialect, but not immediately obvious how to actually
+            // get the dialect string from a `DialectHandler` (though we could
+            // add it to each impl...)
+            //
+            // MSSQL doesn't support them, MySQL & SQLite have a different construction.
+            anyhow::bail!("regex functions are not supported by this dialect (or PRQL doesn't yet implement this dialect)");
+        };
+
+        let args = [search, target]
+            .into_iter()
+            .map(FunctionArgExpr::Expr)
+            .map(FunctionArg::Unnamed)
+            .collect();
+
+        Ok(sql_ast::Expr::Function(Function {
+            name: ObjectName(vec![sql_ast::Ident::new(regex_function)]),
+            args,
+            over: None,
+            distinct: false,
+            special: false,
+        }))
     }
 }
 

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -218,30 +218,10 @@ fn process_concat(expr: &Expr, ctx: &mut Context) -> Result<sql_ast::Expr> {
 }
 
 fn process_regex(search: &Expr, target: &Expr, ctx: &mut Context) -> Result<sql_ast::Expr> {
-    let Some(regex_function) = ctx.dialect.regex_function() else {
-        // TODO: name the dialect, but not immediately obvious how to actually
-        // get the dialect string from a `DialectHandler`.
-        //
-        // MSSQL doesn't support them, MySQL & SQLite have a different construction.
-        bail!("regex functions are not supported by this dialect (or PRQL doesn't yet implement this dialect)");
-    };
+    let search = translate_expr(search.clone(), ctx)?;
+    let target = translate_expr(target.clone(), ctx)?;
 
-    let args = [search, target]
-        .into_iter()
-        .map(|a| {
-            translate_expr(a.clone(), ctx)
-                .map(FunctionArgExpr::Expr)
-                .map(FunctionArg::Unnamed)
-        })
-        .try_collect()?;
-
-    Ok(sql_ast::Expr::Function(Function {
-        name: ObjectName(vec![sql_ast::Ident::new(regex_function)]),
-        args,
-        over: None,
-        distinct: false,
-        special: false,
-    }))
+    ctx.dialect.translate_regex(search, target)
 }
 
 fn translate_binary_operator(


### PR DESCRIPTION
We actually can't do what I'd hoped re mysql & sqlite yet https://github.com/sqlparser-rs/sqlparser-rs/issues/863#issuecomment-1537272570, but this prepares the ground for when that's available

It's also the first `translate_*` to move into the DialectHandler. (I think one eventual approach is that DialectHandler does _all_ translations. But no need to start on that until it's required; only doing this one `translate` func). And ofc open to feedback if that's not the right approach here.
