### PR TITLE
internal: Use `strum` to produce variant names

### DIFF
--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -94,6 +94,7 @@ use once_cell::sync::Lazy;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use strum::VariantNames;
 
 pub static PRQL_VERSION: Lazy<Version> =
     Lazy::new(|| Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid PRQL version number"));
@@ -147,8 +148,8 @@ impl Target {
     pub fn names() -> Vec<String> {
         let mut names = vec!["sql.any".to_string()];
 
-        let dialects = sql::Dialect::names();
-        names.extend(dialects.into_iter().map(|d| format!("sql.{d}")));
+        let dialects = sql::Dialect::VARIANTS;
+        names.extend(dialects.iter().map(|d| format!("sql.{d}")));
 
         names
     }

--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -14,8 +14,9 @@
 
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
+
 use std::any::{Any, TypeId};
-use strum::{EnumMessage, IntoEnumIterator};
+use strum::VariantNames;
 
 /// SQL dialect.
 ///
@@ -36,6 +37,7 @@ use strum::{EnumMessage, IntoEnumIterator};
     strum::EnumIter,
     strum::EnumMessage,
     strum::EnumString,
+    strum::EnumVariantNames,
 )]
 pub enum Dialect {
     #[strum(serialize = "ansi")]
@@ -81,10 +83,9 @@ impl Dialect {
         }
     }
 
-    pub fn names() -> Vec<&'static str> {
-        Dialect::iter()
-            .flat_map(|d| d.get_serializations().to_vec())
-            .collect::<Vec<&'static str>>()
+    #[deprecated(note = "Use `Dialect::Variants` instead")]
+    pub fn names() -> &'static [&'static str] {
+        Dialect::VARIANTS
     }
 }
 


### PR DESCRIPTION
I came across this feature, seems like an small but easy simplification
