### PR TITLE
internal: Use strum to serialize Dialect names

### DIFF
--- a/bindings/prql-elixir/native/prql/Cargo.toml
+++ b/bindings/prql-elixir/native/prql/Cargo.toml
@@ -16,7 +16,7 @@ name = "prql"
 path = "src/lib.rs"
 
 [dependencies]
-prql-compiler = {path = "../../../../prql-compiler", default-features = false, version = "0.8.1" }
+prql-compiler = {path = "../../../../prql-compiler", default-features = false, version = "0.8.1"}
 
 # See Readme for details on Mac
 [target.'cfg(not(any(target_family="wasm", target_os = "macos")))'.dependencies]

--- a/bindings/prql-elixir/native/prql/src/lib.rs
+++ b/bindings/prql-elixir/native/prql/src/lib.rs
@@ -43,30 +43,30 @@ fn to_result_tuple(result: Result<String, prql_compiler::ErrorMessages>) -> NifR
 
 /// Get the target from an atom. By default `Generic` SQL dialect will be used
 fn target_from_atom(a: Atom) -> prql_compiler::Target {
-    use prql_compiler::sql::Dialect as D;
+    use prql_compiler::sql::Dialect::*;
 
     prql_compiler::Target::Sql(Some(if a == atoms::ansi() {
-        D::Ansi
+        Ansi
     } else if a == atoms::bigquery() {
-        D::BigQuery
+        BigQuery
     } else if a == atoms::clickhouse() {
-        D::ClickHouse
+        ClickHouse
     } else if a == atoms::generic() {
-        D::Generic
+        Generic
     } else if a == atoms::hive() {
-        D::Hive
+        Hive
     } else if a == atoms::mssql() {
-        D::MsSql
+        MsSql
     } else if a == atoms::mysql() {
-        D::MySql
+        MySql
     } else if a == atoms::postgres() {
-        D::PostgreSql
+        Postgres
     } else if a == atoms::sqlite() {
-        D::SQLite
+        SQLite
     } else if a == atoms::snowflake() {
-        D::Snowflake
+        Snowflake
     } else {
-        D::Generic
+        Generic
     }))
 }
 

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -301,7 +301,7 @@ mod tests_lib {
         Ok(
             Sql(
                 Some(
-                    PostgreSql,
+                    Postgres,
                 ),
             ),
         )

--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -37,28 +37,18 @@ use strum::{EnumMessage, IntoEnumIterator};
     strum::EnumMessage,
     strum::EnumString,
 )]
+#[strum(serialize_all = "lowercase")]
 pub enum Dialect {
-    #[strum(serialize = "ansi")]
     Ansi,
-    #[strum(serialize = "bigquery")]
     BigQuery,
-    #[strum(serialize = "clickhouse")]
     ClickHouse,
-    #[strum(serialize = "duckdb")]
     DuckDb,
-    #[strum(serialize = "generic")]
     Generic,
-    #[strum(serialize = "hive")]
     Hive,
-    #[strum(serialize = "mssql")]
     MsSql,
-    #[strum(serialize = "mysql")]
     MySql,
-    #[strum(serialize = "postgres")]
-    PostgreSql,
-    #[strum(serialize = "sqlite")]
+    Postgres,
     SQLite,
-    #[strum(serialize = "snowflake")]
     Snowflake,
 }
 
@@ -76,7 +66,7 @@ impl Dialect {
             Dialect::ClickHouse => Box::new(ClickHouseDialect),
             Dialect::Snowflake => Box::new(SnowflakeDialect),
             Dialect::DuckDb => Box::new(DuckDbDialect),
-            Dialect::PostgreSql => Box::new(PostgresDialect),
+            Dialect::Postgres => Box::new(PostgresDialect),
             Dialect::Ansi | Dialect::Generic | Dialect::Hive => Box::new(GenericDialect),
         }
     }
@@ -320,7 +310,7 @@ mod tests {
     fn test_dialect_from_str() {
         assert_debug_snapshot!(Dialect::from_str("postgres"), @r###"
         Ok(
-            PostgreSql,
+            Postgres,
         )
         "###);
 

--- a/prql-compiler/tests/integration/connection.rs
+++ b/prql-compiler/tests/integration/connection.rs
@@ -228,7 +228,7 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_dialect(&self) -> Dialect {
-        Dialect::PostgreSql
+        Dialect::Postgres
     }
 
     fn modify_sql(&self, sql: String) -> String {


### PR DESCRIPTION
Another refine-y simplification

This renames the postgres variant
