### PR TITLE
internal: Implement WithErrorInfo for anyhow::Error

### DIFF
--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -7,7 +7,7 @@ use semver::VersionReq;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Error, Reason, Span};
+use crate::error::{Error, Reason, Span, WithErrorInfo};
 
 use super::*;
 

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -15,7 +15,7 @@ use self::lexer::Token;
 
 use super::ast::pl::*;
 
-use crate::error::{Error, Errors, Reason};
+use crate::error::{Error, Errors, Reason, WithErrorInfo};
 
 /// Build PL AST from a PRQL query string.
 pub fn parse(source: &str) -> Result<Vec<Stmt>> {

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, fmt::Debug};
 use super::module::{Module, NS_DEFAULT_DB, NS_FRAME, NS_FRAME_RIGHT, NS_INFER, NS_SELF, NS_STD};
 use crate::ast::pl::*;
 use crate::ast::rq::RelationColumn;
-use crate::error::{Error, Span};
+use crate::error::{Error, Span, WithErrorInfo};
 
 /// Context of the pipeline.
 #[derive(Default, Serialize, Deserialize, Clone)]

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -12,7 +12,7 @@ use crate::ast::pl::{
     WindowFrame,
 };
 use crate::ast::rq::{self, CId, Query, RelationColumn, TId, TableDecl, Transform};
-use crate::error::{Error, Reason, Span};
+use crate::error::{Error, Reason, Span, WithErrorInfo};
 use crate::semantic::context::TableExpr;
 use crate::semantic::module::Module;
 use crate::utils::{toposort, IdGenerator};

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail, Result};
 use itertools::{Itertools, Position};
 
 use crate::ast::pl::{fold::*, *};
-use crate::error::{Error, Reason, Span};
+use crate::error::{Error, Reason, Span, WithErrorInfo};
 use crate::semantic::static_analysis;
 use crate::semantic::transforms::coerce_and_flatten;
 use crate::utils::IdGenerator;

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -17,7 +17,7 @@ use crate::ast::pl::{
     ColumnSort, InterpolateItem, Literal, Range, SortDirection, WindowFrame, WindowKind,
 };
 use crate::ast::rq::*;
-use crate::error::{Error, Span};
+use crate::error::{Error, Span, WithErrorInfo};
 use crate::sql::context::ColumnDecl;
 use crate::utils::OrMap;
 

--- a/prql-compiler/src/sql/gen_projection.rs
+++ b/prql-compiler/src/sql/gen_projection.rs
@@ -9,7 +9,7 @@ use sqlparser::ast::{
 
 use crate::ast::rq::{CId, RelationColumn};
 
-use crate::error::{Error, Span};
+use crate::error::{Error, Span, WithErrorInfo};
 use crate::sql::context::ColumnDecl;
 
 use super::context::AnchorContext;

--- a/prql-compiler/src/sql/preprocess.rs
+++ b/prql-compiler/src/sql/preprocess.rs
@@ -9,7 +9,7 @@ use crate::ast::pl::{
     ColumnSort, InterpolateItem, JoinSide, Literal, Range, WindowFrame, WindowKind,
 };
 use crate::ast::rq::{self, CId, Compute, Expr, ExprKind, RqFold, Transform, Window};
-use crate::error::Error;
+use crate::error::{Error, WithErrorInfo};
 use crate::sql::context::AnchorContext;
 
 use super::anchor::{infer_complexity, CidCollector, Complexity};

--- a/prql-compiler/src/utils/only.rs
+++ b/prql-compiler/src/utils/only.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use crate::ast::pl::Expr;
-use crate::error::{Error, Reason};
+use crate::error::{Error, Reason, WithErrorInfo};
 
 pub trait ExactlyOneNode {
     fn exactly_one_node(self, who: &str, occupation: &str) -> Result<Expr, Error>;


### PR DESCRIPTION
This extends the approach discussed in https://github.com/PRQL/prql/pull/2535, making it possible to call `.with_span` on an `anyhow::Error` without inline downcasting. And on any `Result` containing a compatible `Error`.

On the downside, it requires each file `use`ing `WithErrorInfo`.