### PR TITLE
feat!: infering modules and treating them as SQL schemas

### DIFF
--- a/bindings/prql-elixir/test/prql_test.exs
+++ b/bindings/prql-elixir/test/prql_test.exs
@@ -27,10 +27,7 @@ defmodule PRQLTest do
             "code": null,
             "reason": "Unknown name invalid",
             "hint": null,
-            "span": {
-              "start": 0,
-              "end": 7
-            },
+            "span": "span-chars-0-7",
             "display": "Error: \n   ╭─[:1:1]\n   │\n 1 │ invalid\n   │ ───┬───  \n   │    ╰───── Unknown name invalid\n───╯\n",
             "location": {
               "start": [0, 0],

--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -495,7 +495,8 @@ group a_column (take 10 | sort b_column | derive [the_number = rank, last = lag 
         - id: 0
           name: null
           relation:
-            kind: !ExternRef x
+            kind: !ExternRef
+            - x
             columns:
             - !Single y
             - Wildcard

--- a/prql-compiler/src/ast/pl/ident.rs
+++ b/prql-compiler/src/ast/pl/ident.rs
@@ -66,6 +66,12 @@ impl Ident {
             .zip(self.iter())
             .all(|(prefix_component, self_component)| prefix_component == self_component)
     }
+
+    pub fn starts_with_part(&self, prefix: &str) -> bool {
+        std::iter::once(prefix)
+            .zip(self.iter())
+            .all(|(prefix_component, self_component)| prefix_component == self_component)
+    }
 }
 
 impl std::fmt::Display for Ident {

--- a/prql-compiler/src/ast/pl/ident.rs
+++ b/prql-compiler/src/ast/pl/ident.rs
@@ -26,6 +26,8 @@ impl Ident {
         }
     }
 
+    /// Remove last part of the ident.
+    /// Result will generally refer to the parent of this ident.
     pub fn pop(self) -> Option<Self> {
         let mut path = self.path;
         path.pop().map(|name| Ident { path, name })

--- a/prql-compiler/src/ast/pl/ident.rs
+++ b/prql-compiler/src/ast/pl/ident.rs
@@ -42,6 +42,12 @@ impl Ident {
         }
     }
 
+    pub fn prepend(self, part: String) -> Ident {
+        let mut parts = vec![part];
+        parts.extend(self.into_iter());
+        Ident::from_path(parts)
+    }
+
     pub fn with_name<S: ToString>(mut self, name: S) -> Self {
         self.name = name.to_string();
         self

--- a/prql-compiler/src/ast/pl/ident.rs
+++ b/prql-compiler/src/ast/pl/ident.rs
@@ -68,7 +68,9 @@ impl Ident {
     }
 
     pub fn starts_with_part(&self, prefix: &str) -> bool {
-       self.iter().next().map_or(false, |self_component| self_component == prefix)
+        self.iter()
+            .next()
+            .map_or(false, |self_component| self_component == prefix)
     }
 }
 

--- a/prql-compiler/src/ast/pl/ident.rs
+++ b/prql-compiler/src/ast/pl/ident.rs
@@ -68,9 +68,7 @@ impl Ident {
     }
 
     pub fn starts_with_part(&self, prefix: &str) -> bool {
-        std::iter::once(prefix)
-            .zip(self.iter())
-            .all(|(prefix_component, self_component)| prefix_component == self_component)
+       self.iter().next().map_or(false, |self_component| self_component == prefix)
     }
 }
 

--- a/prql-compiler/src/ast/rq/mod.rs
+++ b/prql-compiler/src/ast/rq/mod.rs
@@ -15,8 +15,8 @@ pub use transform::*;
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 
-use super::pl::{InterpolateItem, Ident};
 use super::pl::{ColumnSort, QueryDef, Range, RelationLiteral, WindowFrame};
+use super::pl::{Ident, InterpolateItem};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Query {

--- a/prql-compiler/src/ast/rq/mod.rs
+++ b/prql-compiler/src/ast/rq/mod.rs
@@ -15,7 +15,7 @@ pub use transform::*;
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 
-use super::pl::InterpolateItem;
+use super::pl::{InterpolateItem, Ident};
 use super::pl::{ColumnSort, QueryDef, Range, RelationLiteral, WindowFrame};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -37,7 +37,7 @@ pub struct Relation {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, EnumAsInner)]
 pub enum RelationKind {
-    ExternRef(String),
+    ExternRef(Ident),
     Pipeline(Vec<Transform>),
     Literal(RelationLiteral),
     SString(Vec<InterpolateItem<Expr>>),

--- a/prql-compiler/src/semantic/mod.rs
+++ b/prql-compiler/src/semantic/mod.rs
@@ -150,7 +150,8 @@ mod test {
             name: ~
             relation:
               kind:
-                ExternRef: employees
+                ExternRef:
+                  - employees
               columns:
                 - Wildcard
         relation:

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -355,11 +355,8 @@ impl Resolver {
     }
 
     pub fn resolve_ident(&mut self, ident: &Ident, span: Option<Span>) -> Result<Ident> {
-        let res = if ident.path.is_empty() && self.default_namespace.is_some() {
-            let defaulted = Ident {
-                path: vec![self.default_namespace.clone().unwrap()],
-                name: ident.name.clone(),
-            };
+        let res = if let Some(def) = &self.default_namespace {
+            let defaulted = ident.clone().prepend(def.to_string());
             self.context.resolve_ident(&defaulted)
         } else {
             self.context.resolve_ident(ident)

--- a/prql-compiler/src/semantic/std.prql
+++ b/prql-compiler/src/semantic/std.prql
@@ -49,15 +49,17 @@ func join<table> `default_db.with`<table> filter `noresolve.side`:inner tbl<tabl
 func group<table> by pipeline tbl<table> -> null
 func window<table> rows:0..0 range:0..0 expanding:false rolling:0 pipeline tbl<table> -> null
 
+func noop x -> x
+
 func append<table> `default_db.bottom`<table> top<table> -> null
 func intersect<table> `default_db.bottom`<table> top<table> -> (
-    from t = _param.top
-    join b = _param.bottom (all (map _eq (zip t.* b.*)))
+    noop t = top
+    join (noop b = bottom) (all (map _eq (zip t.* b.*)))
     select t.*
 )
 func remove<table> `default_db.bottom`<table> top<table> -> (
-    from t = _param.top
-    join side:left b = _param.bottom (all (map _eq (zip t.* b.*)))
+    noop t = top
+    join side:left (noop b = bottom) (all (map _eq (zip t.* b.*)))
     filter (all (map _is_null b.*))
     select t.*
 )

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -1040,7 +1040,8 @@ mod tests {
             name: ~
             relation:
               kind:
-                ExternRef: c_invoice
+                ExternRef:
+                  - c_invoice
               columns:
                 - Single: invoice_no
                 - Wildcard
@@ -1199,7 +1200,8 @@ mod tests {
             name: ~
             relation:
               kind:
-                ExternRef: invoices
+                ExternRef:
+                  - invoices
               columns:
                 - Single: issued_at
                 - Single: amount

--- a/prql-compiler/src/sql/gen_projection.rs
+++ b/prql-compiler/src/sql/gen_projection.rs
@@ -7,6 +7,7 @@ use sqlparser::ast::{
     WildcardAdditionalOptions,
 };
 
+use crate::ast::pl::Ident;
 use crate::ast::rq::{CId, RelationColumn};
 use crate::error::{Error, Span, WithErrorInfo};
 
@@ -34,7 +35,7 @@ pub(super) fn try_into_exprs(
 
         // star
         let t = &ctx.anchor.relation_instances[riid];
-        let table_name = t.table_ref.name.clone();
+        let table_name = t.table_ref.name.clone().map(Ident::from_name);
 
         let ident = translate_star(ctx, span)?;
         if let Some(excluded) = excluded.get(&cid) {
@@ -134,7 +135,7 @@ pub(super) fn translate_select_items(
 
             // wildcard case
             let t = &ctx.anchor.relation_instances[riid];
-            let table_name = t.table_ref.name.clone();
+            let table_name = t.table_ref.name.clone().map(Ident::from_name);
 
             let ident = translate_ident(table_name, Some("*".to_string()), ctx);
 

--- a/prql-compiler/src/sql/srq/gen_query.rs
+++ b/prql-compiler/src/sql/srq/gen_query.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use anyhow::Result;
 use itertools::Itertools;
 
+use crate::ast::pl::Ident;
 use crate::ast::rq::{Query, RelationKind, RqFold, TableRef, Transform};
 use crate::utils::BreakUp;
 use crate::Target;
@@ -232,7 +233,7 @@ fn compile_loop(
 
     let recursive_name = "_loop".to_string();
     let initial = ctx.anchor.table_decls.get_mut(&from.source).unwrap();
-    initial.name = Some(recursive_name.clone());
+    initial.name = Some(Ident::from_name(recursive_name.clone()));
 
     // compile initial
     let initial = if let RelationStatus::NotYetDefined(rel) = initial.relation.take_to_define() {
@@ -259,7 +260,7 @@ fn compile_loop(
     let loop_decl = ctx.anchor.table_decls.get_mut(&from.source).unwrap();
 
     let loop_name = ctx.anchor.table_name.gen();
-    loop_decl.name = Some(loop_name);
+    loop_decl.name = Some(Ident::from_name(loop_name));
     loop_decl.relation = RelationStatus::Defined;
 
     // push the whole thing into WITH of the main query

--- a/prql-compiler/src/sql/srq/postprocess.rs
+++ b/prql-compiler/src/sql/srq/postprocess.rs
@@ -1,3 +1,7 @@
+//! An AST pass after compilation to SRQ.
+//!
+//! Currently only moves [SqlTransform::Sort]s.
+
 use std::collections::HashMap;
 
 use anyhow::Result;

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -3492,6 +3492,22 @@ fn test_upper() {
 }
 
 #[test]
+fn test_1535() -> anyhow::Result<()> {
+    assert_display_snapshot!(compile(r#"
+    from x.y.z
+    "#)?,
+        @r###"
+    SELECT
+      UPPER(name) AS upper_name
+    FROM
+      test_tables
+    "###
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_read_parquet_duckdb() {
     assert_display_snapshot!(compile(r#"
     from (read_parquet 'x.parquet')

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -182,7 +182,7 @@ fn test_append() {
         take 10
     )
     "###).unwrap(), @r###"
-    WITH table_0 AS (
+    WITH table_3 AS (
       SELECT
         *,
         name,
@@ -210,7 +210,7 @@ fn test_append() {
     SELECT
       *
     FROM
-      table_0 AS table_1
+      table_3 AS table_1
     "###);
 
     assert_display_snapshot!(compile(r###"
@@ -287,7 +287,7 @@ fn test_remove() {
     )
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         artist_id
       FROM
@@ -302,7 +302,7 @@ fn test_remove() {
     SELECT
       *
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 
@@ -314,7 +314,7 @@ fn test_remove() {
     )
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         artist_id
       FROM
@@ -325,7 +325,7 @@ fn test_remove() {
       album.title
     FROM
       album
-      LEFT JOIN table_0 AS table_1 ON album.artist_id = table_1.artist_id
+      LEFT JOIN table_2 AS table_1 ON album.artist_id = table_1.artist_id
     WHERE
       table_1.artist_id IS NULL
     "###
@@ -422,7 +422,7 @@ fn test_intersect() {
     )
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         artist_id
       FROM
@@ -437,7 +437,7 @@ fn test_intersect() {
     SELECT
       *
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 
@@ -453,7 +453,7 @@ fn test_intersect() {
     distinct
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_4 AS (
       SELECT
         artist_id
       FROM
@@ -469,7 +469,7 @@ fn test_intersect() {
       SELECT
         *
       FROM
-        table_0 AS table_1
+        table_4 AS table_1
     )
     SELECT
       DISTINCT artist_id
@@ -489,7 +489,7 @@ fn test_intersect() {
     distinct
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_4 AS (
       SELECT
         artist_id
       FROM
@@ -505,7 +505,7 @@ fn test_intersect() {
       SELECT
         *
       FROM
-        table_0 AS table_1
+        table_4 AS table_1
     )
     SELECT
       DISTINCT artist_id
@@ -525,7 +525,7 @@ fn test_intersect() {
     )
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         artist_id
       FROM
@@ -540,7 +540,7 @@ fn test_intersect() {
     SELECT
       *
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 
@@ -612,11 +612,11 @@ derive `from` = 5
     )
     SELECT
       "UPPER".*,
-      some_schema.tablename.*,
+      "some_schema.tablename".*,
       5 AS "from"
     FROM
       "UPPER"
-      JOIN some_schema.tablename ON "UPPER".id = some_schema.tablename.id
+      JOIN "some_schema.tablename" ON "UPPER".id = "some_schema.tablename".id
     "###);
 
     // GH-1493
@@ -1637,7 +1637,7 @@ fn test_bare_s_string() {
     let sql = compile(query).unwrap();
     assert_display_snapshot!(sql,
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         SUM(a)
       FROM
@@ -1649,7 +1649,7 @@ fn test_bare_s_string() {
       SELECT
         *
       FROM
-        table_0 AS table_1
+        table_2 AS table_1
     )
     SELECT
       *
@@ -1667,7 +1667,7 @@ fn test_bare_s_string() {
     let sql = compile(query).unwrap();
     assert_display_snapshot!(sql,
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         insensitive
       from
@@ -1677,7 +1677,7 @@ fn test_bare_s_string() {
       SELECT
         *
       FROM
-        table_0 AS table_1
+        table_2 AS table_1
     )
     SELECT
       *
@@ -1695,7 +1695,7 @@ fn test_bare_s_string() {
     let sql = compile(query).unwrap();
     assert_display_snapshot!(sql,
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         insensitive
       from
@@ -1705,7 +1705,7 @@ fn test_bare_s_string() {
       SELECT
         *
       FROM
-        table_0 AS table_1
+        table_2 AS table_1
     )
     SELECT
       *
@@ -1728,7 +1728,7 @@ fn test_bare_s_string() {
     let sql = compile(query).unwrap();
     assert_display_snapshot!(sql,
       @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         foo
       FROM
@@ -1738,7 +1738,7 @@ fn test_bare_s_string() {
       SELECT
         *
       FROM
-        table_0 AS table_1
+        table_2 AS table_1
     )
     SELECT
       *
@@ -2436,7 +2436,7 @@ fn test_inline_tables() {
     join s = (from salaries | select [emp_id, salary]) [==emp_id]
     "###).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         emp_id,
         salary
@@ -2453,7 +2453,7 @@ fn test_inline_tables() {
       table_1.salary
     FROM
       employees
-      JOIN table_0 AS table_1 ON employees.emp_id = table_1.emp_id
+      JOIN table_2 AS table_1 ON employees.emp_id = table_1.emp_id
     "###
     );
 }
@@ -2538,7 +2538,7 @@ fn test_table_s_string() {
     s"SELECT DISTINCT ON first_name, age FROM employees ORDER BY age ASC"
     "###).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         DISTINCT ON first_name,
         age
@@ -2549,7 +2549,7 @@ fn test_table_s_string() {
     )
     SELECT
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 
@@ -2560,7 +2560,7 @@ fn test_table_s_string() {
     join s = s"SELECT * FROM salaries" [==id]
     "###).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_4 AS (
       SELECT
         DISTINCT ON first_name,
         id,
@@ -2570,7 +2570,7 @@ fn test_table_s_string() {
       ORDER BY
         age ASC
     ),
-    table_1 AS (
+    table_5 AS (
       SELECT
         *
       FROM
@@ -2580,8 +2580,8 @@ fn test_table_s_string() {
       table_2.*,
       table_3.*
     FROM
-      table_0 AS table_2
-      JOIN table_1 AS table_3 ON table_2.id = table_3.id
+      table_4 AS table_2
+      JOIN table_5 AS table_3 ON table_2.id = table_3.id
     "###
     );
 
@@ -2590,7 +2590,7 @@ fn test_table_s_string() {
     filter country == "USA"
     "###).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         *
       FROM
@@ -2599,7 +2599,7 @@ fn test_table_s_string() {
     SELECT
       *
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     WHERE
       country = 'USA'
     "###
@@ -2610,7 +2610,7 @@ fn test_table_s_string() {
     filter e.country == "USA"
     "###).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         *
       FROM
@@ -2619,7 +2619,7 @@ fn test_table_s_string() {
     SELECT
       *
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     WHERE
       country = 'USA'
     "###
@@ -2632,7 +2632,7 @@ fn test_table_s_string() {
     weeks_between @2022-06-03 (current_week + 4)
     "###).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         generate_series(
           DATE '2022-06-03',
@@ -2642,7 +2642,7 @@ fn test_table_s_string() {
     )
     SELECT
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 
@@ -2650,7 +2650,7 @@ fn test_table_s_string() {
     s"SELECT * FROM {default_db.x}"
     "###).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         *
       FROM
@@ -2658,7 +2658,7 @@ fn test_table_s_string() {
     )
     SELECT
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 }
@@ -3080,7 +3080,7 @@ fn test_exclude_columns() {
     select ![bar]
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         *
       FROM
@@ -3089,7 +3089,7 @@ fn test_exclude_columns() {
     SELECT
       * EXCLUDE (bar)
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 }
@@ -3177,7 +3177,7 @@ a,b,c
     select [b, c]
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         '1' AS a,
         '2' AS b,
@@ -3193,7 +3193,7 @@ a,b,c
       b,
       c
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 
@@ -3204,7 +3204,7 @@ a,b,c
     select [b, c]
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         1 AS a,
         'x' AS b,
@@ -3220,7 +3220,7 @@ a,b,c
       b,
       c
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 
@@ -3235,7 +3235,7 @@ a,b,c
     select [b, c]
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_2 AS (
       SELECT
         1 AS a,
         'x' AS b,
@@ -3251,7 +3251,7 @@ a,b,c
       b,
       c
     FROM
-      table_0 AS table_1
+      table_2 AS table_1
     "###
     );
 }
@@ -3332,7 +3332,7 @@ fn test_loop() {
     take 4
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_6 AS (
       SELECT
         1 AS n
     ),
@@ -3341,7 +3341,7 @@ fn test_loop() {
         SELECT
           n - 2 AS _expr_0
         FROM
-          table_0 AS table_1
+          table_6 AS table_1
         UNION
         ALL
         SELECT
@@ -3500,7 +3500,7 @@ fn test_1535() -> anyhow::Result<()> {
     SELECT
       *
     FROM
-      z
+      x.y.z
     "###
     );
 
@@ -3514,13 +3514,13 @@ fn test_read_parquet_duckdb() {
     join (read_parquet "y.parquet") [==foo]
     "#).unwrap(),
         @r###"
-    WITH table_0 AS (
+    WITH table_4 AS (
       SELECT
         *
       FROM
         read_parquet('x.parquet')
     ),
-    table_1 AS (
+    table_5 AS (
       SELECT
         *
       FROM
@@ -3530,8 +3530,8 @@ fn test_read_parquet_duckdb() {
       table_2.*,
       table_3.*
     FROM
-      table_0 AS table_2
-      JOIN table_1 AS table_3 ON table_2.foo = table_3.foo
+      table_4 AS table_2
+      JOIN table_5 AS table_3 ON table_2.foo = table_3.foo
     "###
     );
 

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -214,7 +214,7 @@ fn test_append() {
     "###);
 
     assert_display_snapshot!(compile(r###"
-    func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+    func distinct rel -> (noop t = rel | group [t.*] (take 1))
     func union `default_db.bottom` top -> (top | append bottom | distinct)
 
     from employees
@@ -233,7 +233,7 @@ fn test_append() {
     "###);
 
     assert_display_snapshot!(compile(r###"
-    func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+    func distinct rel -> (noop t = rel | group [t.*] (take 1))
     func union `default_db.bottom` top -> (top | append bottom | distinct)
 
     from employees
@@ -345,7 +345,7 @@ fn test_remove() {
     assert_display_snapshot!(compile(r#"
     prql target:sql.sqlite
 
-    func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+    func distinct rel -> (noop t = rel | group [t.*] (take 1))
     func except `default_db.bottom` top -> (top | distinct | remove bottom)
 
     from album
@@ -374,7 +374,7 @@ fn test_remove() {
     assert_display_snapshot!(compile(r#"
     prql target:sql.sqlite
 
-    func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+    func distinct rel -> (noop t = rel | group [t.*] (take 1))
     func except `default_db.bottom` top -> (top | distinct | remove bottom)
 
     from album
@@ -442,7 +442,7 @@ fn test_intersect() {
     );
 
     assert_display_snapshot!(compile(r#"
-    func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+    func distinct rel -> (noop t = rel | group [t.*] (take 1))
 
     from album
     select artist_id
@@ -479,7 +479,7 @@ fn test_intersect() {
     );
 
     assert_display_snapshot!(compile(r#"
-    func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+    func distinct rel -> (noop t = rel | group [t.*] (take 1))
 
     from album
     select artist_id
@@ -515,7 +515,7 @@ fn test_intersect() {
     );
 
     assert_display_snapshot!(compile(r#"
-    func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+    func distinct rel -> (noop t = rel | group [t.*] (take 1))
 
     from album
     select artist_id
@@ -3498,9 +3498,9 @@ fn test_1535() -> anyhow::Result<()> {
     "#)?,
         @r###"
     SELECT
-      UPPER(name) AS upper_name
+      *
     FROM
-      test_tables
+      z
     "###
     );
 

--- a/prql-compiler/tests/integration/queries/set_ops_remove.prql
+++ b/prql-compiler/tests/integration/queries/set_ops_remove.prql
@@ -1,4 +1,4 @@
-func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+func distinct rel -> (noop t = rel | group [t.*] (take 1))
 
 from_text format:json '{ "columns": ["a"], "data": [[1], [2], [2], [3]] }'
 distinct

--- a/prql-compiler/tests/integration/snapshots/integration__loop.prql@loop.prql.snap
+++ b/prql-compiler/tests/integration/snapshots/integration__loop.prql@loop.prql.snap
@@ -1,9 +1,9 @@
 ---
 source: prql-compiler/tests/integration/main.rs
-expression: "# skip_mssql\nfrom_text format:json '[{\"n\": 1 }]'\nselect n = n - 2\nloop (\n    filter n<4\n    select n = n+1\n)\nselect n = n * 2\n"
+expression: "# skip_mssql (the keyword RECURSIVE is not allowed and you have to declare the columns for CTE)\nfrom_text format:json '[{\"n\": 1 }]'\nselect n = n - 2\nloop (\n    filter n<4\n    select n = n+1\n)\nselect n = n * 2\n"
 input_file: prql-compiler/tests/integration/queries/loop.prql
 ---
-WITH table_0 AS (
+WITH table_5 AS (
   SELECT
     1 AS n
 ),
@@ -12,7 +12,7 @@ table_4 AS (
     SELECT
       n - 2 AS _expr_0
     FROM
-      table_0 AS table_1
+      table_5 AS table_1
     UNION
     ALL
     SELECT

--- a/prql-compiler/tests/integration/snapshots/integration__set_ops_remove.prql@set_ops_remove.prql.snap
+++ b/prql-compiler/tests/integration/snapshots/integration__set_ops_remove.prql@set_ops_remove.prql.snap
@@ -1,9 +1,9 @@
 ---
 source: prql-compiler/tests/integration/main.rs
-expression: "# skip_mssql\nfunc distinct rel -> (from t = _param.rel | group [t.*] (take 1))\n\nfrom_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2], [2], [3]] }'\ndistinct\nremove (from_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2]] }')\n"
+expression: "func distinct rel -> (noop t = rel | group [t.*] (take 1))\n\nfrom_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2], [2], [3]] }'\ndistinct\nremove (from_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2]] }')\n"
 input_file: prql-compiler/tests/integration/queries/set_ops_remove.prql
 ---
-WITH table_0 AS (
+WITH table_4 AS (
   SELECT
     1 AS a
   UNION
@@ -19,7 +19,7 @@ WITH table_0 AS (
   SELECT
     3 AS a
 ),
-table_1 AS (
+table_5 AS (
   SELECT
     1 AS a
   UNION
@@ -30,11 +30,11 @@ table_1 AS (
 SELECT
   a
 FROM
-  table_0 AS table_2
+  table_4 AS table_2
 EXCEPT
   DISTINCT
 SELECT
   *
 FROM
-  table_1 AS table_3
+  table_5 AS table_3
 

--- a/web/book/src/syntax/quoted-identifiers.md
+++ b/web/book/src/syntax/quoted-identifiers.md
@@ -31,14 +31,10 @@ join `project-bar.dataset.table` [==col_bax]
 
 ## Quoting schemas
 
-```admonish note
-This is currently not great and we are working on improving it; see
-https://github.com/PRQL/prql/issues/1535 for progress.
-```
-
-If supplying a schema without a column — for example in a `from` or `join`
-transform, that also needs to be a quoted identifier:
+Identifiers of tables can be prefixed with databases and schema names. Note that
+all of following identifiers will be treated as separate table definitions:
+`tracks`, `public.tracks`, `my_database.public.tracks`.
 
 ```prql
-from `music.albums`
+from my_database.chinook.albums
 ```

--- a/web/book/src/transforms/append.md
+++ b/web/book/src/transforms/append.md
@@ -40,11 +40,11 @@ To imitate set operations i.e. (`UNION`, `EXCEPT` and `INTERSECT`), you can use
 the following functions:
 
 ```prql no-eval
-func distinct rel -> (from t = _param.rel | group [t.*] (take 1))
+func distinct rel -> (noop t = rel | group [t.*] (take 1))
 func union `default_db.bottom` top -> (top | append bottom | distinct)
 func except `default_db.bottom` top -> (top | distinct | remove bottom)
 func intersect_distinct `default_db.bottom` top -> (top | intersect bottom | distinct)
 ```
 
-Don't mind the `default_db.` and `_param.`, these are compiler implementation
+Don't mind the `default_db.` and `noop`, these are compiler implementation
 detail for now.

--- a/web/book/tests/snapshots/snapshot__language-features__s-strings-3.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__s-strings-3.snap
@@ -2,7 +2,7 @@
 source: web/book/tests/snapshot.rs
 expression: "from s\"SELECT DISTINCT ON first_name, id, age FROM employees ORDER BY age ASC\"\njoin s = s\"SELECT * FROM salaries\" [==id]\n"
 ---
-WITH table_0 AS (
+WITH table_4 AS (
   SELECT
     DISTINCT ON first_name,
     id,
@@ -12,7 +12,7 @@ WITH table_0 AS (
   ORDER BY
     age ASC
 ),
-table_1 AS (
+table_5 AS (
   SELECT
     *
   FROM
@@ -22,6 +22,6 @@ SELECT
   table_2.*,
   table_3.*
 FROM
-  table_0 AS table_2
-  JOIN table_1 AS table_3 ON table_2.id = table_3.id
+  table_4 AS table_2
+  JOIN table_5 AS table_3 ON table_2.id = table_3.id
 

--- a/web/book/tests/snapshots/snapshot__language-features__standard-library__from_text-0.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__standard-library__from_text-0.snap
@@ -2,7 +2,7 @@
 source: web/book/tests/snapshot.rs
 expression: "from_text \"\"\"\na,b,c\n1,2,3\n4,5,6\n\"\"\"\nderive [\n    d = b + c,\n    answer = 20 * 2 + 2,\n]\n"
 ---
-WITH table_0 AS (
+WITH table_2 AS (
   SELECT
     '1' AS a,
     '2' AS b,
@@ -21,5 +21,5 @@ SELECT
   b + c AS d,
   42 AS answer
 FROM
-  table_0 AS table_1
+  table_2 AS table_1
 

--- a/web/book/tests/snapshots/snapshot__language-features__standard-library__from_text-1.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__standard-library__from_text-1.snap
@@ -2,7 +2,7 @@
 source: web/book/tests/snapshot.rs
 expression: "let temp_format_lookup = from_text format:csv \"\"\"\ncountry_code,format\nuk,C\nus,F\nlr,F\nde,C\n\"\"\"\n\nfrom temperatures\njoin temp_format_lookup [==country_code]\n"
 ---
-WITH table_0 AS (
+WITH table_2 AS (
   SELECT
     'uk' AS country_code,
     'C' AS format
@@ -27,7 +27,7 @@ temp_format_lookup AS (
     country_code,
     format
   FROM
-    table_0 AS table_1
+    table_2 AS table_1
 )
 SELECT
   temperatures.*,

--- a/web/book/tests/snapshots/snapshot__language-features__standard-library__from_text-2.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__standard-library__from_text-2.snap
@@ -2,7 +2,7 @@
 source: web/book/tests/snapshot.rs
 expression: "let x = from_text format:json \"\"\"{\n    \"columns\": [\"a\", \"b\", \"c\"],\n    \"data\": [\n        [1, \"x\", false],\n        [4, \"y\", null]\n    ]\n}\"\"\"\n\nlet y = from_text format:json \"\"\"\n    [\n        {\"a\": 1, \"m\": \"5\"},\n        {\"a\": 4, \"n\": \"6\"}\n    ]\n\"\"\"\n\nfrom x | join y [==a]\n"
 ---
-WITH table_0 AS (
+WITH table_4 AS (
   SELECT
     1 AS a,
     'x' AS b,
@@ -20,9 +20,9 @@ x AS (
     b,
     c
   FROM
-    table_0 AS table_1
+    table_4 AS table_1
 ),
-table_2 AS (
+table_5 AS (
   SELECT
     1 AS a,
     '5' AS m
@@ -37,7 +37,7 @@ y AS (
     a,
     m
   FROM
-    table_2 AS table_3
+    table_5 AS table_3
 )
 SELECT
   x.a,

--- a/web/book/tests/snapshots/snapshot__language-features__standard-library__loop-0.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__standard-library__loop-0.snap
@@ -2,7 +2,7 @@
 source: web/book/tests/snapshot.rs
 expression: "from_text format:json '[{\"n\": 1 }]'\nloop (\n    filter n<4\n    select n = n+1\n)\n\n# returns [1, 2, 3, 4]\n"
 ---
-WITH table_0 AS (
+WITH table_5 AS (
   SELECT
     1 AS n
 ),
@@ -11,7 +11,7 @@ table_4 AS (
     SELECT
       n
     FROM
-      table_0 AS table_1
+      table_5 AS table_1
     UNION
     ALL
     SELECT

--- a/web/book/tests/snapshots/snapshot__language-features__standard-library__reading-files-0.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__standard-library__reading-files-0.snap
@@ -2,13 +2,13 @@
 source: web/book/tests/snapshot.rs
 expression: "from (read_parquet 'artists.parquet')\njoin (read_csv 'albums.csv') [==track_id]\n"
 ---
-WITH table_0 AS (
+WITH table_4 AS (
   SELECT
     *
   FROM
     read_parquet('artists.parquet')
 ),
-table_1 AS (
+table_5 AS (
   SELECT
     *
   FROM
@@ -18,6 +18,6 @@ SELECT
   table_2.*,
   table_3.*
 FROM
-  table_0 AS table_2
-  JOIN table_1 AS table_3 ON table_2.track_id = table_3.track_id
+  table_4 AS table_2
+  JOIN table_5 AS table_3 ON table_2.track_id = table_3.track_id
 

--- a/web/book/tests/snapshots/snapshot__queries__variables-1.snap
+++ b/web/book/tests/snapshots/snapshot__queries__variables-1.snap
@@ -2,7 +2,7 @@
 source: web/book/tests/snapshot.rs
 expression: "let grouping = s\"\"\"\n  SELECT SUM(a)\n  FROM tbl\n  GROUP BY\n    GROUPING SETS\n    ((b, c, d), (d), (b, d))\n\"\"\"\n\nfrom grouping\n"
 ---
-WITH table_0 AS (
+WITH table_2 AS (
   SELECT
     SUM(a)
   FROM
@@ -14,7 +14,7 @@ grouping AS (
   SELECT
     *
   FROM
-    table_0 AS table_1
+    table_2 AS table_1
 )
 SELECT
   *

--- a/web/book/tests/snapshots/snapshot__syntax__quoted-identifiers-4.snap
+++ b/web/book/tests/snapshots/snapshot__syntax__quoted-identifiers-4.snap
@@ -1,9 +1,9 @@
 ---
 source: web/book/tests/snapshot.rs
-expression: "from `music.albums`\n"
+expression: "from my_database.chinook.albums\n"
 ---
 SELECT
   *
 FROM
-  music.albums
+  my_database.chinook.albums
 


### PR DESCRIPTION
- Squashed commit of the following
- infer modules
- make table reference an Ident instead of String

Closes #1535

A big commit, I had to tweak how we do inference.

A thought: should we throw an error when a table name ends in `.parquet` or `.csv`? It'd be nice to redirect users toward `read_parquet` or `read_csv`.