### PR TITLE
feat: arrays and type system consolidation

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -9,7 +9,7 @@ use std::process::exit;
 use std::str::FromStr;
 
 use prql_compiler::semantic::{self, reporting::*};
-use prql_compiler::{ast::pl::Frame, pl_to_prql};
+use prql_compiler::{ast::pl::Lineage, pl_to_prql};
 use prql_compiler::{downcast, Options, Target};
 use prql_compiler::{pl_to_rq_tree, prql_to_pl, prql_to_pl_tree, rq_to_sql, FileTree, Span};
 
@@ -326,7 +326,7 @@ impl Command {
     }
 }
 
-fn combine_prql_and_frames(source: &str, frames: Vec<(Span, Frame)>) -> String {
+fn combine_prql_and_frames(source: &str, frames: Vec<(Span, Lineage)>) -> String {
     let source = Source::from(source);
     let lines = source.lines().collect_vec();
     let width = lines.iter().map(|l| l.len()).max().unwrap_or(0);

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Write};
 
 use anyhow::{anyhow, Result};
 use enum_as_inner::EnumAsInner;
+use itertools::Itertools;
 use semver::VersionReq;
 
 use serde::{Deserialize, Serialize};
@@ -56,7 +57,10 @@ pub enum ExprKind {
     },
     Literal(Literal),
     Pipeline(Pipeline),
+
+    /// Also known as tuple or struct
     List(Vec<Expr>),
+    Array(Vec<Expr>),
     Range(Range),
     Binary {
         left: Box<Expr>,
@@ -524,6 +528,10 @@ impl Display for Expr {
                     }
                     f.write_str("]")?;
                 }
+            }
+            ExprKind::Array(items) => {
+                let items = items.into_iter().map(|x| x.to_string()).join(", ");
+                write!(f, "{{{items}}}")?;
             }
             ExprKind::Range(r) => {
                 if let Some(start) = &r.start {

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -91,7 +91,7 @@ pub enum ExprKind {
         args: Vec<Expr>,
     },
 
-    Set(PrimitiveSet),
+    Type(TyKind),
 
     /// a placeholder for values provided after query is compiled
     Param(String),
@@ -639,7 +639,7 @@ impl Display for Expr {
             ExprKind::BuiltInFunction { .. } => {
                 f.write_str("<built-in>")?;
             }
-            ExprKind::Set(_) => {
+            ExprKind::Type(_) => {
                 writeln!(f, "<type-expr>")?;
             }
             ExprKind::Param(id) => {

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -81,6 +81,10 @@ pub enum ExprKind {
         name: String,
         args: Vec<Expr>,
     },
+
+    // TODO: it does not make sense to have Type also be an expression.
+    // This should be renamed to "Set" (which can later be converted into a TypeExpr).
+    // Also, it'd be nice if we can tighten what's allowed and only have [TyLit] inside.
     Type(TypeExpr),
 
     /// a placeholder for values provided after query is compiled
@@ -530,7 +534,7 @@ impl Display for Expr {
                 }
             }
             ExprKind::Array(items) => {
-                let items = items.into_iter().map(|x| x.to_string()).join(", ");
+                let items = items.iter().map(|x| x.to_string()).join(", ");
                 write!(f, "{{{items}}}")?;
             }
             ExprKind::Range(r) => {

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -32,7 +32,8 @@ pub struct Expr {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub target_ids: Vec<usize>,
 
-    /// Type of expression this node represents. [None] means type has not yet been determined.
+    /// Type of expression this node represents.
+    /// [None] means that type should be inferred.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ty: Option<Ty>,
 

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -91,10 +91,7 @@ pub enum ExprKind {
         args: Vec<Expr>,
     },
 
-    // TODO: it does not make sense to have Type also be an expression.
-    // This should be renamed to "Set" (which can later be converted into a TypeExpr).
-    // Also, it'd be nice if we can tighten what's allowed and only have [TyLit] inside.
-    Type(TyKind),
+    Set(PrimitiveSet),
 
     /// a placeholder for values provided after query is compiled
     Param(String),
@@ -642,7 +639,7 @@ impl Display for Expr {
             ExprKind::BuiltInFunction { .. } => {
                 f.write_str("<built-in>")?;
             }
-            ExprKind::Type(_) => {
+            ExprKind::Set(_) => {
                 writeln!(f, "<type-expr>")?;
             }
             ExprKind::Param(id) => {

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -37,6 +37,13 @@ pub struct Expr {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ty: Option<Ty>,
 
+    /// Information about where data of this expression will come from.
+    ///
+    /// Currently, this is used to infer relational pipeline frames.
+    /// Must always exists if ty is a relation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lineage: Option<Lineage>,
+
     #[serde(skip)]
     pub needs_window: bool,
 
@@ -45,6 +52,7 @@ pub struct Expr {
 
     /// When true on [ExprKind::List], this list will be flattened when placed
     /// in some other list.
+    // TODO: maybe we should have a special ExprKind instead of this flag?
     #[serde(skip)]
     pub flatten: bool,
 }
@@ -449,6 +457,7 @@ impl From<ExprKind> for Expr {
             target_id: None,
             target_ids: Vec::new(),
             ty: None,
+            lineage: None,
             needs_window: false,
             alias: None,
             flatten: false,

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -348,6 +348,24 @@ pub enum TransformKind {
     Loop(Box<Expr>),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ColumnSort<T = Expr> {
+    pub direction: SortDirection,
+    pub column: T,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl Default for SortDirection {
+    fn default() -> Self {
+        SortDirection::Asc
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum WindowKind {
     Rows,

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -94,7 +94,7 @@ pub enum ExprKind {
     // TODO: it does not make sense to have Type also be an expression.
     // This should be renamed to "Set" (which can later be converted into a TypeExpr).
     // Also, it'd be nice if we can tighten what's allowed and only have [TyLit] inside.
-    Type(TypeExpr),
+    Type(TyKind),
 
     /// a placeholder for values provided after query is compiled
     Param(String),

--- a/prql-compiler/src/ast/pl/fold.rs
+++ b/prql-compiler/src/ast/pl/fold.rs
@@ -123,7 +123,7 @@ pub fn fold_expr_kind<T: ?Sized + AstFold>(fold: &mut T, expr_kind: ExprKind) ->
         Param(id) => Param(id),
 
         // None of these capture variables, so we don't need to fold them.
-        Literal(_) | Set(_) | FuncDef(_) => expr_kind,
+        Literal(_) | Type(_) | FuncDef(_) => expr_kind,
     })
 }
 

--- a/prql-compiler/src/ast/pl/fold.rs
+++ b/prql-compiler/src/ast/pl/fold.rs
@@ -95,6 +95,7 @@ pub fn fold_expr_kind<T: ?Sized + AstFold>(fold: &mut T, expr_kind: ExprKind) ->
             expr: Box::new(fold.fold_expr(*expr)?),
         },
         List(items) => List(fold.fold_exprs(items)?),
+        Array(items) => Array(fold.fold_exprs(items)?),
         Range(range) => Range(fold_range(fold, range)?),
         Pipeline(p) => Pipeline(fold.fold_pipeline(p)?),
         SString(items) => SString(

--- a/prql-compiler/src/ast/pl/fold.rs
+++ b/prql-compiler/src/ast/pl/fold.rs
@@ -123,7 +123,7 @@ pub fn fold_expr_kind<T: ?Sized + AstFold>(fold: &mut T, expr_kind: ExprKind) ->
         Param(id) => Param(id),
 
         // None of these capture variables, so we don't need to fold them.
-        Literal(_) | Type(_) | FuncDef(_) => expr_kind,
+        Literal(_) | Set(_) | FuncDef(_) => expr_kind,
     })
 }
 

--- a/prql-compiler/src/ast/pl/frame.rs
+++ b/prql-compiler/src/ast/pl/frame.rs
@@ -1,13 +1,11 @@
-use std::{
-    collections::HashSet,
-    fmt::{Debug, Display, Formatter},
-};
+use std::collections::HashSet;
+use std::fmt::{Debug, Display, Formatter};
 
 use enum_as_inner::EnumAsInner;
 use itertools::{Itertools, Position};
 use serde::{Deserialize, Serialize};
 
-use super::{Expr, Ident};
+use super::Ident;
 
 /// Represents the object that is manipulated by the pipeline transforms.
 /// Similar to a view in a database or a data frame.
@@ -46,24 +44,6 @@ pub enum FrameColumn {
         name: Option<Ident>,
         expr_id: usize,
     },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ColumnSort<T = Expr> {
-    pub direction: SortDirection,
-    pub column: T,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum SortDirection {
-    Asc,
-    Desc,
-}
-
-impl Default for SortDirection {
-    fn default() -> Self {
-        SortDirection::Asc
-    }
 }
 
 impl Display for Frame {

--- a/prql-compiler/src/ast/pl/frame.rs
+++ b/prql-compiler/src/ast/pl/frame.rs
@@ -9,19 +9,19 @@ use super::Ident;
 
 /// Represents the object that is manipulated by the pipeline transforms.
 /// Similar to a view in a database or a data frame.
-#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Frame {
-    pub columns: Vec<FrameColumn>,
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lineage {
+    pub columns: Vec<LineageColumn>,
 
-    pub inputs: Vec<FrameInput>,
+    pub inputs: Vec<LineageInput>,
 
     // A hack that allows name retention when applying `ExprKind::All { except }`
     #[serde(skip)]
-    pub prev_columns: Vec<FrameColumn>,
+    pub prev_columns: Vec<LineageColumn>,
 }
 
-#[derive(Clone, Eq, Debug, PartialEq, Serialize, Deserialize)]
-pub struct FrameInput {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineageInput {
     /// Id of the node in AST that declares this input.
     pub id: usize,
 
@@ -33,7 +33,7 @@ pub struct FrameInput {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, EnumAsInner)]
-pub enum FrameColumn {
+pub enum LineageColumn {
     /// All columns (including unknown ones) from an input (i.e. `foo_table.*`)
     All {
         input_name: String,
@@ -46,24 +46,17 @@ pub enum FrameColumn {
     },
 }
 
-impl Display for Frame {
+impl Display for Lineage {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        display_frame(self, f, false)
+        display_lineage(self, f, false)
     }
 }
 
-impl Debug for Frame {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        display_frame(self, f, true)?;
-        std::fmt::Debug::fmt(&self.inputs, f)
-    }
-}
-
-fn display_frame(frame: &Frame, f: &mut Formatter, display_ids: bool) -> std::fmt::Result {
+fn display_lineage(lineage: &Lineage, f: &mut Formatter, display_ids: bool) -> std::fmt::Result {
     write!(f, "[")?;
-    for col in frame.columns.iter().with_position() {
+    for col in lineage.columns.iter().with_position() {
         let is_last = matches!(col, Position::Last(_) | Position::Only(_));
-        display_frame_column(col.into_inner(), f, display_ids)?;
+        display_lineage_column(col.into_inner(), f, display_ids)?;
         if !is_last {
             write!(f, ", ")?;
         }
@@ -71,16 +64,16 @@ fn display_frame(frame: &Frame, f: &mut Formatter, display_ids: bool) -> std::fm
     write!(f, "]")
 }
 
-fn display_frame_column(
-    col: &FrameColumn,
+fn display_lineage_column(
+    col: &LineageColumn,
     f: &mut Formatter,
     display_ids: bool,
 ) -> std::fmt::Result {
     match col {
-        FrameColumn::All { input_name, .. } => {
+        LineageColumn::All { input_name, .. } => {
             write!(f, "{input_name}.*")?;
         }
-        FrameColumn::Single { name, expr_id } => {
+        LineageColumn::Single { name, expr_id } => {
             if let Some(name) = name {
                 write!(f, "{name}")?
             } else {

--- a/prql-compiler/src/ast/pl/literal.rs
+++ b/prql-compiler/src/ast/pl/literal.rs
@@ -15,7 +15,6 @@ pub enum Literal {
     Time(String),
     Timestamp(String),
     ValueAndUnit(ValueAndUnit),
-    Relation(RelationLiteral),
 }
 
 // Compound units, such as "2 days 3 hours" can be represented as `2days + 3hours`
@@ -87,10 +86,6 @@ impl Display for Literal {
 
             Literal::ValueAndUnit(i) => {
                 write!(f, "{}{}", i.n, i.unit)?;
-            }
-
-            Literal::Relation(_) => {
-                write!(f, "<unimplemented relation>")?;
             }
         }
         Ok(())

--- a/prql-compiler/src/ast/pl/types.rs
+++ b/prql-compiler/src/ast/pl/types.rs
@@ -8,7 +8,7 @@ use super::Literal;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, EnumAsInner)]
 pub enum TyKind {
     /// Type of a built-in primitive type
-    Primitive(TyLit),
+    Primitive(PrimitiveSet),
 
     /// Type that contains only a one value
     Singleton(Literal),
@@ -47,10 +47,11 @@ pub struct Ty {
     pub name: Option<String>,
 }
 
+/// Built-in sets.
 #[derive(
     Debug, Clone, Serialize, Deserialize, PartialEq, Eq, strum::EnumString, strum::Display,
 )]
-pub enum TyLit {
+pub enum PrimitiveSet {
     #[strum(to_string = "int")]
     Int,
     #[strum(to_string = "float")]

--- a/prql-compiler/src/ast/pl/types.rs
+++ b/prql-compiler/src/ast/pl/types.rs
@@ -24,7 +24,10 @@ pub enum TypeExpr {
 
     /// Type of sets.
     /// Used for exprs that can be converted to SetExpr and then used as a Ty.
-    Type,
+    Set,
+
+    /// Type of functions with defined params and return types.
+    Function(TyFunc),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -37,10 +40,6 @@ pub enum TupleElement {
 pub enum Ty {
     /// Value is an element of this [TypeExpr]
     TypeExpr(TypeExpr),
-
-    /// Value is a function described by [TyFunc]
-    // TODO: convert into [TypeExpr].
-    Function(TyFunc),
 
     /// Special type for relations.
     // TODO: convert into [TypeExpr].
@@ -114,6 +113,10 @@ impl Ty {
             _ => false,
         }
     }
+
+    pub fn is_function(&self) -> bool {
+        matches!(self, Ty::TypeExpr(TypeExpr::Function(_)))
+    }
 }
 
 impl TypeExpr {
@@ -142,15 +145,6 @@ impl Display for Ty {
             Ty::TypeExpr(ty_expr) => write!(f, "{:}", ty_expr),
             Ty::Table(frame) => write!(f, "table<{frame}>"),
             Ty::Infer => write!(f, "infer"),
-            Ty::Function(func) => {
-                write!(f, "func")?;
-
-                for t in &func.args {
-                    write!(f, " {t}")?;
-                }
-                write!(f, " -> {}", func.return_ty)?;
-                Ok(())
-            }
         }
     }
 }
@@ -190,8 +184,17 @@ impl Display for TypeExpr {
                 write!(f, "]")?;
                 Ok(())
             }
-            TypeExpr::Type => write!(f, "set"),
+            TypeExpr::Set => write!(f, "set"),
             TypeExpr::Array(elem) => write!(f, "{{{elem}}}"),
+            TypeExpr::Function(func) => {
+                write!(f, "func")?;
+
+                for t in &func.args {
+                    write!(f, " {t}")?;
+                }
+                write!(f, " -> {}", func.return_ty)?;
+                Ok(())
+            }
         }
     }
 }

--- a/prql-compiler/src/ast/pl/types.rs
+++ b/prql-compiler/src/ast/pl/types.rs
@@ -10,7 +10,7 @@ pub enum TypeExpr {
     /// Type of a built-in primitive type
     Primitive(TyLit),
 
-    /// Type that contains only a literal value
+    /// Type that contains only a one value
     Singleton(Literal),
 
     /// Union of sets (sum)
@@ -22,8 +22,8 @@ pub enum TypeExpr {
     /// Type of arrays
     Array(Box<TypeExpr>),
 
-    /// Type of sets.
-    /// Used for exprs that can be converted to SetExpr and then used as a Ty.
+    /// Type of sets
+    /// Used for expressions that can be converted to TypeExpr.
     Set,
 
     /// Type of functions with defined params and return types.
@@ -39,6 +39,9 @@ pub enum TupleElement {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ty {
     pub kind: TyKind,
+
+    /// Name inferred from the type declaration.
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, EnumAsInner)]
@@ -139,6 +142,10 @@ impl TypeExpr {
 
 impl Display for Ty {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if let Some(name) = &self.name {
+            return write!(f, "{}", name);
+        }
+
         match &self.kind {
             TyKind::TypeExpr(ty_expr) => write!(f, "{:}", ty_expr),
             TyKind::Table(frame) => write!(f, "table<{frame}>"),

--- a/prql-compiler/src/ast/pl/types.rs
+++ b/prql-compiler/src/ast/pl/types.rs
@@ -77,7 +77,7 @@ pub struct TyFunc {
 
 impl Ty {
     pub fn is_superset_of(&self, subset: &Ty) -> bool {
-        if self.is_table() && subset.is_table() {
+        if self.is_relation() && subset.is_relation() {
             return true;
         }
 
@@ -88,7 +88,7 @@ impl Ty {
         self.kind.is_array()
     }
 
-    pub fn is_table(&self) -> bool {
+    pub fn is_relation(&self) -> bool {
         match &self.kind {
             TyKind::Array(elem) => {
                 matches!(elem.as_ref(), TyKind::Tuple(_))

--- a/prql-compiler/src/parser/lexer.rs
+++ b/prql-compiler/src/parser/lexer.rs
@@ -353,7 +353,7 @@ fn digits(count: usize) -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
 }
 
 fn end_expr() -> impl Parser<char, (), Error = Cheap<char>> {
-    choice((end(), one_of(",)]\r\n\t ").ignored(), just("..").ignored())).rewind()
+    choice((end(), one_of(",)]}\r\n\t ").ignored(), just("..").ignored())).rewind()
 }
 
 impl Token {

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -2518,4 +2518,34 @@ join s=salaries [==id]
             kind: Main
         "###);
     }
+
+    #[test]
+    fn test_array() {
+        assert_yaml_snapshot!(parse(r#"
+        let a = {1, 2,}
+        let a = {false, "hello"}
+        "#).unwrap(), @r###"
+        ---
+        - name: a
+          VarDef:
+            value:
+              Array:
+                - Literal:
+                    Integer: 1
+                - Literal:
+                    Integer: 2
+            ty_expr: ~
+            kind: Let
+        - name: a
+          VarDef:
+            value:
+              Array:
+                - Literal:
+                    Boolean: false
+                - Literal:
+                    String: hello
+            ty_expr: ~
+            kind: Let
+        "###);
+    }
 }

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -115,14 +115,14 @@ impl Context {
 
                 let ty = value.ty.clone().unwrap();
                 let frame = ty.kind.into_table().unwrap_or_else(|_| {
-                    let expected = Ty {
+                    let expected = Some(Ty {
                         kind: TyKind::Table(Frame::default()),
-                    };
+                    });
                     let assumed = self
                         .validate_type(value.as_ref(), &expected, || None)
                         .unwrap();
-                    value.ty = Some(assumed.clone());
-                    assumed.kind.into_table().unwrap()
+                    value.ty = assumed.clone();
+                    assumed.unwrap().kind.into_table().unwrap()
                 });
 
                 let columns = (frame.columns.iter())
@@ -137,8 +137,7 @@ impl Context {
                 let expr = TableExpr::RelationVar(value);
                 Ok(DeclKind::TableDecl(TableDecl { columns, expr }))
             }
-            Some(_) => Ok(DeclKind::Expr(value)),
-            None => Err(Error::new_simple("Cannot infer type. Type annotations needed.").into()),
+            _ => Ok(DeclKind::Expr(value)),
         }
     }
 

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -105,7 +105,7 @@ impl Context {
         Ok(())
     }
 
-    pub fn prepare_expr_decl(&mut self, value: Box<Expr>) -> Result<DeclKind> {
+    pub fn prepare_expr_decl(&mut self, value: Box<Expr>, name: &str) -> DeclKind {
         match &value.ty {
             Some(Ty {
                 kind: TyKind::Table(_),
@@ -117,6 +117,7 @@ impl Context {
                 let frame = ty.kind.into_table().unwrap_or_else(|_| {
                     let expected = Some(Ty {
                         kind: TyKind::Table(Frame::default()),
+                        name: Some(name.to_owned()),
                     });
                     let assumed = self
                         .validate_type(value.as_ref(), &expected, || None)
@@ -135,9 +136,9 @@ impl Context {
                     .collect();
 
                 let expr = TableExpr::RelationVar(value);
-                Ok(DeclKind::TableDecl(TableDecl { columns, expr }))
+                DeclKind::TableDecl(TableDecl { columns, expr })
             }
-            _ => Ok(DeclKind::Expr(value)),
+            _ => DeclKind::Expr(value),
         }
     }
 

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -60,7 +60,7 @@ pub enum DeclKind {
     QueryDef(QueryDef),
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Serialize, Deserialize, Clone)]
 pub struct TableDecl {
     /// Columns layout
     pub columns: Vec<RelationColumn>,
@@ -105,31 +105,13 @@ impl Context {
         Ok(())
     }
 
-    pub fn prepare_expr_decl(&mut self, value: Box<Expr>, name: &str) -> DeclKind {
-        match &value.ty {
-            Some(Ty {
-                kind: TyKind::Table(_),
-                ..
-            }) => {
-                let mut value = value;
-
-                let ty = value.ty.clone().unwrap();
-                let frame = ty.kind.into_table().unwrap_or_else(|_| {
-                    let expected = Some(Ty {
-                        kind: TyKind::Table(Frame::default()),
-                        name: Some(name.to_owned()),
-                    });
-                    let assumed = self
-                        .validate_type(value.as_ref(), &expected, || None)
-                        .unwrap();
-                    value.ty = assumed.clone();
-                    assumed.unwrap().kind.into_table().unwrap()
-                });
-
+    pub fn prepare_expr_decl(&mut self, value: Box<Expr>) -> DeclKind {
+        match &value.lineage {
+            Some(frame) => {
                 let columns = (frame.columns.iter())
                     .map(|col| match col {
-                        FrameColumn::All { .. } => RelationColumn::Wildcard,
-                        FrameColumn::Single { name, .. } => {
+                        LineageColumn::All { .. } => RelationColumn::Wildcard,
+                        LineageColumn::Single { name, .. } => {
                             RelationColumn::Single(name.as_ref().map(|n| n.name.clone()))
                         }
                     })
@@ -367,11 +349,7 @@ impl Context {
 
         // also add into input tables of this table expression
         if let TableExpr::RelationVar(expr) = &table_decl.expr {
-            if let Some(Ty {
-                kind: TyKind::Table(frame),
-                ..
-            }) = expr.ty.as_ref()
-            {
+            if let Some(frame) = &expr.lineage {
                 let wildcard_inputs = (frame.columns.iter())
                     .filter_map(|c| c.as_all())
                     .collect_vec();
@@ -401,13 +379,13 @@ impl Context {
         table_fq: &Ident,
         input_name: String,
         input_id: usize,
-    ) -> Frame {
+    ) -> Lineage {
         let id = input_id;
         let table_decl = self.root_mod.get(table_fq).unwrap();
         let TableDecl { columns, .. } = table_decl.kind.as_table_decl().unwrap();
 
-        let instance_frame = Frame {
-            inputs: vec![FrameInput {
+        let instance_frame = Lineage {
+            inputs: vec![LineageInput {
                 id,
                 name: input_name.clone(),
                 table: table_fq.clone(),
@@ -415,14 +393,14 @@ impl Context {
             columns: columns
                 .iter()
                 .map(|col| match col {
-                    RelationColumn::Wildcard => FrameColumn::All {
+                    RelationColumn::Wildcard => LineageColumn::All {
                         input_name: input_name.clone(),
                         except: columns
                             .iter()
                             .flat_map(|c| c.as_single().cloned().flatten())
                             .collect(),
                     },
-                    RelationColumn::Single(col_name) => FrameColumn::Single {
+                    RelationColumn::Single(col_name) => LineageColumn::Single {
                         name: col_name
                             .clone()
                             .map(|col_name| Ident::from_path(vec![input_name.clone(), col_name])),
@@ -444,7 +422,7 @@ impl Context {
         input_id: usize,
         columns: Option<Vec<RelationColumn>>,
         name_hint: Option<String>,
-    ) -> Frame {
+    ) -> Lineage {
         let id = input_id;
         let global_name = format!("_literal_{}", id);
 
@@ -576,5 +554,13 @@ impl<'a> std::fmt::Display for RelationColumns<'a> {
             }
         }
         write!(f, "]")
+    }
+}
+
+impl std::fmt::Debug for TableDecl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let json = serde_json::to_string(self).unwrap();
+        let json = serde_json::from_str::<serde_json::Value>(&json).unwrap();
+        f.write_str(&serde_yaml::to_string(&json).unwrap())
     }
 }

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -263,11 +263,13 @@ impl Lowerer {
 
                 // pull columns from the table decl
                 let frame = expr.lineage.as_ref().unwrap();
-                let input = frame.inputs.get(0).unwrap();
-
-                let table_decl = self.context.root_mod.get(&input.table).unwrap();
-                let table_decl = table_decl.kind.as_table_decl().unwrap();
-                let columns = table_decl.columns.clone();
+                let columns = (frame.columns.iter())
+                    .map(|c| {
+                        RelationColumn::Single(
+                            c.as_single().unwrap().0.as_ref().map(|i| i.name.clone()),
+                        )
+                    })
+                    .collect_vec();
 
                 let lit = RelationLiteral {
                     columns: columns

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -780,7 +780,7 @@ impl Lowerer {
             | pl::ExprKind::Array(_)
             | pl::ExprKind::Closure(_)
             | pl::ExprKind::Pipeline(_)
-            | pl::ExprKind::Type(_)
+            | pl::ExprKind::Set(_)
             | pl::ExprKind::FuncDef(_)
             | pl::ExprKind::TransformCall(_) => {
                 log::debug!("cannot lower {ast:?}");

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -177,6 +177,7 @@ impl Lowerer {
             // make sure that type of this expr has been inferred to be a table
             let expected = Some(Ty {
                 kind: TyKind::Table(Frame::default()),
+                name: None,
             });
             expr.ty = self.context.validate_type(&expr, &expected, || None)?;
         }

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -781,6 +781,7 @@ impl Lowerer {
             pl::ExprKind::FuncCall(_)
             | pl::ExprKind::Range(_)
             | pl::ExprKind::List(_)
+            | pl::ExprKind::Array(_)
             | pl::ExprKind::Closure(_)
             | pl::ExprKind::Pipeline(_)
             | pl::ExprKind::Type(_)

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -173,17 +173,12 @@ impl Lowerer {
     /// Lower an expression into a instance of a table in the query
     fn lower_table_ref(&mut self, expr: Expr) -> Result<rq::TableRef> {
         let mut expr = expr;
-        if let Some(Ty {
-            kind: TyKind::Infer,
-            ..
-        }) = expr.ty
-        {
+        if expr.ty.is_none() {
             // make sure that type of this expr has been inferred to be a table
-            let expected = Ty {
+            let expected = Some(Ty {
                 kind: TyKind::Table(Frame::default()),
-            };
-            let inferred = self.context.validate_type(&expr, &expected, || None)?;
-            expr.ty = Some(inferred);
+            });
+            expr.ty = self.context.validate_type(&expr, &expected, || None)?;
         }
 
         Ok(match expr.kind {

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -798,7 +798,7 @@ impl Lowerer {
             | pl::ExprKind::Array(_)
             | pl::ExprKind::Closure(_)
             | pl::ExprKind::Pipeline(_)
-            | pl::ExprKind::Set(_)
+            | pl::ExprKind::Type(_)
             | pl::ExprKind::FuncDef(_)
             | pl::ExprKind::TransformCall(_) => {
                 log::debug!("cannot lower {ast:?}");

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -977,7 +977,7 @@ impl AstFold for TableDepsCollector {
         expr.kind = match expr.kind {
             pl::ExprKind::Ident(ref ident) => {
                 if let Some(ty) = &expr.ty {
-                    if ty.is_table() {
+                    if ty.is_relation() {
                         self.deps.push(ident.clone());
                     }
                 }

--- a/prql-compiler/src/semantic/mod.rs
+++ b/prql-compiler/src/semantic/mod.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 pub use self::context::Context;
 pub use self::module::Module;
 
-use crate::ast::pl::{Frame, FrameColumn, Stmt};
+use crate::ast::pl::{Lineage, LineageColumn, Stmt};
 use crate::ast::rq::Query;
 use crate::error::WithErrorInfo;
 use crate::{Error, FileTree};

--- a/prql-compiler/src/semantic/module.rs
+++ b/prql-compiler/src/semantic/module.rs
@@ -8,7 +8,7 @@ use crate::ast::pl::{Expr, Ident};
 use crate::ast::rq::RelationColumn;
 
 use super::context::{Decl, DeclKind, TableDecl, TableExpr};
-use super::{Frame, FrameColumn, NS_PARAM, NS_STD};
+use super::{Lineage, LineageColumn, NS_PARAM, NS_STD};
 use super::{NS_FRAME, NS_FRAME_RIGHT, NS_INFER, NS_INFER_MODULE, NS_SELF};
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Clone)]
@@ -214,15 +214,15 @@ impl Module {
         res
     }
 
-    pub(super) fn insert_frame(&mut self, frame: &Frame, namespace: &str) {
+    pub(super) fn insert_frame(&mut self, frame: &Lineage, namespace: &str) {
         let namespace = self.names.entry(namespace.to_string()).or_default();
         let namespace = namespace.kind.as_module_mut().unwrap();
 
         for (col_index, column) in frame.columns.iter().enumerate() {
             // determine input name
             let input_name = match column {
-                FrameColumn::All { input_name, .. } => Some(input_name),
-                FrameColumn::Single { name, .. } => name.as_ref().and_then(|n| n.path.first()),
+                LineageColumn::All { input_name, .. } => Some(input_name),
+                LineageColumn::Single { name, .. } => name.as_ref().and_then(|n| n.path.first()),
             };
 
             // get or create input namespace
@@ -259,7 +259,7 @@ impl Module {
 
             // insert column decl
             match column {
-                FrameColumn::All { input_name, .. } => {
+                LineageColumn::All { input_name, .. } => {
                     let input = frame.inputs.iter().find(|i| &i.name == input_name).unwrap();
 
                     let kind = DeclKind::Infer(Box::new(DeclKind::Column(input.id)));
@@ -271,7 +271,7 @@ impl Module {
                     };
                     ns.names.insert(NS_INFER.to_string(), decl);
                 }
-                FrameColumn::Single {
+                LineageColumn::Single {
                     name: Some(name),
                     expr_id,
                 } => {

--- a/prql-compiler/src/semantic/reporting.rs
+++ b/prql-compiler/src/semantic/reporting.rs
@@ -143,7 +143,7 @@ impl AstFold for FrameCollector {
     fn fold_expr(&mut self, expr: Expr) -> Result<Expr> {
         if matches!(expr.kind, ExprKind::TransformCall(_)) {
             if let Some(span) = expr.span {
-                let frame = expr.ty.as_ref().and_then(|t| t.as_table().cloned());
+                let frame = expr.ty.as_ref().and_then(|t| t.kind.as_table().cloned());
                 if let Some(frame) = frame {
                     self.frames.push((span, frame));
                 }

--- a/prql-compiler/src/semantic/reporting.rs
+++ b/prql-compiler/src/semantic/reporting.rs
@@ -6,7 +6,7 @@ use ariadne::{Color, Label, Report, ReportBuilder, ReportKind, Source};
 
 use super::context::{DeclKind, RelationColumns, TableDecl, TableExpr};
 use super::NS_DEFAULT_DB;
-use super::{Context, Frame};
+use super::{Context, Lineage};
 use crate::ast::pl::{fold::*, *};
 use crate::error::Span;
 
@@ -125,7 +125,7 @@ impl<'a> AstFold for Labeler<'a> {
     }
 }
 
-pub fn collect_frames(expr: Expr) -> Vec<(Span, Frame)> {
+pub fn collect_frames(expr: Expr) -> Vec<(Span, Lineage)> {
     let mut collector = FrameCollector { frames: vec![] };
 
     collector.fold_expr(expr).unwrap();
@@ -136,16 +136,16 @@ pub fn collect_frames(expr: Expr) -> Vec<(Span, Frame)> {
 
 /// Traverses AST and collects all node.frame
 struct FrameCollector {
-    frames: Vec<(Span, Frame)>,
+    frames: Vec<(Span, Lineage)>,
 }
 
 impl AstFold for FrameCollector {
     fn fold_expr(&mut self, expr: Expr) -> Result<Expr> {
         if matches!(expr.kind, ExprKind::TransformCall(_)) {
             if let Some(span) = expr.span {
-                let frame = expr.ty.as_ref().and_then(|t| t.kind.as_table().cloned());
-                if let Some(frame) = frame {
-                    self.frames.push((span, frame));
+                let lineage = expr.lineage.clone();
+                if let Some(lineage) = lineage {
+                    self.frames.push((span, lineage));
                 }
             }
         }

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -898,17 +898,17 @@ fn env_of_closure(closure: Closure) -> (Module, Expr) {
 }
 
 fn get_stdlib_decl(name: &str) -> Option<ExprKind> {
-    let ty_lit = match name {
-        "int" => TyLit::Int,
-        "float" => TyLit::Float,
-        "bool" => TyLit::Bool,
-        "text" => TyLit::Text,
-        "date" => TyLit::Date,
-        "time" => TyLit::Time,
-        "timestamp" => TyLit::Timestamp,
+    let set = match name {
+        "int" => PrimitiveSet::Int,
+        "float" => PrimitiveSet::Float,
+        "bool" => PrimitiveSet::Bool,
+        "text" => PrimitiveSet::Text,
+        "date" => PrimitiveSet::Date,
+        "time" => PrimitiveSet::Time,
+        "timestamp" => PrimitiveSet::Timestamp,
         _ => return None,
     };
-    Some(ExprKind::Type(TyKind::Primitive(ty_lit)))
+    Some(ExprKind::Set(set))
 }
 
 #[cfg(test)]

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -97,7 +97,7 @@ impl Resolver {
                     let mut var_def = VarDef {
                         value: Box::new(ty_def.value.unwrap_or_else(|| {
                             let mut e = Expr::null();
-                            e.ty = Some(Ty::TypeExpr(TypeExpr::Type));
+                            e.ty = Some(Ty::TypeExpr(TypeExpr::Set));
                             e
                         })),
                         // FIXME
@@ -578,7 +578,7 @@ impl Resolver {
             ty.args = ty.args[args_len..].to_vec();
 
             let mut node = Expr::from(ExprKind::Closure(Box::new(closure)));
-            node.ty = Some(Ty::Function(ty));
+            node.ty = Some(Ty::TypeExpr(TypeExpr::Function(ty)));
 
             node
         };

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -98,7 +98,7 @@ impl Resolver {
                         value: Box::new(ty_def.value.unwrap_or_else(|| {
                             let mut e = Expr::null();
                             e.ty = Some(Ty {
-                                kind: TyKind::TypeExpr(TypeExpr::Set),
+                                kind: TyKind::Set,
                                 name: None,
                             });
                             e
@@ -217,7 +217,7 @@ impl AstFold for Resolver {
                         Expr {
                             kind: ExprKind::Ident(fq_ident),
                             ty: Some(Ty {
-                                kind: TyKind::TypeExpr(TypeExpr::Array(Box::new(TypeExpr::Tuple(
+                                kind: TyKind::Array(Box::new(TyKind::Tuple(
                                     lineage
                                         .columns
                                         .iter()
@@ -226,12 +226,12 @@ impl AstFold for Resolver {
                                             LineageColumn::Single { name, .. } => {
                                                 TupleElement::Single(
                                                     name.as_ref().map(|i| i.name.clone()),
-                                                    TypeExpr::Singleton(Literal::Null),
+                                                    TyKind::Singleton(Literal::Null),
                                                 )
                                             }
                                         })
                                         .collect(),
-                                )))),
+                                ))),
                                 name: None,
                             }),
                             lineage: Some(lineage),
@@ -604,7 +604,7 @@ impl Resolver {
 
             let mut node = Expr::from(ExprKind::Closure(Box::new(closure)));
             node.ty = Some(Ty {
-                kind: TyKind::TypeExpr(TypeExpr::Function(ty)),
+                kind: TyKind::Function(ty),
                 name: None,
             });
 
@@ -908,7 +908,7 @@ fn get_stdlib_decl(name: &str) -> Option<ExprKind> {
         "timestamp" => TyLit::Timestamp,
         _ => return None,
     };
-    Some(ExprKind::Type(TypeExpr::Primitive(ty_lit)))
+    Some(ExprKind::Type(TyKind::Primitive(ty_lit)))
 }
 
 #[cfg(test)]

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
@@ -10,12 +10,12 @@ columns:
       input_name: customers
       except: []
 inputs:
-  - id: 6
+  - id: 8
     name: table_1
     table:
       - default_db
       - table_1
-  - id: 13
+  - id: 18
     name: customers
     table:
       - default_db

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
@@ -1,24 +1,23 @@
 ---
 source: prql-compiler/src/semantic/resolver.rs
-expression: "resolve_type(r#\"\n            from table_1\n            join customers [==customer_no]\n            \"#).unwrap()"
+expression: "resolve_lineage(r#\"\n            from table_1\n            join customers [==customer_no]\n            \"#).unwrap()"
 ---
-Table:
-  columns:
-    - All:
-        input_name: table_1
-        except: []
-    - All:
-        input_name: customers
-        except: []
-  inputs:
-    - id: 6
-      name: table_1
-      table:
-        - default_db
-        - table_1
-    - id: 13
-      name: customers
-      table:
-        - default_db
-        - customers
+columns:
+  - All:
+      input_name: table_1
+      except: []
+  - All:
+      input_name: customers
+      except: []
+inputs:
+  - id: 6
+    name: table_1
+    table:
+      - default_db
+      - table_1
+  - id: 13
+    name: customers
+    table:
+      - default_db
+      - customers
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
@@ -7,23 +7,23 @@ columns:
       name:
         - e
         - emp_no
-      expr_id: 24
+      expr_id: 31
   - Single:
       name:
         - e
         - gender
-      expr_id: 25
+      expr_id: 32
   - Single:
       name:
         - emp_salary
-      expr_id: 36
+      expr_id: 46
 inputs:
-  - id: 6
+  - id: 8
     name: e
     table:
       - default_db
       - employees
-  - id: 18
+  - id: 25
     name: salaries
     table:
       - default_db

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
@@ -1,32 +1,31 @@
 ---
 source: prql-compiler/src/semantic/resolver.rs
-expression: "resolve_type(r#\"\n            from e = employees\n            join salaries [==emp_no]\n            group [e.emp_no, e.gender] (\n                aggregate [\n                    emp_salary = average salaries.salary\n                ]\n            )\n            \"#).unwrap()"
+expression: "resolve_lineage(r#\"\n            from e = employees\n            join salaries [==emp_no]\n            group [e.emp_no, e.gender] (\n                aggregate [\n                    emp_salary = average salaries.salary\n                ]\n            )\n            \"#).unwrap()"
 ---
-Table:
-  columns:
-    - Single:
-        name:
-          - e
-          - emp_no
-        expr_id: 24
-    - Single:
-        name:
-          - e
-          - gender
-        expr_id: 25
-    - Single:
-        name:
-          - emp_salary
-        expr_id: 36
-  inputs:
-    - id: 6
-      name: e
-      table:
-        - default_db
-        - employees
-    - id: 18
-      name: salaries
-      table:
-        - default_db
-        - salaries
+columns:
+  - Single:
+      name:
+        - e
+        - emp_no
+      expr_id: 24
+  - Single:
+      name:
+        - e
+        - gender
+      expr_id: 25
+  - Single:
+      name:
+        - emp_salary
+      expr_id: 36
+inputs:
+  - id: 6
+    name: e
+    table:
+      - default_db
+      - employees
+  - id: 18
+    name: salaries
+    table:
+      - default_db
+      - salaries
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
@@ -7,22 +7,22 @@ columns:
       name:
         - orders
         - customer_no
-      expr_id: 19
+      expr_id: 27
   - Single:
       name:
         - orders
         - gross
-      expr_id: 20
+      expr_id: 28
   - Single:
       name:
         - orders
         - tax
-      expr_id: 21
+      expr_id: 29
   - Single:
       name: ~
-      expr_id: 22
+      expr_id: 30
 inputs:
-  - id: 6
+  - id: 8
     name: orders
     table:
       - default_db

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
@@ -1,31 +1,30 @@
 ---
 source: prql-compiler/src/semantic/resolver.rs
-expression: "resolve_type(r#\"\n            from orders\n            select [customer_no, gross, tax, gross - tax]\n            take 20\n            \"#).unwrap()"
+expression: "resolve_lineage(r#\"\n            from orders\n            select [customer_no, gross, tax, gross - tax]\n            take 20\n            \"#).unwrap()"
 ---
-Table:
-  columns:
-    - Single:
-        name:
-          - orders
-          - customer_no
-        expr_id: 19
-    - Single:
-        name:
-          - orders
-          - gross
-        expr_id: 20
-    - Single:
-        name:
-          - orders
-          - tax
-        expr_id: 21
-    - Single:
-        name: ~
-        expr_id: 22
-  inputs:
-    - id: 6
-      name: orders
-      table:
-        - default_db
+columns:
+  - Single:
+      name:
         - orders
+        - customer_no
+      expr_id: 19
+  - Single:
+      name:
+        - orders
+        - gross
+      expr_id: 20
+  - Single:
+      name:
+        - orders
+        - tax
+      expr_id: 21
+  - Single:
+      name: ~
+      expr_id: 22
+inputs:
+  - id: 6
+    name: orders
+    table:
+      - default_db
+      - orders
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
@@ -8,20 +8,20 @@ Table:
         name:
           - orders
           - customer_no
-        expr_id: 18
-    - Single:
-        name:
-          - orders
-          - gross
         expr_id: 19
     - Single:
         name:
           - orders
-          - tax
+          - gross
         expr_id: 20
     - Single:
-        name: ~
+        name:
+          - orders
+          - tax
         expr_id: 21
+    - Single:
+        name: ~
+        expr_id: 22
   inputs:
     - id: 6
       name: orders

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
@@ -11,7 +11,6 @@ expression: "resolve_derive(r#\"\n            let subtract = a b -> a - b\n\n   
         - employees
         - gross_salary
       target_id: 8
-      ty: Infer
     op: Sub
     right:
       id: 18
@@ -20,25 +19,25 @@ expression: "resolve_derive(r#\"\n            let subtract = a b -> a - b\n\n   
         - employees
         - tax
       target_id: 8
-      ty: Infer
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
   alias: net_salary
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
@@ -2,23 +2,23 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            let subtract = a b -> a - b\n\n            from employees\n            derive [\n                net_salary = subtract gross_salary tax\n            ]\n            \"#).unwrap()"
 ---
-- id: 19
+- id: 24
   Binary:
     left:
-      id: 17
+      id: 22
       Ident:
         - _frame
         - employees
         - gross_salary
-      target_id: 8
+      target_id: 10
     op: Sub
     right:
-      id: 18
+      id: 23
       Ident:
         - _frame
         - employees
         - tax
-      target_id: 8
+      target_id: 10
   ty:
     kind:
       Union:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
@@ -23,6 +23,22 @@ expression: "resolve_derive(r#\"\n            let subtract = a b -> a - b\n\n   
       ty: Infer
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
   alias: net_salary
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
@@ -39,5 +39,6 @@ expression: "resolve_derive(r#\"\n            let subtract = a b -> a - b\n\n   
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
   alias: net_salary
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_1.snap
@@ -21,24 +21,23 @@ expression: "resolve_derive(r#\"\n            let subtract = a b -> a - b\n\n   
       target_id: 8
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
   alias: net_salary
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
@@ -17,7 +17,6 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
                 - a
                 - b
               target_id: 10
-              ty: Infer
             op: Div
             right:
               id: 28
@@ -30,19 +29,16 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
                       - a
                       - b
                     target_id: 10
-                    ty: Infer
                 - String: )
-              ty: Infer
-          ty: Infer
         op: Sub
         right:
           id: 30
           Literal:
             Integer: 1
           ty:
-            TypeExpr:
-              Primitive: Int
-      ty: Infer
+            kind:
+              TypeExpr:
+                Primitive: Int
     op: Add
     right:
       id: 20
@@ -51,24 +47,24 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
         - a
         - c
       target_id: 10
-      ty: Infer
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
@@ -2,37 +2,37 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo({x})\"\n            let ret = x dividend_return ->  x / (lag_day x) - 1 + dividend_return\n\n            from a\n            derive (ret b c)\n            \"#).unwrap()"
 ---
-- id: 21
+- id: 26
   Binary:
     left:
-      id: 22
+      id: 27
       Binary:
         left:
-          id: 23
+          id: 28
           Binary:
             left:
-              id: 19
+              id: 24
               Ident:
                 - _frame
                 - a
                 - b
-              target_id: 10
+              target_id: 12
             op: Div
             right:
-              id: 28
+              id: 33
               SString:
                 - String: lag_day_todo(
                 - Expr:
-                    id: 19
+                    id: 24
                     Ident:
                       - _frame
                       - a
                       - b
-                    target_id: 10
+                    target_id: 12
                 - String: )
         op: Sub
         right:
-          id: 30
+          id: 35
           Literal:
             Integer: 1
           ty:
@@ -41,12 +41,12 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
             name: ~
     op: Add
     right:
-      id: 20
+      id: 25
       Ident:
         - _frame
         - a
         - c
-      target_id: 10
+      target_id: 12
   ty:
     kind:
       Union:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
@@ -37,8 +37,7 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
             Integer: 1
           ty:
             kind:
-              TypeExpr:
-                Primitive: Int
+              Primitive: Int
             name: ~
     op: Add
     right:
@@ -50,23 +49,22 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
       target_id: 10
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
@@ -54,5 +54,21 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
       ty: Infer
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
@@ -39,6 +39,7 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
             kind:
               TypeExpr:
                 Primitive: Int
+            name: ~
     op: Add
     right:
       id: 20
@@ -67,4 +68,5 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -9,8 +9,9 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
       Literal:
         Integer: 2
       ty:
-        TypeExpr:
-          Primitive: Int
+        kind:
+          TypeExpr:
+            Primitive: Int
     op: Add
     right:
       id: 30
@@ -26,35 +27,34 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
                   - a
                   - foo
                 target_id: 10
-                ty: Infer
-          ty: Infer
         op: Add
         right:
           id: 32
           Literal:
             Integer: 1
           ty:
-            TypeExpr:
-              Primitive: Int
-      ty: Infer
+            kind:
+              TypeExpr:
+                Primitive: Int
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
   alias: b
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -39,6 +39,22 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
       ty: Infer
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
   alias: b
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -12,6 +12,7 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
         kind:
           TypeExpr:
             Primitive: Int
+        name: ~
     op: Add
     right:
       id: 30
@@ -36,6 +37,7 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
             kind:
               TypeExpr:
                 Primitive: Int
+            name: ~
   ty:
     kind:
       TypeExpr:
@@ -56,5 +58,6 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
   alias: b
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -2,10 +2,10 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n            let plus = x y -> x + y\n\n            from a\n            derive [b = (sum foo | plus_one | plus 2)]\n            \"#).unwrap()"
 ---
-- id: 33
+- id: 40
   Binary:
     left:
-      id: 27
+      id: 34
       Literal:
         Integer: 2
       ty:
@@ -14,22 +14,22 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
         name: ~
     op: Add
     right:
-      id: 30
+      id: 37
       Binary:
         left:
-          id: 18
+          id: 23
           BuiltInFunction:
             name: std.sum
             args:
-              - id: 23
+              - id: 30
                 Ident:
                   - _frame
                   - a
                   - foo
-                target_id: 10
+                target_id: 12
         op: Add
         right:
-          id: 32
+          id: 39
           Literal:
             Integer: 1
           ty:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -10,8 +10,7 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
         Integer: 2
       ty:
         kind:
-          TypeExpr:
-            Primitive: Int
+          Primitive: Int
         name: ~
     op: Add
     right:
@@ -35,29 +34,27 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
             Integer: 1
           ty:
             kind:
-              TypeExpr:
-                Primitive: Int
+              Primitive: Int
             name: ~
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
   alias: b
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -2,16 +2,16 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            from a\n            derive one = (foo | sum)\n            \"#).unwrap()"
 ---
-- id: 15
+- id: 20
   BuiltInFunction:
     name: std.sum
     args:
-      - id: 14
+      - id: 19
         Ident:
           - _frame
           - a
           - foo
-        target_id: 6
+        target_id: 8
   ty:
     kind:
       Union:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -15,6 +15,22 @@ expression: "resolve_derive(r#\"\n            from a\n            derive one = (
         ty: Infer
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
   alias: one
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -14,24 +14,23 @@ expression: "resolve_derive(r#\"\n            from a\n            derive one = (
         target_id: 6
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
   alias: one
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -12,25 +12,25 @@ expression: "resolve_derive(r#\"\n            from a\n            derive one = (
           - a
           - foo
         target_id: 6
-        ty: Infer
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
   alias: one
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -32,5 +32,6 @@ expression: "resolve_derive(r#\"\n            from a\n            derive one = (
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
   alias: one
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
@@ -22,7 +22,23 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
           Primitive: Int
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
   alias: added
 - id: 26
   Binary:
@@ -44,6 +60,22 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
           Primitive: Int
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
   alias: added_default
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
@@ -20,6 +20,7 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
         kind:
           TypeExpr:
             Primitive: Int
+        name: ~
   ty:
     kind:
       TypeExpr:
@@ -40,6 +41,7 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
   alias: added
 - id: 26
   Binary:
@@ -59,6 +61,7 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
         kind:
           TypeExpr:
             Primitive: Int
+        name: ~
   ty:
     kind:
       TypeExpr:
@@ -79,5 +82,6 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
   alias: added_default
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
@@ -18,29 +18,27 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
         Integer: 3
       ty:
         kind:
-          TypeExpr:
-            Primitive: Int
+          Primitive: Int
         name: ~
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
   alias: added
 - id: 26
@@ -59,29 +57,27 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
         Integer: 1
       ty:
         kind:
-          TypeExpr:
-            Primitive: Int
+          Primitive: Int
         name: ~
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
   alias: added_default
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
@@ -11,34 +11,35 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
         - foo_table
         - bar
       target_id: 8
-      ty: Infer
     op: Add
     right:
       id: 17
       Literal:
         Integer: 3
       ty:
-        TypeExpr:
-          Primitive: Int
+        kind:
+          TypeExpr:
+            Primitive: Int
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
   alias: added
 - id: 26
   Binary:
@@ -49,33 +50,34 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
         - foo_table
         - bar
       target_id: 8
-      ty: Infer
     op: Add
     right:
       id: 24
       Literal:
         Integer: 1
       ty:
-        TypeExpr:
-          Primitive: Int
+        kind:
+          TypeExpr:
+            Primitive: Int
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
   alias: added_default
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__named_args.snap
@@ -2,18 +2,18 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n            from foo_table\n            derive [\n                added = add bar to:3,\n                added_default = add bar\n            ]\n            \"#).unwrap()"
 ---
-- id: 19
+- id: 24
   Binary:
     left:
-      id: 18
+      id: 23
       Ident:
         - _frame
         - foo_table
         - bar
-      target_id: 8
+      target_id: 10
     op: Add
     right:
-      id: 17
+      id: 22
       Literal:
         Integer: 3
       ty:
@@ -41,18 +41,18 @@ expression: "resolve_derive(r#\"\n            let add = x to:1 -> x + to\n\n    
           - Singleton: "Null"
     name: scalar
   alias: added
-- id: 26
+- id: 31
   Binary:
     left:
-      id: 25
+      id: 30
       Ident:
         - _frame
         - foo_table
         - bar
-      target_id: 8
+      target_id: 10
     op: Add
     right:
-      id: 24
+      id: 29
       Literal:
         Integer: 1
       ty:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
@@ -21,24 +21,23 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
       target_id: 6
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
   alias: gross_salary
 - id: 16
@@ -59,24 +58,23 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
       target_id: 6
   ty:
     kind:
-      TypeExpr:
-        Union:
-          - - ~
-            - Primitive: Int
-          - - ~
-            - Primitive: Float
-          - - ~
-            - Primitive: Bool
-          - - ~
-            - Primitive: Text
-          - - ~
-            - Primitive: Date
-          - - ~
-            - Primitive: Time
-          - - ~
-            - Primitive: Timestamp
-          - - ~
-            - Singleton: "Null"
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
     name: scalar
   alias: gross_cost
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
@@ -39,6 +39,7 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
   alias: gross_salary
 - id: 16
   Binary:
@@ -76,5 +77,6 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
             - Primitive: Timestamp
           - - ~
             - Singleton: "Null"
+    name: scalar
   alias: gross_cost
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
@@ -23,7 +23,23 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
       ty: Infer
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
   alias: gross_salary
 - id: 16
   Binary:
@@ -45,6 +61,22 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
       ty: Infer
   ty:
     TypeExpr:
-      Primitive: Column
+      Union:
+        - - ~
+          - Primitive: Int
+        - - ~
+          - Primitive: Float
+        - - ~
+          - Primitive: Bool
+        - - ~
+          - Primitive: Text
+        - - ~
+          - Primitive: Date
+        - - ~
+          - Primitive: Time
+        - - ~
+          - Primitive: Timestamp
+        - - ~
+          - Singleton: "Null"
   alias: gross_cost
 

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
@@ -2,23 +2,23 @@
 source: prql-compiler/src/semantic/resolver.rs
 expression: "resolve_derive(r#\"\n            from employees\n            derive [\n                gross_salary = salary + payroll_tax,\n                gross_cost =   gross_salary + benefits_cost\n            ]\n            \"#).unwrap()"
 ---
-- id: 13
+- id: 18
   Binary:
     left:
-      id: 14
+      id: 19
       Ident:
         - _frame
         - employees
         - salary
-      target_id: 6
+      target_id: 8
     op: Add
     right:
-      id: 15
+      id: 20
       Ident:
         - _frame
         - employees
         - payroll_tax
-      target_id: 6
+      target_id: 8
   ty:
     kind:
       Union:
@@ -40,22 +40,22 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
           - Singleton: "Null"
     name: scalar
   alias: gross_salary
-- id: 16
+- id: 21
   Binary:
     left:
-      id: 17
+      id: 22
       Ident:
         - _frame
         - gross_salary
-      target_id: 13
+      target_id: 18
     op: Add
     right:
-      id: 18
+      id: 23
       Ident:
         - _frame
         - employees
         - benefits_cost
-      target_id: 6
+      target_id: 8
   ty:
     kind:
       Union:

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__variables_1.snap
@@ -11,7 +11,6 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
         - employees
         - salary
       target_id: 6
-      ty: Infer
     op: Add
     right:
       id: 15
@@ -20,26 +19,26 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
         - employees
         - payroll_tax
       target_id: 6
-      ty: Infer
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
   alias: gross_salary
 - id: 16
   Binary:
@@ -49,7 +48,6 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
         - _frame
         - gross_salary
       target_id: 13
-      ty: Infer
     op: Add
     right:
       id: 18
@@ -58,25 +56,25 @@ expression: "resolve_derive(r#\"\n            from employees\n            derive
         - employees
         - benefits_cost
       target_id: 6
-      ty: Infer
   ty:
-    TypeExpr:
-      Union:
-        - - ~
-          - Primitive: Int
-        - - ~
-          - Primitive: Float
-        - - ~
-          - Primitive: Bool
-        - - ~
-          - Primitive: Text
-        - - ~
-          - Primitive: Date
-        - - ~
-          - Primitive: Time
-        - - ~
-          - Primitive: Timestamp
-        - - ~
-          - Singleton: "Null"
+    kind:
+      TypeExpr:
+        Union:
+          - - ~
+            - Primitive: Int
+          - - ~
+            - Primitive: Float
+          - - ~
+            - Primitive: Bool
+          - - ~
+            - Primitive: Text
+          - - ~
+            - Primitive: Date
+          - - ~
+            - Primitive: Time
+          - - ~
+            - Primitive: Timestamp
+          - - ~
+            - Singleton: "Null"
   alias: gross_cost
 

--- a/prql-compiler/src/semantic/std.prql
+++ b/prql-compiler/src/semantic/std.prql
@@ -12,25 +12,25 @@
 
 # Aggregate functions
 # These return either a scalar when used within `aggregate`, or a column when used anywhere else.
-let min = column -> <scalar || column> null
-let max = column -> <scalar || column> null
-let sum = column -> <scalar || column> null
-let avg = column -> <scalar || column> null
-let stddev = column -> <scalar || column> null
-let average = column -> <scalar || column> null
-let count = non_null:s"*" -> <scalar || column> null
+let min = column -> <scalar || array> null
+let max = column -> <scalar || array> null
+let sum = column -> <scalar || array> null
+let avg = column -> <scalar || array> null
+let stddev = column -> <scalar || array> null
+let average = column -> <scalar || array> null
+let count = non_null:s"*" -> <scalar || array> null
 # TODO: Possibly make this into `count distinct:true` (or like `distinct:` as an
 # abbreviation of that?)
-let count_distinct = column -> <scalar || column> null
+let count_distinct = column -> <scalar || array> null
 
 # Window functions
-let lag = offset column -> <column> null
-let lead = offset column -> <column> null
-let first = offset column -> <column> null
-let last = offset column -> <column> null
-let rank = -> <column> null
-let rank_dense = -> <column> null
-let row_number = -> <column> null
+let lag = offset column -> <array> null
+let lead = offset column -> <array> null
+let first = offset column -> <array> null
+let last = offset column -> <array> null
+let rank = -> <array> null
+let rank_dense = -> <array> null
+let row_number = -> <array> null
 
 # Other functions
 let round = n_digits column -> <scalar> null
@@ -39,12 +39,12 @@ let in = pattern value -> <bool> null
 
 # Transform type definitions
 let from = `default_db.source`<table> -> <table> null
-let select = columns<column> tbl<table> -> <table> null
+let select = columns<scalar> tbl<table> -> <table> null
 let filter = condition<bool> tbl<table> -> <table> null
-let derive = columns<column> tbl<table> -> <table> null
-let aggregate = a<column> tbl<table> -> <table> null
-let sort = by tbl<table> -> <table> null
-let take = expr tbl<table> -> <table> null
+let derive = columns<scalar> tbl<table> -> <table> null
+let aggregate = columns<array> tbl<table> -> <table> null
+let sort = by<scalar> tbl<table> -> <table> null
+let take = expr<scalar> tbl<table> -> <table> null
 let join = `default_db.with`<table> filter `noresolve.side`:inner tbl<table> -> <table> null
 let group = by pipeline tbl<table> -> <table> null
 let window = rows:0..0 range:0..0 expanding:false rolling:0 pipeline tbl<table> -> <table> null
@@ -66,10 +66,10 @@ let remove = `default_db.bottom`<table> top<table> -> <table> (
 let loop = pipeline top<table> -> <table> null
 
 # List functions
-let all = list<list> -> <bool> null
-let map = fn list<list> -> <list> null
-let zip = a<list> b<list> -> <list> null
-let _eq = a<list> -> <list> null
+let all = list -> <bool> null
+let map = fn list -> null
+let zip = a b -> null
+let _eq = a -> null
 let _is_null = a -> _param.a == null
 
 # Misc
@@ -87,10 +87,17 @@ type text
 type date
 type time
 type timestamp
-type table
-type column
-type list
-type scalar
+
+# a tuple
+type list = []
+
+# relation is an array of tupes
+type table = {[]}
+
+# TODO: an array of anything
+type array = {null}
+
+type scalar = int || float || bool || text || date || time || timestamp || null
 
 # Source-reading functions, primarily for DuckDB
 let read_parquet = source<text> -> <table> s"SELECT * FROM read_parquet({source})"

--- a/prql-compiler/src/semantic/std.prql
+++ b/prql-compiler/src/semantic/std.prql
@@ -38,32 +38,32 @@ let as = `noresolve.type` column -> <scalar> null
 let in = pattern value -> <bool> null
 
 # Transform type definitions
-let from = `default_db.source`<table> -> <table> null
-let select = columns<scalar> tbl<table> -> <table> null
-let filter = condition<bool> tbl<table> -> <table> null
-let derive = columns<scalar> tbl<table> -> <table> null
-let aggregate = columns<array> tbl<table> -> <table> null
-let sort = by<scalar> tbl<table> -> <table> null
-let take = expr<scalar> tbl<table> -> <table> null
-let join = `default_db.with`<table> filter `noresolve.side`:inner tbl<table> -> <table> null
-let group = by pipeline tbl<table> -> <table> null
-let window = rows:0..0 range:0..0 expanding:false rolling:0 pipeline tbl<table> -> <table> null
+let from = `default_db.source`<relation> -> <relation> null
+let select = columns<scalar> tbl<relation> -> <relation> null
+let filter = condition<bool> tbl<relation> -> <relation> null
+let derive = columns<scalar> tbl<relation> -> <relation> null
+let aggregate = columns<array> tbl<relation> -> <relation> null
+let sort = by<scalar> tbl<relation> -> <relation> null
+let take = expr<scalar> tbl<relation> -> <relation> null
+let join = `default_db.with`<relation> filter `noresolve.side`:inner tbl<relation> -> <relation> null
+let group = by pipeline tbl<relation> -> <relation> null
+let window = rows:0..0 range:0..0 expanding:false rolling:0 pipeline tbl<relation> -> <relation> null
 
 let noop = x -> x
 
-let append = `default_db.bottom`<table> top<table> -> <table> null
-let intersect = `default_db.bottom`<table> top<table> -> <table> (
+let append = `default_db.bottom`<relation> top<relation> -> <relation> null
+let intersect = `default_db.bottom`<relation> top<relation> -> <relation> (
     noop t = top
     join (noop b = bottom) (all (map _eq (zip t.* b.*)))
     select t.*
 )
-let remove = `default_db.bottom`<table> top<table> -> <table> (
+let remove = `default_db.bottom`<relation> top<relation> -> <relation> (
     noop t = top
     join side:left (noop b = bottom) (all (map _eq (zip t.* b.*)))
     filter (all (map _is_null b.*))
     select t.*
 )
-let loop = pipeline top<table> -> <table> null
+let loop = pipeline top<relation> -> <relation> null
 
 # List functions
 let all = list -> <bool> null
@@ -73,7 +73,7 @@ let _eq = a -> null
 let _is_null = a -> _param.a == null
 
 # Misc
-let from_text = input<text> `noresolve.format`:csv -> <table> null
+let from_text = input<text> `noresolve.format`:csv -> <relation> null
 
 # String functions
 let lower = column -> <text> null
@@ -92,7 +92,7 @@ type timestamp
 type list = []
 
 # relation is an array of tupes
-type table = {[]}
+type relation = {[]}
 
 # TODO: an array of anything
 type array = {null}
@@ -100,5 +100,5 @@ type array = {null}
 type scalar = int || float || bool || text || date || time || timestamp || null
 
 # Source-reading functions, primarily for DuckDB
-let read_parquet = source<text> -> <table> s"SELECT * FROM read_parquet({source})"
-let read_csv = source<text> -> <table> s"SELECT * FROM read_csv_auto({source})"
+let read_parquet = source<text> -> <relation> s"SELECT * FROM read_parquet({source})"
+let read_csv = source<text> -> <relation> s"SELECT * FROM read_csv_auto({source})"

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -1122,17 +1122,18 @@ mod tests {
                 - default_db
                 - c_invoice
               ty:
-                Table:
-                  columns:
-                    - All:
-                        input_name: c_invoice
-                        except: []
-                  inputs:
-                    - id: 6
-                      name: c_invoice
-                      table:
-                        - default_db
-                        - c_invoice
+                kind:
+                  Table:
+                    columns:
+                      - All:
+                          input_name: c_invoice
+                          except: []
+                    inputs:
+                      - id: 6
+                        name: c_invoice
+                        table:
+                          - default_db
+                          - c_invoice
             kind:
               Aggregate:
                 assigns:
@@ -1146,11 +1147,11 @@ mod tests {
                             - c_invoice
                             - amount
                           target_id: 6
-                          ty: Infer
                     ty:
-                      TypeExpr:
-                        Array:
-                          Singleton: "Null"
+                      kind:
+                        TypeExpr:
+                          Array:
+                            Singleton: "Null"
             partition:
               - id: 12
                 Ident:
@@ -1158,24 +1159,24 @@ mod tests {
                   - c_invoice
                   - issued_at
                 target_id: 6
-                ty: Infer
           ty:
-            Table:
-              columns:
-                - Single:
-                    name:
+            kind:
+              Table:
+                columns:
+                  - Single:
+                      name:
+                        - c_invoice
+                        - issued_at
+                      expr_id: 12
+                  - Single:
+                      name: ~
+                      expr_id: 22
+                inputs:
+                  - id: 6
+                    name: c_invoice
+                    table:
+                      - default_db
                       - c_invoice
-                      - issued_at
-                    expr_id: 12
-                - Single:
-                    name: ~
-                    expr_id: 22
-              inputs:
-                - id: 6
-                  name: c_invoice
-                  table:
-                    - default_db
-                    - c_invoice
         - - main
         "###);
     }

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -366,7 +366,9 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Closure) -> Result<Resul
 
             let res = Expr::from(ExprKind::Literal(Literal::Relation(res)));
             let res = Expr {
-                ty: Some(Ty::Table(frame)),
+                ty: Some(Ty {
+                    kind: TyKind::Table(frame),
+                }),
                 id: text_expr.id,
                 ..res
             };
@@ -486,7 +488,7 @@ impl TransformCall {
         fn ty_frame_or_default(expr: &Expr) -> Result<Frame> {
             expr.ty
                 .as_ref()
-                .and_then(|t| t.as_table())
+                .and_then(|t| t.kind.as_table())
                 .cloned()
                 .ok_or_else(|| anyhow!("expected {expr:?} to have table type"))
         }
@@ -511,7 +513,7 @@ impl TransformCall {
 
                 // TODO: See #2270 — this is a bad error message and likely
                 // should be handled prior to reaching this point.
-                let mut frame = body.ty.clone().unwrap().into_table().map_err(|_| {
+                let mut frame = body.ty.clone().unwrap().kind.into_table().map_err(|_| {
                     Error::new_simple(format!(
                         "Expected a function that could operate on a table, but instead found {}",
                         body.ty.clone().unwrap(),
@@ -541,7 +543,7 @@ impl TransformCall {
                 // pipeline's body is resolved, just use its type
                 let Closure { body, .. } = pipeline.kind.as_closure().unwrap().as_ref();
 
-                body.ty.clone().unwrap().into_table().unwrap()
+                body.ty.clone().unwrap().kind.into_table().unwrap()
             }
             Aggregate { assigns } => {
                 let mut frame = ty_frame_or_default(&self.input)?;

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -1133,10 +1133,10 @@ mod tests {
         let res = ctx.find_main(&[]).unwrap().clone();
         assert_yaml_snapshot!(res, @r###"
         ---
-        - id: 28
+        - id: 37
           TransformCall:
             input:
-              id: 6
+              id: 8
               Ident:
                 - default_db
                 - c_invoice
@@ -1152,7 +1152,7 @@ mod tests {
                       input_name: c_invoice
                       except: []
                 inputs:
-                  - id: 6
+                  - id: 8
                     name: c_invoice
                     table:
                       - default_db
@@ -1160,28 +1160,28 @@ mod tests {
             kind:
               Aggregate:
                 assigns:
-                  - id: 22
+                  - id: 29
                     BuiltInFunction:
                       name: std.average
                       args:
-                        - id: 27
+                        - id: 36
                           Ident:
                             - _frame
                             - c_invoice
                             - amount
-                          target_id: 6
+                          target_id: 8
                     ty:
                       kind:
                         Array:
                           Singleton: "Null"
                       name: array
             partition:
-              - id: 12
+              - id: 16
                 Ident:
                   - _frame
                   - c_invoice
                   - issued_at
-                target_id: 6
+                target_id: 8
           ty:
             kind:
               Array:
@@ -1193,12 +1193,12 @@ mod tests {
                   name:
                     - c_invoice
                     - issued_at
-                  expr_id: 12
+                  expr_id: 16
               - Single:
                   name: ~
-                  expr_id: 22
+                  expr_id: 29
             inputs:
-              - id: 6
+              - id: 8
                 name: c_invoice
                 table:
                   - default_db

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -1131,10 +1131,9 @@ mod tests {
                 - c_invoice
               ty:
                 kind:
-                  TypeExpr:
-                    Array:
-                      Tuple:
-                        - Wildcard
+                  Array:
+                    Tuple:
+                      - Wildcard
                 name: ~
               lineage:
                 columns:
@@ -1162,9 +1161,8 @@ mod tests {
                           target_id: 6
                     ty:
                       kind:
-                        TypeExpr:
-                          Array:
-                            Singleton: "Null"
+                        Array:
+                          Singleton: "Null"
                       name: array
             partition:
               - id: 12
@@ -1175,9 +1173,8 @@ mod tests {
                 target_id: 6
           ty:
             kind:
-              TypeExpr:
-                Array:
-                  Tuple: []
+              Array:
+                Tuple: []
             name: table
           lineage:
             columns:

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -513,7 +513,7 @@ impl TransformCall {
                 // TODO: See #2270 — this is a bad error message and likely
                 // should be handled prior to reaching this point.
                 if let Some(ty) = &body.ty {
-                    if !ty.is_table() {
+                    if !ty.is_relation() {
                         return Err(
                             Error::new_simple(format!(
                                 "Expected a function that could operate on a table, but instead found {}",
@@ -1175,7 +1175,7 @@ mod tests {
             kind:
               Array:
                 Tuple: []
-            name: table
+            name: relation
           lineage:
             columns:
               - Single:

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -1147,7 +1147,8 @@ mod tests {
                           ty: Infer
                     ty:
                       TypeExpr:
-                        Primitive: Column
+                        Array:
+                          Singleton: "Null"
             partition:
               - id: 12
                 Ident:

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -367,7 +367,18 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Closure) -> Result<Resul
                 Some(input_name),
             );
 
-            let res = Expr::from(ExprKind::Literal(Literal::Relation(res)));
+            let res = Expr::from(ExprKind::Array(
+                res.rows
+                    .into_iter()
+                    .map(|row| {
+                        Expr::from(ExprKind::List(
+                            row.into_iter()
+                                .map(|lit| Expr::from(ExprKind::Literal(lit)))
+                                .collect(),
+                        ))
+                    })
+                    .collect(),
+            ));
             let res = Expr {
                 lineage: Some(frame),
                 id: text_expr.id,

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -368,6 +368,7 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Closure) -> Result<Resul
             let res = Expr {
                 ty: Some(Ty {
                     kind: TyKind::Table(frame),
+                    name: None,
                 }),
                 id: text_expr.id,
                 ..res
@@ -1134,6 +1135,7 @@ mod tests {
                         table:
                           - default_db
                           - c_invoice
+                name: ~
             kind:
               Aggregate:
                 assigns:
@@ -1152,6 +1154,7 @@ mod tests {
                         TypeExpr:
                           Array:
                             Singleton: "Null"
+                      name: array
             partition:
               - id: 12
                 Ident:
@@ -1177,6 +1180,7 @@ mod tests {
                     table:
                       - default_db
                       - c_invoice
+            name: ~
         - - main
         "###);
     }

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -159,7 +159,7 @@ impl Context {
         let Some(found_ty) = found_ty else {
             // found is none: infer from expected
 
-            if found.lineage.is_none() && expected.is_table() {
+            if found.lineage.is_none() && expected.is_relation() {
                 // special case: infer a table type
                 // inferred tables are needed for s-strings that represent tables
                 // similarly as normal table references, we want to be able to infer columns

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -103,7 +103,6 @@ pub fn infer_type(node: &Expr) -> Result<Option<Ty>> {
             Literal::Time(_) => TyKind::Primitive(PrimitiveSet::Time),
             Literal::Timestamp(_) => TyKind::Primitive(PrimitiveSet::Timestamp),
             Literal::ValueAndUnit(_) => return Ok(None), // TODO
-            Literal::Relation(_) => return Ok(None),     // TODO
         },
 
         ExprKind::Ident(_) | ExprKind::Pipeline(_) | ExprKind::FuncCall(_) => return Ok(None),

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -19,9 +19,9 @@ fn coerce_to_named_type(expr: Expr, context: &Context) -> Result<(Option<String>
 }
 
 fn coerce_kind_to_set(expr: ExprKind, context: &Context) -> Result<TyKind, Error> {
-    // primitives
-    if let ExprKind::Set(set_expr) = expr {
-        return Ok(TyKind::Primitive(set_expr));
+    // already resolved type expressions (mostly primitives)
+    if let ExprKind::Type(set_expr) = expr {
+        return Ok(set_expr);
     }
 
     // singletons

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -20,8 +20,8 @@ fn coerce_to_named_type(expr: Expr, context: &Context) -> Result<(Option<String>
 
 fn coerce_kind_to_set(expr: ExprKind, context: &Context) -> Result<TyKind, Error> {
     // primitives
-    if let ExprKind::Type(set_expr) = expr {
-        return Ok(set_expr);
+    if let ExprKind::Set(set_expr) = expr {
+        return Ok(TyKind::Primitive(set_expr));
     }
 
     // singletons
@@ -95,13 +95,13 @@ pub fn infer_type(node: &Expr) -> Result<Option<Ty>> {
     let kind = match &node.kind {
         ExprKind::Literal(ref literal) => match literal {
             Literal::Null => return Ok(None),
-            Literal::Integer(_) => TyKind::Primitive(TyLit::Int),
-            Literal::Float(_) => TyKind::Primitive(TyLit::Float),
-            Literal::Boolean(_) => TyKind::Primitive(TyLit::Bool),
-            Literal::String(_) => TyKind::Primitive(TyLit::Text),
-            Literal::Date(_) => TyKind::Primitive(TyLit::Date),
-            Literal::Time(_) => TyKind::Primitive(TyLit::Time),
-            Literal::Timestamp(_) => TyKind::Primitive(TyLit::Timestamp),
+            Literal::Integer(_) => TyKind::Primitive(PrimitiveSet::Int),
+            Literal::Float(_) => TyKind::Primitive(PrimitiveSet::Float),
+            Literal::Boolean(_) => TyKind::Primitive(PrimitiveSet::Bool),
+            Literal::String(_) => TyKind::Primitive(PrimitiveSet::Text),
+            Literal::Date(_) => TyKind::Primitive(PrimitiveSet::Date),
+            Literal::Time(_) => TyKind::Primitive(PrimitiveSet::Time),
+            Literal::Timestamp(_) => TyKind::Primitive(PrimitiveSet::Timestamp),
             Literal::ValueAndUnit(_) => return Ok(None), // TODO
             Literal::Relation(_) => return Ok(None),     // TODO
         },
@@ -109,7 +109,7 @@ pub fn infer_type(node: &Expr) -> Result<Option<Ty>> {
         ExprKind::Ident(_) | ExprKind::Pipeline(_) | ExprKind::FuncCall(_) => return Ok(None),
 
         ExprKind::SString(_) => return Ok(None),
-        ExprKind::FString(_) => TyKind::Primitive(TyLit::Text),
+        ExprKind::FString(_) => TyKind::Primitive(PrimitiveSet::Text),
         ExprKind::Range(_) => return Ok(None), // TODO
 
         ExprKind::TransformCall(_) => return Ok(None), // TODO

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -172,7 +172,7 @@ impl Context {
                 found: format!("type `{}`", found_ty),
             })
             .with_span(found.span));
-            if matches!(found_ty, Ty::Function(_)) && !matches!(expected, Ty::Function(_)) {
+            if found_ty.is_function() && !expected.is_function() {
                 let func_name = found.kind.as_closure().and_then(|c| c.name.as_ref());
                 let to_what = func_name
                     .map(|n| format!("to function {n}"))

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -351,7 +351,6 @@ pub(super) fn translate_literal(l: Literal, ctx: &Context) -> Result<sql_ast::Ex
                 fractional_seconds_precision: None,
             }
         }
-        Literal::Relation(_) => unreachable!(),
     })
 }
 

--- a/prql-compiler/src/sql/std_impl.prql
+++ b/prql-compiler/src/sql/std_impl.prql
@@ -10,25 +10,25 @@ let count = non_null:s"*" -> <scalar || column> s"COUNT({non_null})"
 let count_distinct = column -> <scalar || column> s"COUNT(DISTINCT {column})"
 
 # Window functions
-let lag = offset column -> <column> s"LAG({column}, {offset})"
-let lead = offset column -> <column> s"LEAD({column}, {offset})"
-let first = offset column -> <column> s"FIRST_VALUE({column}, {offset})"
-let last = offset column -> <column> s"LAST_VALUE({column}, {offset})"
-let rank = -> <column> s"RANK()"
-let rank_dense = -> <column> s"DENSE_RANK()"
-let row_number = -> <column> s"ROW_NUMBER()"
+let lag = offset column -> s"LAG({column}, {offset})"
+let lead = offset column -> s"LEAD({column}, {offset})"
+let first = offset column -> s"FIRST_VALUE({column}, {offset})"
+let last = offset column -> s"LAST_VALUE({column}, {offset})"
+let rank = -> s"RANK()"
+let rank_dense = -> s"DENSE_RANK()"
+let row_number = -> s"ROW_NUMBER()"
 
 # Other functions
-let round = n_digits column -> <scalar> s"ROUND({column}, {n_digits})"
-let as = `noresolve.type` column -> <scalar> s"CAST({column} AS {type})"
+let round = n_digits column -> s"ROUND({column}, {n_digits})"
+let as = `noresolve.type` column -> s"CAST({column} AS {type})"
 
 # String functions
 let lower = column -> <text> s"LOWER({column})"
 let upper = column -> <text> s"UPPER({column})"
 
 # Source-reading functions, primarily for DuckDB
-let read_parquet = source<text> -> <table> s"SELECT * FROM read_parquet({source})"
-let read_csv = source<text> -> <table> s"SELECT * FROM read_csv_auto({source})"
+let read_parquet = source<text> -> s"SELECT * FROM read_parquet({source})"
+let read_csv = source<text> -> s"SELECT * FROM read_csv_auto({source})"
 
 let mul = l r -> null
 let div = l r -> null

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -3630,4 +3630,40 @@ fn test_array() {
     ───╯
     "###
     );
+
+    assert_snapshot!(compile(r#"
+    let my_relation = {
+        [a = 3, b = false],
+        [a = 4, b = true],
+    }
+
+    let main = (my_relation | filter b)
+    "#).unwrap(),
+        @r###"
+    WITH table_2 AS (
+      SELECT
+        3 AS a,
+        false AS b
+      UNION
+      ALL
+      SELECT
+        4 AS a,
+        true AS b
+    ),
+    my_relation AS (
+      SELECT
+        a,
+        b
+      FROM
+        table_2 AS table_1
+    )
+    SELECT
+      a,
+      b
+    FROM
+      my_relation
+    WHERE
+      b
+    "###
+    );
 }

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -3614,3 +3614,20 @@ fn test_into() {
     "###
     );
 }
+
+#[test]
+fn test_array() {
+    assert_display_snapshot!(compile(r#"
+    let a = {1, 2, false}
+    "#).unwrap_err(),
+        @r###"
+    Error:
+       ╭─[:2:20]
+       │
+     2 │     let a = {1, 2, false}
+       │                    ──┬──
+       │                      ╰──── array expected types of all of its elements to be int, but found bool
+    ───╯
+    "###
+    );
+}

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -2942,7 +2942,7 @@ fn test_static_analysis() {
 fn test_closures_and_pipelines() {
     assert_display_snapshot!(compile(
         r###"
-    let addthree = a b c -> <column> s"{a} || {b} || {c}"
+    let addthree = a b c -> s"{a} || {b} || {c}"
     let arg = myarg myfunc -> ( myfunc myarg )
 
     from y

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -2526,7 +2526,7 @@ fn test_unused_alias() {
 #[test]
 fn test_table_s_string() {
     assert_display_snapshot!(compile(r###"
-    let main <table> = s"SELECT DISTINCT ON first_name, age FROM employees ORDER BY age ASC"
+    let main <relation> = s"SELECT DISTINCT ON first_name, age FROM employees ORDER BY age ASC"
     "###).unwrap(),
         @r###"
     WITH table_2 AS (

--- a/prql-compiler/src/tests/test_bad_error_messages.rs
+++ b/prql-compiler/src/tests/test_bad_error_messages.rs
@@ -29,7 +29,7 @@ fn test_bad_error_messages() {
        │
      3 │     group
        │     ──┬──
-       │       ╰──── main expected type `table<[]>`, but found type `func infer table<[]> -> table<[]>`
+       │       ╰──── main expected type `{[]}`, but found type `func infer {[]} -> {[]}`
        │
        │ Help: Have you forgotten an argument to function std.group?
     ───╯
@@ -60,6 +60,6 @@ fn test_2270() {
     "###,
     )
     .unwrap_err(), @r###"
-    Error: Expected a function that could operate on a table, but instead found func table<[]> -> table<[]>
+    Error: Expected a function that could operate on a table, but instead found func {[]} -> {[]}
     "###);
 }

--- a/prql-compiler/src/tests/test_bad_error_messages.rs
+++ b/prql-compiler/src/tests/test_bad_error_messages.rs
@@ -29,7 +29,7 @@ fn test_bad_error_messages() {
        │
      3 │     group
        │     ──┬──
-       │       ╰──── main expected type `{[]}`, but found type `func infer {[]} -> {[]}`
+       │       ╰──── main expected type `table`, but found type `func infer table -> table`
        │
        │ Help: Have you forgotten an argument to function std.group?
     ───╯
@@ -60,6 +60,6 @@ fn test_2270() {
     "###,
     )
     .unwrap_err(), @r###"
-    Error: Expected a function that could operate on a table, but instead found func {[]} -> {[]}
+    Error: Expected a function that could operate on a table, but instead found func table -> table
     "###);
 }

--- a/prql-compiler/src/tests/test_bad_error_messages.rs
+++ b/prql-compiler/src/tests/test_bad_error_messages.rs
@@ -29,7 +29,7 @@ fn test_bad_error_messages() {
        │
      3 │     group
        │     ──┬──
-       │       ╰──── main expected type `table`, but found type `func infer table -> table`
+       │       ╰──── main expected type `relation`, but found type `func infer relation -> relation`
        │
        │ Help: Have you forgotten an argument to function std.group?
     ───╯
@@ -60,6 +60,6 @@ fn test_2270() {
     "###,
     )
     .unwrap_err(), @r###"
-    Error: Expected a function that could operate on a table, but instead found func table -> table
+    Error: Expected a function that could operate on a table, but instead found func relation -> relation
     "###);
 }

--- a/prql-compiler/src/tests/test_error_messages.rs
+++ b/prql-compiler/src/tests/test_error_messages.rs
@@ -120,7 +120,7 @@ fn test_hint_missing_args() {
        │
      3 │     select [film_id, lag film_id]
        │                      ─────┬─────
-       │                           ╰─────── function std.select, param `columns` expected type `column`, but found type `func infer -> column`
+       │                           ╰─────── function std.select, param `columns` expected type `int|float|bool|text|date|time|timestamp|null`, but found type `func infer -> {null}`
        │
        │ Help: Have you forgotten an argument to function std.lag?
     ───╯

--- a/prql-compiler/src/tests/test_error_messages.rs
+++ b/prql-compiler/src/tests/test_error_messages.rs
@@ -120,7 +120,7 @@ fn test_hint_missing_args() {
        │
      3 │     select [film_id, lag film_id]
        │                      ─────┬─────
-       │                           ╰─────── function std.select, param `columns` expected type `int|float|bool|text|date|time|timestamp|null`, but found type `func infer -> {null}`
+       │                           ╰─────── function std.select, param `columns` expected type `scalar`, but found type `func infer -> array`
        │
        │ Help: Have you forgotten an argument to function std.lag?
     ───╯


### PR DESCRIPTION
This PR contains many small changes mostly in the frontend of the compiler:

- parsing arrays
- use arrays in the type system
- refactor: Ty::Function -> TypeExpr::Function
- refactor Ty -> TyKind
- refactor minor AST
- refactor TyKind::Infer -> None
- ty name
- refactor TyKind::Table -> Expr.lineage
- refactor TyExpr -> TyKind
- refactor ExprKind::Type -> ExprKind::Set
- refactor std.table -> std.relation
- make relation literal an array of lists
- revert ExprKind::Set -> ExprKind::Type
- array constants to relation literals


I've added a non-breaking syntax for arrays:

```elm
let a = {1, 2, 3}
```

They cannot be directly translated into SQL, but are used in the type system a lot (they are used to implement relations).

I've refactored the data structure that tracks how a relation is manipulated and renamed it from "Frame" into "Lineage".

And I've made sure that relations are actually just arrays of tuples:

```elm
let row1 = [a = 5, b = false]
let row2 = [a = 6, b = true]
let my_relation = {row1, row2}

my_relation | filter b == true
```

... which make great one-liners for constructing relations on-the-fly:

```elm
{[a = 5, b = false], [a = 6, b = true]}
filter b == true
```


Ref #2124 #1965 

Closes #1787

Closes #286