### PR TITLE
docs: Add docs for `into`

### DIFF
--- a/web/book/src/queries/variables.md
+++ b/web/book/src/queries/variables.md
@@ -1,6 +1,11 @@
 # Variables
 
-We can define a relation — similar to a CTE in SQL — as a variable with `let`:
+We can define a relation — similar to a CTE in SQL — with two approaches — a
+prefix `let` or a postfix `into.
+
+## `let`
+
+Here we assign a variable to `foo` with `let` by prefixing with `let foo =`:
 
 ```prql
 let top_50 = (
@@ -29,13 +34,27 @@ let grouping = s"""
 from grouping
 ```
 
+## `into`
+
+We can also assign a variable to `foo` by postfixing with `into foo`:
+
+```prql
+from employees
+sort salary
+take 50
+aggregate [total_salary = sum salary]
+into top_50
+
+from top_50      # Starts a new pipeline
+```
+
 ```admonish info
-In PRQL `table`s are far less common than CTEs are in SQL, since a linear series
+In PRQL variables are far less common than CTEs are in SQL, since a linear series
 of CTEs can be represented with a single pipeline.
 ```
 
-Currently defining variables with `let` is restricted to relations. We'd like to
-extend this to expressions that evaluate to scalars.
+Currently defining variables is restricted to relations. We'd like to extend
+this to expressions that evaluate to scalars.
 
 <!--
 , like recursive queries:

--- a/web/book/tests/snapshots/snapshot__queries__variables-2.snap
+++ b/web/book/tests/snapshots/snapshot__queries__variables-2.snap
@@ -1,0 +1,24 @@
+---
+source: web/book/tests/snapshot.rs
+expression: "from employees\nsort salary\ntake 50\naggregate [total_salary = sum salary]\ninto top_50\n\nfrom top_50      # Starts a new pipeline\n"
+---
+WITH table_1 AS (
+  SELECT
+    salary
+  FROM
+    employees
+  ORDER BY
+    salary
+  LIMIT
+    50
+), top_50 AS (
+  SELECT
+    SUM(salary) AS total_salary
+  FROM
+    table_1 AS table_0
+)
+SELECT
+  total_salary
+FROM
+  top_50
+


### PR DESCRIPTION
From #2577. We could probably market it more aggressively through the docs too
