### PR TITLE
test: Assert failures fail

### DIFF
--- a/web/book/src/language-features/target.md
+++ b/web/book/src/language-features/target.md
@@ -15,7 +15,7 @@ sort age
 take 10
 ```
 
-```prql no-fmt
+```prql
 prql target:sql.mssql
 
 from employees

--- a/web/book/src/syntax/expressions-and-operators.md
+++ b/web/book/src/syntax/expressions-and-operators.md
@@ -89,13 +89,21 @@ sort [-distance]
 ```
 
 Note: The `total_distance` statement below generates an error because the
-function is not in a list. (The PRQL compiler should display a better error
+function is not in a list... (The PRQL compiler should display a better error
 message.)
 
-```prql error
+```prql error no-fmt
 from employees
-derive total_distance = sum distance # generates the error shown below
-derive other_distance = (sum distance) # works as expected
+derive total_distance = sum distance
+```
+
+...while with parentheses, it works at expected:
+
+<!-- TODO: why doesn't this format? -->
+
+```prql no-fmt
+from employees
+derive other_distance = (sum distance)
 ```
 
 ```admonish note

--- a/web/book/tests/snapshot.rs
+++ b/web/book/tests/snapshot.rs
@@ -98,36 +98,58 @@ fn collect_book_examples() -> Result<Vec<Example>> {
 // compilation. For that to provide a good output, we need to implement a proper
 // autoformatter.
 #[test]
-fn test_display() -> Result<(), ErrorMessages> {
+fn test_display() -> Result<()> {
     collect_book_examples()?
         .iter()
         .try_for_each(|Example { name, tags, prql }| {
-            if tags.contains(&LangTag::Error) || tags.contains(&LangTag::NoFmt) {
-                return Ok(());
-            }
-            prql_to_pl(prql)
+            let result = prql_to_pl(prql)
                 .and_then(pl_to_prql)
-                .and_then(|formatted| compile(&formatted, &Options::default()))
-                .unwrap_or_else(|_| {
-                    panic!(
-                        "
-Failed compiling the formatted result of {name:?}
-To skip this test for an example, use `prql no-fmt` as the language label.
+                .and_then(|formatted| compile(&formatted, &Options::default()));
+            let should_format = !tags.contains(&LangTag::NoFmt);
 
-The original PRQL was:
+            match (should_format, result) {
+                (true, Err(e)) => bail!(
+                    "
+Failed compiling the formatted result of {name:?}
+Use `prql no-fmt` as the language label to assert an error from compiling the formatted result.
+
+The original PRQL:
 
 {prql}
 
+And the error:
+
+{e}
+
 ",
-                        name = name,
-                        prql = prql
-                    )
-                });
+                    name = name,
+                    prql = prql,
+                    e = e
+                ),
 
-            Ok::<(), ErrorMessages>(())
-        })?;
+                (false, Ok(formatted_prql)) => bail!(
+                    "
+Succeeded at compiling the formatted result of {name:?}, but example was marked as `no-fmt`.
+Remove `no-fmt` as a language label to assert successfully compiling the formatted resullt.
 
-    Ok(())
+The original PRQL:
+
+{prql}
+
+And the formatted PRQL:
+
+{formatted_prql}
+
+",
+                    name = name,
+                    prql = prql,
+                    formatted_prql = formatted_prql
+                ),
+                _ => Ok::<(), anyhow::Error>(()),
+            }?;
+
+            Ok(())
+        })
 }
 
 #[test]

--- a/web/book/tests/snapshots/snapshot__syntax__expressions-and-operators-2.snap
+++ b/web/book/tests/snapshots/snapshot__syntax__expressions-and-operators-2.snap
@@ -1,11 +1,11 @@
 ---
 source: web/book/tests/snapshot.rs
-expression: "from employees\nderive total_distance = sum distance # generates the error shown below\nderive other_distance = (sum distance) # works as expected\n"
+expression: "from employees\nderive total_distance = sum distance\n"
 ---
 Error:
    ╭─[:2:29]
    │
- 2 │ derive total_distance = sum distance # generates the error shown below
+ 2 │ derive total_distance = sum distance
    │                             ────┬───
    │                                 ╰───── Unknown name distance
 ───╯

--- a/web/book/tests/snapshots/snapshot__syntax__expressions-and-operators-3.snap
+++ b/web/book/tests/snapshots/snapshot__syntax__expressions-and-operators-3.snap
@@ -1,0 +1,10 @@
+---
+source: web/book/tests/snapshot.rs
+expression: "from employees\nderive other_distance = (sum distance)\n"
+---
+SELECT
+  *,
+  SUM(distance) OVER () AS other_distance
+FROM
+  employees
+


### PR DESCRIPTION
This limits us from marking everything with `no-fmt` — there were some examples that did actually format. Also better diagnostics...
