### PR TITLE
internal: Remove BQ special-case

### DIFF
--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -121,10 +121,6 @@ pub(super) trait DialectHandler: Any + Debug {
         '"'
     }
 
-    fn big_query_quoting(&self) -> bool {
-        false
-    }
-
     fn column_exclude(&self) -> Option<ColumnExclude> {
         None
     }
@@ -297,9 +293,6 @@ impl DialectHandler for ClickHouseDialect {
 impl DialectHandler for BigQueryDialect {
     fn ident_quote(&self) -> char {
         '`'
-    }
-    fn big_query_quoting(&self) -> bool {
-        true
     }
     fn column_exclude(&self) -> Option<ColumnExclude> {
         // https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -736,13 +736,7 @@ pub(super) fn translate_ident(
     let mut parts = Vec::with_capacity(4);
     if !ctx.query.omit_ident_prefix || column.is_none() {
         if let Some(table) = table_ident {
-            #[allow(clippy::if_same_then_else)]
-            if ctx.dialect.big_query_quoting() {
-                // Special-case this for BigQuery, Ref #852
-                parts.push(table.into_iter().join("."));
-            } else {
-                parts.extend(table.into_iter());
-            }
+            parts.extend(table.into_iter());
         }
     }
 

--- a/web/book/src/syntax/quoted-identifiers.md
+++ b/web/book/src/syntax/quoted-identifiers.md
@@ -29,9 +29,9 @@ from `project-foo.dataset.table`
 join `project-bar.dataset.table` [==col_bax]
 ```
 
-## Quoting schemas
+## Schemas & database names
 
-Identifiers of tables can be prefixed with databases and schema names. Note that
+Identifiers of tables can be prefixed with schema and databases names. Note that
 all of following identifiers will be treated as separate table definitions:
 `tracks`, `public.tracks`, `my_database.public.tracks`.
 


### PR DESCRIPTION
Because of the new module system, we don't need a special-case for BigQuery any longer!

(At least, I can't find how we'd need it, but I might be wrong — lmk if you suspect I might be...)
