### PR TITLE
build: Bump toolchain, test `prqlc` for `msrv`

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -144,9 +144,12 @@ jobs:
         with:
           crate: cargo-msrv
         # Note this currently uses a manually maintained key in
-        # `prql-compiler/Cargo.toml`, because of
+        # `prql-compiler/Cargo.toml` (and `prql-compiler/prqlc/Cargo.toml` below), because of
         # https://github.com/foresterre/cargo-msrv/issues/590
-      - name: Verify minimum rust version
+      - name: Verify minimum rust version — prql-compiler
         # Ideally we'd check all crates, ref https://github.com/foresterre/cargo-msrv/issues/295
         working-directory: prql-compiler
+        run: cargo msrv verify
+      - name: Verify minimum rust version — prqlc
+        working-directory: prqlc
         run: cargo msrv verify

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -151,5 +151,5 @@ jobs:
         working-directory: prql-compiler
         run: cargo msrv verify
       - name: Verify minimum rust version — prqlc
-        working-directory: prqlc
+        working-directory: prql-compiler/prqlc
         run: cargo msrv verify

--- a/prql-compiler/prqlc/Cargo.toml
+++ b/prql-compiler/prqlc/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+metadata.msrv = "1.65.0"
+
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 anyhow = {version = "1.0.57"}
 ariadne = "0.2.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66.0"
 components = ["rustfmt", "clippy"]
 # We want two targets: wasm32, and the default target for the platform, which we
 # don't list here. (i.e. we use each platform to test each platform)


### PR DESCRIPTION
`rust-analyzer` is now raising mistaken errors for 1.65, as they only support the latest version https://github.com/rust-lang/rust-analyzer/issues/12751#issuecomment-1182887933

We don't want to bump the required version because of https://github.com/PRQL/prql/pull/1561, but I think this approach:
- Lets us work on an updated version
- Tests `prql-compiler` & `prqlc` to ensure they don't fail to support 1.65
- Doesn't let us use any new features in `prql-compiler` or `prqlc` until we bump the required version, but that's completely fine (is there even _anything_ we'd use?)
