### PR TITLE
build: Reenable toolchain updates

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,17 +64,17 @@ jobs:
   update-rust-toolchain:
     runs-on: ubuntu-latest
     # Don't run on forks; will attempt to create a PR into the fork...
-    # if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
 
-    # Disabling until we resolve what version Debian supports, ref https://github.com/PRQL/prql/pull/1561
-    if: false
+    # Note that this doesn't change the minimum supported version, only the
+    # default to run on. The minimum is defined by Cargo.toml's metadata.msrv.
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
       - uses: a-kenji/update-rust-toolchain@main
         with:
           # Discussion in #1561
-          minor-version-delta: 3
+          minor-version-delta: 1
           toolchain-path: "./rust-toolchain.toml"
           pr-title: "build: Update rust toolchain version"
 


### PR DESCRIPTION
In #2621 I realized that we didn't have to couple these — sorry for overcomplicating previously
