### PR TITLE
chore: Fix broken test

### DIFF
--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -1491,8 +1491,8 @@ fn test_distinct_on() {
     prql target:sql.duckdb
 
     from x
-    select [class, begins]
-    group [begins] (take 1)
+    select {class, begins}
+    group {begins} (take 1)
     "###).unwrap()), @r###"
     SELECT
       DISTINCT ON (begins) class,


### PR DESCRIPTION
We hadn't rebased a PR, and the tuple / syntax broke. One of the first times this has happened...
