### PR TITLE
devops: Add `wasm-opt` to `dev-setup`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,7 +23,8 @@ vars:
     rust-lang.rust-analyzer
   cargo_crates:
     bacon cargo-audit cargo-insta cargo-release default-target mdbook
-    mdbook-admonish mdbook-footnote mdbook-toc wasm-bindgen-cli wasm-pack
+    mdbook-admonish mdbook-footnote mdbook-toc wasm-bindgen-cli wasm-opt
+    wasm-pack
 
 tasks:
   # main installer is "setup-dev" which calls other tasks


### PR DESCRIPTION
Generally `wasm-pack` installs this itself, but on the devcontainer it seems to not find the binary.

This may close #2630
