### PR TITLE
fix: Refine some error messages

### DIFF
--- a/prql-compiler/src/error.rs
+++ b/prql-compiler/src/error.rs
@@ -137,7 +137,7 @@ impl Display for ErrorMessage {
 
             writeln!(f, "{}Error: {}", code, &self.reason)?;
             if let Some(hint) = &self.hint {
-                writeln!(f, " Hint: {}", hint)?;
+                writeln!(f, "Hint: {}", hint)?;
             }
         }
         Ok(())

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -92,7 +92,7 @@ fn extern_ref_to_relation(
 fn validate_query_def(query_def: &QueryDef) -> Result<()> {
     if let Some(requirement) = &query_def.version {
         if !requirement.matches(&COMPILER_VERSION) {
-            return Err(Error::new_simple("This query uses a version of PRQL that is not supported by your prql-compiler. You may want to upgrade the compiler.").into());
+            return Err(Error::new_simple("This query uses a version of PRQL that is not supported by the prql-compiler. Please upgrade the compiler.").into());
         }
     }
     Ok(())

--- a/prql-compiler/src/sql/srq/preprocess.rs
+++ b/prql-compiler/src/sql/srq/preprocess.rs
@@ -311,8 +311,8 @@ pub(in crate::sql) fn except(
             // EXCEPT ALL is not supported
             // can we fall back to anti-join?
             if ctx.anchor.contains_wildcard(&top) || ctx.anchor.contains_wildcard(&bottom) {
-                return Err(Error::new_simple("Your dialect does not support EXCEPT ALL")
-                    .with_help("If you provide more column information, your query can be translated to an anti join.")
+                return Err(Error::new_simple(format!("The dialect {:?} does not support EXCEPT ALL", ctx.dialect))
+                    .with_help("Providing more column information will allow the query to be translated to an anti-join.")
                     .into());
             } else {
                 // Don't create Except, fallback to anti-join.
@@ -391,8 +391,8 @@ pub(in crate::sql) fn intersect(
             // INTERCEPT ALL is not supported
             // can we fall back to anti-join?
             if ctx.anchor.contains_wildcard(&top) || ctx.anchor.contains_wildcard(&bottom) {
-                return Err(Error::new_simple("Your dialect does not support INTERCEPT ALL")
-                    .with_help("If you provide more column information, your query can be translated to an inner join.")
+                return Err(Error::new_simple(format!("The dialect {:?} does not support INTERSECT ALL", ctx.dialect))
+                    .with_help("Providing more column information will allow the query to be translated to an anti-join.")
                     .into());
             } else {
                 // Don't create Intercept, fallback to inner join.

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -338,8 +338,8 @@ fn test_remove() {
     remove artist
     "#).unwrap_err(),
         @r###"
-    Error: Your dialect does not support EXCEPT ALL
-     Hint: If you provide more column information, your query can be translated to an anti join.
+    Error: The dialect SQLiteDialect does not support EXCEPT ALL
+    Hint: Providing more column information will allow the query to be translated to an anti-join.
     "###
     );
 
@@ -554,8 +554,8 @@ fn test_intersect() {
     intersect artist
     "#).unwrap_err(),
         @r###"
-    Error: Your dialect does not support INTERCEPT ALL
-     Hint: If you provide more column information, your query can be translated to an inner join.
+    Error: The dialect SQLiteDialect does not support INTERSECT ALL
+    Hint: Providing more column information will allow the query to be translated to an anti-join.
     "###
     );
 }
@@ -1747,7 +1747,7 @@ fn test_bare_s_string() {
     from s"SELECTfoo"
     "###).unwrap_err(), @r###"
     Error: s-strings representing a table must start with `SELECT `
-     Hint: this is a limitation by current compiler implementation
+    Hint: this is a limitation by current compiler implementation
     "###);
 }
 

--- a/prql-compiler/src/tests/test_error_messages.rs
+++ b/prql-compiler/src/tests/test_error_messages.rs
@@ -110,6 +110,20 @@ fn test_errors() {
 }
 
 #[test]
+fn test_union_all_sqlite() {
+    // TODO: `SQLiteDialect` would be better as `sql.sqlite` or `sqlite`.
+    assert_display_snapshot!(compile(r###"
+    prql target:sql.sqlite
+
+    from film
+    remove film2
+    "###).unwrap_err(), @r###"
+    Error: The dialect SQLiteDialect does not support EXCEPT ALL
+    Hint: Providing more column information will allow the query to be translated to an anti-join.
+    "###)
+}
+
+#[test]
 fn test_hint_missing_args() {
     assert_display_snapshot!(compile(r###"
     from film


### PR DESCRIPTION
`INTERCEPT` vs `INTERSECT`, remove use of 2nd person, align `Hint` & `Error`
