### PR TITLE
ci: Limit python tests concurrency

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -7,6 +7,11 @@ on:
       - ".github/workflows/test-python.yaml"
   workflow_call:
 
+concurrency:
+  # See notes in `pull-request.yaml`
+  group: ${{ github.workflow }}-${{ github.ref }}-python
+  cancel-in-progress: true
+
 jobs:
   build-python-wheels:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We somehow left this out, so it wasn't canceling existing runs when a new commit was pushed
