### PR TITLE
fix: Add indent into hint

### DIFF
--- a/prql-compiler/src/error.rs
+++ b/prql-compiler/src/error.rs
@@ -137,7 +137,8 @@ impl Display for ErrorMessage {
 
             writeln!(f, "{}Error: {}", code, &self.reason)?;
             if let Some(hint) = &self.hint {
-                writeln!(f, "Hint: {}", hint)?;
+                // TODO: consider alternative formatting for hints.
+                writeln!(f, "↳ Hint: {}", hint)?;
             }
         }
         Ok(())

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -339,7 +339,7 @@ fn test_remove() {
     "#).unwrap_err(),
         @r###"
     Error: The dialect SQLiteDialect does not support EXCEPT ALL
-    Hint: Providing more column information will allow the query to be translated to an anti-join.
+    ↳ Hint: Providing more column information will allow the query to be translated to an anti-join.
     "###
     );
 
@@ -555,7 +555,7 @@ fn test_intersect() {
     "#).unwrap_err(),
         @r###"
     Error: The dialect SQLiteDialect does not support INTERSECT ALL
-    Hint: Providing more column information will allow the query to be translated to an anti-join.
+    ↳ Hint: Providing more column information will allow the query to be translated to an anti-join.
     "###
     );
 }
@@ -1747,7 +1747,7 @@ fn test_bare_s_string() {
     from s"SELECTfoo"
     "###).unwrap_err(), @r###"
     Error: s-strings representing a table must start with `SELECT `
-    Hint: this is a limitation by current compiler implementation
+    ↳ Hint: this is a limitation by current compiler implementation
     "###);
 }
 

--- a/prql-compiler/src/tests/test_error_messages.rs
+++ b/prql-compiler/src/tests/test_error_messages.rs
@@ -119,7 +119,7 @@ fn test_union_all_sqlite() {
     remove film2
     "###).unwrap_err(), @r###"
     Error: The dialect SQLiteDialect does not support EXCEPT ALL
-    Hint: Providing more column information will allow the query to be translated to an anti-join.
+    ↳ Hint: Providing more column information will allow the query to be translated to an anti-join.
     "###)
 }
 


### PR DESCRIPTION
Follow up from https://github.com/PRQL/prql/pull/2666#discussion_r1211151955

I don't love it, but I do think it looks less misplaced than a space. What do others think?
