### PR TITLE
feat: Better error messages on supplying directories to `prqlc fmt`

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use anyhow::Result;
 use ariadne::Source;
 use clap::{CommandFactory, Parser, Subcommand, ValueHint};
@@ -169,7 +170,7 @@ impl Command {
                 self.write_output(&buf)?;
             }
             Err(e) => {
-                print!("{:}", e);
+                eprint!("{:}", e);
                 std::process::exit(1)
             }
         }
@@ -193,7 +194,12 @@ impl Command {
                 }
             }
             Command::Format(_) => {
-                let (_, source) = sources.sources.clone().into_iter().exactly_one()?;
+                let (_, source) = sources.sources.clone().into_iter().exactly_one().or_else(
+                    |_| bail!(
+                        "Currently `fmt` only works with a single source, but found multiple sources: {:?}", 
+                        sources.sources.keys().map(|x| format!("'{}'", x.display())).join(", ")
+                    )
+                )?;
                 let ast = prql_to_pl(&source)?;
 
                 pl_to_prql(ast)?.as_bytes().to_vec()
@@ -215,7 +221,12 @@ impl Command {
                 out
             }
             Command::Annotate(_) => {
-                let (_, source) = sources.sources.clone().into_iter().exactly_one()?;
+                let (_, source) = sources.sources.clone().into_iter().exactly_one().or_else(
+                    |_| bail!(
+                        "Currently `annotate` only works with a single source, but found multiple sources: {:?}", 
+                        sources.sources.keys().map(|x| format!("`{}`", x.display())).join(", ")
+                    )
+                )?;
 
                 // TODO: potentially if there is code performing a role beyond
                 // presentation, it should be a library function; and we could
@@ -298,8 +309,10 @@ impl Command {
             | Resolve { io_args, .. }
             | SQLCompile { io_args, .. }
             | SQLPreprocess(io_args)
-            | SQLAnchor { io_args, .. } => io_args,
-            Format(io) | Debug(io) | Annotate(io) => io,
+            | SQLAnchor { io_args, .. }
+            | Format(io_args)
+            | Debug(io_args)
+            | Annotate(io_args) => io_args,
             _ => unreachable!(),
         };
         let input = &mut io_args.input;

--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -196,7 +196,7 @@ impl Command {
             Command::Format(_) => {
                 let (_, source) = sources.sources.clone().into_iter().exactly_one().or_else(
                     |_| bail!(
-                        "Currently `fmt` only works with a single source, but found multiple sources: {:?}", 
+                        "Currently `fmt` only works with a single source, but found multiple sources: {:?}",
                         sources.sources.keys().map(|x| format!("'{}'", x.display())).join(", ")
                     )
                 )?;
@@ -223,7 +223,7 @@ impl Command {
             Command::Annotate(_) => {
                 let (_, source) = sources.sources.clone().into_iter().exactly_one().or_else(
                     |_| bail!(
-                        "Currently `annotate` only works with a single source, but found multiple sources: {:?}", 
+                        "Currently `annotate` only works with a single source, but found multiple sources: {:?}",
                         sources.sources.keys().map(|x| format!("`{}`", x.display())).join(", ")
                     )
                 )?;

--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -197,7 +197,11 @@ impl Command {
                 let (_, source) = sources.sources.clone().into_iter().exactly_one().or_else(
                     |_| bail!(
                         "Currently `fmt` only works with a single source, but found multiple sources: {:?}",
-                        sources.sources.keys().map(|x| format!("'{}'", x.display())).join(", ")
+                        sources.sources.keys()
+                            .map(|x| x.display().to_string())
+                            .sorted()
+                            .map(|x| format!("`{}`", x))
+                            .join(", ")
                     )
                 )?;
                 let ast = prql_to_pl(&source)?;
@@ -224,7 +228,11 @@ impl Command {
                 let (_, source) = sources.sources.clone().into_iter().exactly_one().or_else(
                     |_| bail!(
                         "Currently `annotate` only works with a single source, but found multiple sources: {:?}",
-                        sources.sources.keys().map(|x| format!("`{}`", x.display())).join(", ")
+                        sources.sources.keys()
+                            .map(|x| x.display().to_string())
+                            .sorted()
+                            .map(|x| format!("`{}`", x))
+                            .join(", ")
                     )
                 )?;
 

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -160,7 +160,7 @@ fn test_format() {
     ----- stdout -----
 
     ----- stderr -----
-    Currently `fmt` only works with a single source, but found multiple sources: "'_project.prql', 'artists.prql'"
+    Currently `fmt` only works with a single source, but found multiple sources: "`_project.prql`, `artists.prql`"
     "###);
 }
 

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -148,6 +148,23 @@ fn test_compile_project() {
 }
 
 #[test]
+fn test_format() {
+    let mut cmd = Command::new(get_cargo_bin("prqlc"));
+    cmd.args(["fmt"]);
+    cmd.arg(project_path());
+    // cmd.arg("-");
+    cmd.arg("favorite_artists");
+    assert_cmd_snapshot!(cmd, @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Currently `fmt` only works with a single source, but found multiple sources: "'_project.prql', 'artists.prql'"
+    "###);
+}
+
+#[test]
 fn test_shell_completion() {
     assert_cmd_snapshot!(Command::new(get_cargo_bin("prqlc"))
         .arg("shell-completion")


### PR DESCRIPTION
The prevous error messages was just one line with an internal error message from `exactly_one`!

I wonder if we can at least provide a backtrace or something like that -- it would at least allow exploring what happened. But not sure whether that's possible.
