### PR TITLE
refactor: Consolidate regex ident checks

### DIFF
--- a/prql-compiler/src/codegen.rs
+++ b/prql-compiler/src/codegen.rs
@@ -1,4 +1,4 @@
-use crate::ast::pl;
+use crate::{ast::pl, utils::VALID_IDENT};
 
 pub fn write(stmts: &Vec<pl::Stmt>) -> String {
     let mut r = String::new();
@@ -305,20 +305,10 @@ impl WriteSource for pl::Ident {
 }
 
 pub fn write_ident_part(s: &str) -> String {
-    fn forbidden_start(c: char) -> bool {
-        !(c.is_ascii_lowercase() || matches!(c, '_' | '$'))
-    }
-    fn forbidden_subsequent(c: char) -> bool {
-        !(c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '_'))
-    }
-    let needs_escape = s.is_empty()
-        || s.starts_with(forbidden_start)
-        || (s.len() > 1 && s.chars().skip(1).any(forbidden_subsequent));
-
-    if needs_escape {
-        format!("`{s}`")
-    } else {
+    if VALID_IDENT.is_match(s) {
         s.to_string()
+    } else {
+        format!("`{}`", s)
     }
 }
 

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -20,7 +20,7 @@ use crate::ast::pl::{
 use crate::ast::rq::*;
 use crate::error::{Error, Span, WithErrorInfo};
 use crate::sql::srq::context::ColumnDecl;
-use crate::utils::OrMap;
+use crate::utils::{OrMap, VALID_IDENT};
 
 use super::gen_projection::try_into_exprs;
 use super::Context;
@@ -771,17 +771,7 @@ fn is_keyword(ident: &str) -> bool {
 }
 
 pub(super) fn translate_ident_part(ident: String, ctx: &Context) -> sql_ast::Ident {
-    static VALID_BARE_IDENT: Lazy<Regex> = Lazy::new(|| {
-        // One of:
-        // - `*`
-        // - An ident starting with `a-z_\$` and containing other characters `a-z0-9_\$`
-        //
-        // We could replace this with pomsky (regex<>pomsky : sql<>prql)
-        // ^ ('*' | [ascii_lower '_$'] [ascii_lower ascii_digit '_$']* ) $
-        Regex::new(r"^((\*)|(^[a-z_\$][a-z0-9_\$]*))$").unwrap()
-    });
-
-    let is_bare = VALID_BARE_IDENT.is_match(&ident);
+    let is_bare = VALID_IDENT.is_match(&ident);
 
     if is_bare && !is_keyword(&ident) {
         sql_ast::Ident::new(ident)

--- a/prql-compiler/src/utils/mod.rs
+++ b/prql-compiler/src/utils/mod.rs
@@ -3,7 +3,9 @@ mod only;
 mod toposort;
 
 pub use id_gen::{IdGenerator, NameGenerator};
+use once_cell::sync::Lazy;
 pub use only::*;
+use regex::Regex;
 pub use toposort::toposort;
 
 use anyhow::Result;
@@ -103,4 +105,19 @@ where
         self.cloned()
             .fold(Some(true), |a, x| a.zip(x).map(|(a, b)| a && b))
     }
+}
+
+pub static VALID_IDENT: Lazy<Regex> = Lazy::new(|| {
+    // One of:
+    // - `*`
+    // - An ident starting with `a-z_\$` and containing other characters `a-z0-9_\$`
+    //
+    // We could replace this with pomsky (regex<>pomsky : sql<>prql)
+    // ^ ('*' | [ascii_lower '_$'] [ascii_lower ascii_digit '_$']* ) $
+    Regex::new(r"^((\*)|(^[a-z_\$][a-z0-9_\$]*))$").unwrap()
+});
+
+#[test]
+fn test_write_ident_part() {
+    assert!(!VALID_IDENT.is_match(""));
 }

--- a/prql-compiler/tests/integration/snapshots/integration__fmt@distinct.prql.snap
+++ b/prql-compiler/tests/integration/snapshots/integration__fmt@distinct.prql.snap
@@ -6,6 +6,6 @@ input_file: prql-compiler/tests/integration/queries/distinct.prql
 
 from tracks
 select {album_id, genre_id}
-group tracks.`*` (take 1)
-sort tracks.`*`
+group tracks.* (take 1)
+sort tracks.*
 

--- a/prql-compiler/tests/integration/snapshots/integration__fmt@set_ops_remove.prql.snap
+++ b/prql-compiler/tests/integration/snapshots/integration__fmt@set_ops_remove.prql.snap
@@ -4,7 +4,7 @@ expression: "let distinct = rel -> (from t = _param.rel | group {t.*} (take 1))\
 input_file: prql-compiler/tests/integration/queries/set_ops_remove.prql
 ---
 
-let distinct = rel -> (from t = _param.rel | group {t.`*`} (take 1))
+let distinct = rel -> (from t = _param.rel | group {t.*} (take 1))
 
 from_text format:json '{ "columns": ["a"], "data": [[1], [2], [2], [3]] }'
 distinct


### PR DESCRIPTION
From https://github.com/PRQL/prql/pull/2669#discussion_r1212792233

The behavior change is on handling `*`, which I _think_ is correct — at least it seems to compile OK.
