### PR TITLE
fix: Add parentheses to new division s-strings

### DIFF
--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -38,9 +38,12 @@ let read_parquet = source -> s"read_parquet({source})"
 let read_csv = source -> s"read_csv_auto({source})"
 
 let mul = l r -> null
-let div_i = l r -> s"FLOOR(FLOOR(ABS({l} / {r})) * SIGN({l} / {r}))"
-let div_f = l r -> s"({l} * 1.0 / {r})"
-let mod = l r -> s"{l} % {r}"
+# If we want to raise an error when division by zero occurs, we can use the
+# following:
+# let div_i = l r -> s"CASE WHEN {l} * {r} < 0 THEN -FLOOR(ABS({l} / {r})) ELSE FLOOR(ABS({l} / {r})) END"
+let div_i = l r -> s"FLOOR(FLOOR(ABS(({l}) / ({r}))) * SIGN(({l}) / ({r})))"
+let div_f = l r -> s"({l} * 1.0 / ({r}))"
+let mod = l r -> s"({l}) % ({r})"
 let add = l r -> null
 let sub = l r -> null
 let eq = l r -> null
@@ -57,22 +60,23 @@ let neg = l -> null
 let not = l -> null
 
 module postgres {
-    let div_i = l r -> s"trunc({l} / {r})::bigint"
+    let div_i = l r -> s"trunc(({l}) / ({r}))::bigint"
     let round = n_digits column -> s"ROUND(({column})::numeric, {n_digits})"
     let regex_search = text pattern -> s"({text} ~ {pattern})"
 }
 
 module sqlite {
-    let div_i = l r -> s"ROUND(ABS({l} / {r}) - 0.5) * SIGN({l} / {r})"
+    let div_i = l r -> s"ROUND(ABS(({l}) / ({r})) - 0.5) * SIGN(({l}) / ({r}))"
     let regex_search = text pattern -> s"({text} REGEXP {pattern})"
 }
 
 module mssql {
+    let div_i = l r -> s"({l} DIV {r})"
     let regex_search = text pattern -> null
 }
 
 module mysql {
-    let div_f = l r -> s"(CAST({l} AS FLOAT) / {r})"
+    let div_f = l r -> s"(CAST({l} AS FLOAT) / ({r}))"
     let mod = l r -> s"FLOOR(MOD({l}, {r}))"
     let regex_search = text pattern -> s"({text} REGEXP {pattern})"
 }

--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -42,7 +42,7 @@ let mul = l r -> null
 # following:
 # let div_i = l r -> s"CASE WHEN {l} * {r} < 0 THEN -FLOOR(ABS({l} / {r})) ELSE FLOOR(ABS({l} / {r})) END"
 let div_i = l r -> s"FLOOR(FLOOR(ABS(({l}) / ({r}))) * SIGN(({l}) / ({r})))"
-# Should this even be: 
+# Should this even be:
 #   let div_f = l r -> s"(({l}) * 1.0 / ({r}))"
 # ...given that we can have higher precedence than mul?
 let div_f = l r -> s"({l} * 1.0 / ({r}))"

--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -42,6 +42,9 @@ let mul = l r -> null
 # following:
 # let div_i = l r -> s"CASE WHEN {l} * {r} < 0 THEN -FLOOR(ABS({l} / {r})) ELSE FLOOR(ABS({l} / {r})) END"
 let div_i = l r -> s"FLOOR(FLOOR(ABS(({l}) / ({r}))) * SIGN(({l}) / ({r})))"
+# Should this even be: 
+#   let div_f = l r -> s"(({l}) * 1.0 / ({r}))"
+# ...given that we can have higher precedence than mul?
 let div_f = l r -> s"({l} * 1.0 / ({r}))"
 let mod = l r -> s"({l}) % ({r})"
 let add = l r -> null

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -59,7 +59,7 @@ fn test_precedence() {
     select temp_c = (temp - 32) / 1.8
     "###).unwrap()), @r###"
     SELECT
-      (temp - 32 * 1.0 / 1.8) AS temp_c
+      (temp - 32 * 1.0 / (1.8)) AS temp_c
     FROM
       x
     "###);
@@ -2403,7 +2403,7 @@ fn test_casting() {
         @r###"
     SELECT
       a,
-      (CAST(a AS int) * 1.0 / 10) AS c
+      (CAST(a AS int) * 1.0 / (10)) AS c
     FROM
       x
     "###

--- a/prql-compiler/tests/integration/snapshots/integration__sql@arithmetic.prql.snap
+++ b/prql-compiler/tests/integration/snapshots/integration__sql@arithmetic.prql.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/tests/integration/main.rs
-expression: "[\n    { x_int =  13, x_float =  13.0, k_int =  5, k_float =  5.0 },\n    { x_int = -13, x_float = -13.0, k_int =  5, k_float =  5.0 },\n    { x_int =  13, x_float =  13.0, k_int = -5, k_float = -5.0 },\n    { x_int = -13, x_float = -13.0, k_int = -5, k_float = -5.0 },\n]\nselect {\n    x_int / k_int,\n    x_int / k_float,\n    x_float / k_int,\n    x_float / k_float,\n    \n    q_ii = x_int // k_int,\n    q_if = x_int // k_float,\n    q_fi = x_float // k_int,\n    q_ff = x_float // k_float,\n\n    r_ii = x_int % k_int,\n    r_if = x_int % k_float,\n    r_fi = x_float % k_int,\n    r_ff = x_float % k_float,\n\n    round 0 (q_ii * k_int + r_ii),\n    round 0 (q_if * k_float + r_if),\n    round 0 (q_fi * k_int + r_fi),\n    round 0 (q_ff * k_float + r_ff),\n}\n"
+expression: "[\n    { x_int =  13, x_float =  13.0, k_int =  5, k_float =  5.0 },\n    { x_int = -13, x_float = -13.0, k_int =  5, k_float =  5.0 },\n    { x_int =  13, x_float =  13.0, k_int = -5, k_float = -5.0 },\n    { x_int = -13, x_float = -13.0, k_int = -5, k_float = -5.0 },\n]\nselect {\n    x_int / k_int,\n    x_int / k_float,\n    x_float / k_int,\n    x_float / k_float,\n\n    q_ii = x_int // k_int,\n    q_if = x_int // k_float,\n    q_fi = x_float // k_int,\n    q_ff = x_float // k_float,\n\n    r_ii = x_int % k_int,\n    r_if = x_int % k_float,\n    r_fi = x_float % k_int,\n    r_ff = x_float % k_float,\n\n    (q_ii * k_int + r_ii | round 0),\n    (q_if * k_float + r_if | round 0),\n    (q_fi * k_int + r_fi | round 0),\n    (q_ff * k_float + r_ff | round 0),\n}\n"
 input_file: prql-compiler/tests/integration/queries/arithmetic.prql
 ---
 WITH table_2 AS (
@@ -32,44 +32,48 @@ WITH table_2 AS (
     -5.0 AS k_float
 )
 SELECT
-  (x_int * 1.0 / k_int),
-  (x_int * 1.0 / k_float),
-  (x_float * 1.0 / k_int),
-  (x_float * 1.0 / k_float),
-  FLOOR(FLOOR(ABS(x_int / k_int)) * SIGN(x_int / k_int)) AS q_ii,
+  (x_int * 1.0 / (k_int)),
+  (x_int * 1.0 / (k_float)),
+  (x_float * 1.0 / (k_int)),
+  (x_float * 1.0 / (k_float)),
   FLOOR(
-    FLOOR(ABS(x_int / k_float)) * SIGN(x_int / k_float)
+    FLOOR(ABS((x_int) / (k_int))) * SIGN((x_int) / (k_int))
+  ) AS q_ii,
+  FLOOR(
+    FLOOR(ABS((x_int) / (k_float))) * SIGN((x_int) / (k_float))
   ) AS q_if,
   FLOOR(
-    FLOOR(ABS(x_float / k_int)) * SIGN(x_float / k_int)
+    FLOOR(ABS((x_float) / (k_int))) * SIGN((x_float) / (k_int))
   ) AS q_fi,
   FLOOR(
-    FLOOR(ABS(x_float / k_float)) * SIGN(x_float / k_float)
+    FLOOR(ABS((x_float) / (k_float))) * SIGN((x_float) / (k_float))
   ) AS q_ff,
-  x_int % k_int AS r_ii,
-  x_int % k_float AS r_if,
-  x_float % k_int AS r_fi,
-  x_float % k_float AS r_ff,
+  (x_int) % (k_int) AS r_ii,
+  (x_int) % (k_float) AS r_if,
+  (x_float) % (k_int) AS r_fi,
+  (x_float) % (k_float) AS r_ff,
   ROUND(
-    FLOOR(FLOOR(ABS(x_int / k_int)) * SIGN(x_int / k_int)) * k_int + x_int % k_int,
+    FLOOR(
+      FLOOR(ABS((x_int) / (k_int))) * SIGN((x_int) / (k_int))
+    ) * k_int + (x_int) % (k_int),
     0
   ),
   ROUND(
     FLOOR(
-      FLOOR(ABS(x_int / k_float)) * SIGN(x_int / k_float)
-    ) * k_float + x_int % k_float,
+      FLOOR(ABS((x_int) / (k_float))) * SIGN((x_int) / (k_float))
+    ) * k_float + (x_int) % (k_float),
     0
   ),
   ROUND(
     FLOOR(
-      FLOOR(ABS(x_float / k_int)) * SIGN(x_float / k_int)
-    ) * k_int + x_float % k_int,
+      FLOOR(ABS((x_float) / (k_int))) * SIGN((x_float) / (k_int))
+    ) * k_int + (x_float) % (k_int),
     0
   ),
   ROUND(
     FLOOR(
-      FLOOR(ABS(x_float / k_float)) * SIGN(x_float / k_float)
-    ) * k_float + x_float % k_float,
+      FLOOR(ABS((x_float) / (k_float))) * SIGN((x_float) / (k_float))
+    ) * k_float + (x_float) % (k_float),
     0
   )
 FROM

--- a/prql-compiler/tests/integration/snapshots/integration__sql@pipelines.prql.snap
+++ b/prql-compiler/tests/integration/snapshots/integration__sql@pipelines.prql.snap
@@ -12,7 +12,7 @@ WITH table_1 AS (
     tracks
   WHERE
     REGEXP(name, 'Love')
-    AND ((milliseconds * 1.0 / 1000) * 1.0 / 60) BETWEEN 3 AND 4
+    AND ((milliseconds * 1.0 / (1000)) * 1.0 / (60)) BETWEEN 3 AND 4
   ORDER BY
     track_id
   LIMIT

--- a/web/book/tests/snapshots/snapshot__examples__misc__1.snap
+++ b/web/book/tests/snapshots/snapshot__examples__misc__1.snap
@@ -5,7 +5,7 @@ expression: "from club_ratings\nfilter rating != null\n# TODO: this is real ugly
 SELECT
   *,
   rating - (
-    AVG(rating) OVER (PARTITION BY year) * 1.0 / STDDEV(rating) OVER (PARTITION BY year)
+    AVG(rating) OVER (PARTITION BY year) * 1.0 / (STDDEV(rating) OVER (PARTITION BY year))
   ) AS rating_norm
 FROM
   club_ratings

--- a/web/book/tests/snapshots/snapshot__examples__variables__1.snap
+++ b/web/book/tests/snapshots/snapshot__examples__variables__1.snap
@@ -21,8 +21,8 @@ table_2 AS (
     titles.title
 )
 SELECT
-  (_expr_0 * 1.0 / 1000) AS salary_k,
-  (_expr_0 * 1.0 / 1000) * 1000 AS salary
+  (_expr_0 * 1.0 / (1000)) AS salary_k,
+  (_expr_0 * 1.0 / (1000)) * 1000 AS salary
 FROM
   table_2 AS table_0
 LIMIT

--- a/web/book/tests/snapshots/snapshot__queries__functions__0.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__0.snap
@@ -4,7 +4,7 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\n\nfrom citie
 ---
 SELECT
   *,
-  (temp_f - 32 * 1.0 / 1.8) AS temp_c
+  (temp_f - 32 * 1.0 / (1.8)) AS temp_c
 FROM
   cities
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__1.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__1.snap
@@ -4,8 +4,8 @@ expression: "let interp = low:0 high x -> (x - low) / (high - low)\n\nfrom stude
 ---
 SELECT
   *,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_1,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_2
+  (sat_score - 0 * 1.0 / (1600 - 0)) AS sat_proportion_1,
+  (sat_score - 0 * 1.0 / (1600 - 0)) AS sat_proportion_2
 FROM
   students
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__late-binding__0.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__late-binding__0.snap
@@ -7,9 +7,9 @@ SELECT
   labor,
   overhead,
   cost_total,
-  (materials * 1.0 / cost_total) AS materials_share,
-  (labor * 1.0 / cost_total) AS labor_share,
-  (overhead * 1.0 / cost_total) AS overhead_share
+  (materials * 1.0 / (cost_total)) AS materials_share,
+  (labor * 1.0 / (cost_total)) AS labor_share,
+  (overhead * 1.0 / (cost_total)) AS overhead_share
 FROM
   costs
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__piping__0.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__piping__0.snap
@@ -4,8 +4,8 @@ expression: "let interp = low:0 high x -> (x - low) / (high - low)\n\nfrom stude
 ---
 SELECT
   *,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_1,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_2
+  (sat_score - 0 * 1.0 / (1600 - 0)) AS sat_proportion_1,
+  (sat_score - 0 * 1.0 / (1600 - 0)) AS sat_proportion_2
 FROM
   students
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__piping__1.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__piping__1.snap
@@ -4,7 +4,7 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\n\nfrom citie
 ---
 SELECT
   *,
-  (temp_f - 32 * 1.0 / 1.8) AS temp_c
+  (temp_f - 32 * 1.0 / (1.8)) AS temp_c
 FROM
   cities
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__piping__2.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__piping__2.snap
@@ -4,7 +4,9 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\nlet interp =
 ---
 SELECT
   *,
-  ((temp_c - 32 * 1.0 / 1.8) - 0 * 1.0 / 100 - 0) AS boiling_proportion
+  (
+    (temp_c - 32 * 1.0 / (1.8)) - 0 * 1.0 / (100 - 0)
+  ) AS boiling_proportion
 FROM
   kettles
 

--- a/web/book/tests/snapshots/snapshot__syntax__expressions-and-operators__parentheses__0.snap
+++ b/web/book/tests/snapshots/snapshot__syntax__expressions-and-operators__parentheses__0.snap
@@ -7,7 +7,7 @@ SELECT
   distance BETWEEN 0 AND 20 AS is_proximate,
   SUM(distance) OVER () AS total_distance,
   MIN(COALESCE(distance, 5)) OVER () AS min_capped_distance,
-  (distance * 1.0 / 40) AS travel_time,
+  (distance * 1.0 / (40)) AS travel_time,
   ROUND(distance, 1 + 1) AS distance_rounded_2_dp,
   distance >= 100 AS is_far,
   distance BETWEEN -100 AND 0,


### PR DESCRIPTION
This is required for correctness — see https://github.com/PRQL/prql/pull/2692 for an example.

But it really pollutes the resulting expressions with parentheses, so I'm not sure if this is the right approach.
