### PR TITLE
fix: `fmt` with escaped braces

### DIFF
--- a/web/book/src/language-features/s-strings.md
+++ b/web/book/src/language-features/s-strings.md
@@ -60,7 +60,7 @@ should implement it in PRQL or PRQL's stdlib.
 
 To output braces from an s-string, use double braces:
 
-```prql no-fmt
+```prql
 from employees
 derive {
   has_valid_title = s"regexp_contains(title, '([a-z0-9]*-){{2,}}')"


### PR DESCRIPTION
One more to go...
