### PR TITLE
fix: `fmt` works for all examples

### DIFF
--- a/prql-compiler/src/codegen.rs
+++ b/prql-compiler/src/codegen.rs
@@ -327,7 +327,7 @@ impl WriteSource for pl::Stmt {
                 let mut r = String::new();
                 r += "prql";
                 if let Some(version) = &query.version {
-                    r += &format!(" version:{}", version);
+                    r += &format!(r#" version:"{}""#, version);
                 }
                 for (key, value) in &query.other {
                     r += &format!(" {key}:{value}");

--- a/web/book/src/language-features/target.md
+++ b/web/book/src/language-features/target.md
@@ -47,7 +47,7 @@ very welcome.
 
 PRQL allows specifying a version of the language in the PRQL header, like:
 
-```prql no-fmt
+```prql
 prql version:"0.8.1"
 
 from employees

--- a/web/book/src/lib.rs
+++ b/web/book/src/lib.rs
@@ -182,7 +182,7 @@ fn replace_examples(text: &str) -> Result<String> {
 
             cmark_acc.push(Event::Html(table_of_error(&prql, &error_message).into()))
         } else {
-            // Either a bare `prql` or with `no-fmt`
+            // Show the comparison
             cmark_acc.push(Event::Html(
                 table_of_comparison(
                     &prql,


### PR DESCRIPTION
We haven't yet tested that the queries are equivalent, and we definitely don't have some fancy fuzz testing! But it's a milestone nonetheless.
