### PR TITLE
feat: support `distinct on` for `sql.postgres` target

### DIFF
--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -169,6 +169,11 @@ impl DialectHandler for PostgresDialect {
     fn requires_quotes_intervals(&self) -> bool {
         true
     }
+
+    fn supports_distinct_on(&self) -> bool {
+        // https://www.postgresql.org/docs/current/sql-select.html
+        true
+    }
 }
 
 impl DialectHandler for SQLiteDialect {
@@ -260,6 +265,7 @@ impl DialectHandler for DuckDbDialect {
     }
 
     fn supports_distinct_on(&self) -> bool {
+        // https://duckdb.org/docs/sql/query_syntax/select.html#distinct-on-clause
         true
     }
 }

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -1490,6 +1490,21 @@ fn test_distinct() {
 #[test]
 fn test_distinct_on() {
     assert_display_snapshot!((compile(r###"
+    prql target:sql.postgres
+
+    from employees
+    group department (
+      sort age
+      take 1
+    )
+    "###).unwrap()), @r###"
+    SELECT
+      DISTINCT ON (department) *
+    FROM
+      employees
+    "###);
+
+    assert_display_snapshot!((compile(r###"
     prql target:sql.duckdb
 
     from x

--- a/web/book/src/language-features/distinct.md
+++ b/web/book/src/language-features/distinct.md
@@ -42,23 +42,16 @@ from employees
 group {first_name, last_name} (take 1)
 ```
 
-## Roadmap
+## Distinct on
 
-When using Postgres dialect, we are planning to compile:
+When compiling to Postgres or DuckDB dialect, `DISTINCT ON` is used to take one row for each group:
 
-```prql no-eval
-# youngest employee from each department
+```prql
+prql target:sql.postgres
+
 from employees
 group department (
   sort age
   take 1
 )
-```
-
-... to ...
-
-```sql
-SELECT DISTINCT ON (department) *
-FROM employees
-ORDER BY department, age
 ```

--- a/web/book/src/language-features/distinct.md
+++ b/web/book/src/language-features/distinct.md
@@ -44,7 +44,8 @@ group {first_name, last_name} (take 1)
 
 ## Distinct on
 
-When compiling to Postgres or DuckDB dialect, `DISTINCT ON` is used to take one row for each group:
+When compiling to Postgres or DuckDB dialect, `DISTINCT ON` is used to take one
+row for each group:
 
 ```prql
 prql target:sql.postgres

--- a/web/book/tests/snapshots/snapshot__language-features__distinct__distinct-on__0.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__distinct__distinct-on__0.snap
@@ -1,0 +1,9 @@
+---
+source: web/book/tests/snapshot.rs
+expression: "prql target:sql.postgres\n\nfrom employees\ngroup department (\n  sort age\n  take 1\n)\n"
+---
+SELECT
+  DISTINCT ON (department) *
+FROM
+  employees
+


### PR DESCRIPTION
Follow up for #2244 (from #2182)