### PR TITLE
feat: s-string format, annotations and SQL binding strength

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -735,6 +735,7 @@ group a_column (take 10 | sort b_column | derive {the_number = rank, last = lag 
                         - y
               ty_expr: null
               kind: Main
+            annotations: []
         source_ids:
           1: ''
         "###);

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -252,7 +252,10 @@ pub struct Pipeline {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum InterpolateItem<T = Expr> {
     String(String),
-    Expr { expr: Box<T>, format: Option<String> },
+    Expr {
+        expr: Box<T>,
+        format: Option<String>,
+    },
 }
 
 /// Inclusive-inclusive range.

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -252,7 +252,7 @@ pub struct Pipeline {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum InterpolateItem<T = Expr> {
     String(String),
-    Expr(Box<T>),
+    Expr { expr: Box<T>, format: Option<String> },
 }
 
 /// Inclusive-inclusive range.

--- a/prql-compiler/src/ast/pl/fold.rs
+++ b/prql-compiler/src/ast/pl/fold.rs
@@ -176,7 +176,10 @@ pub fn fold_interpolate_item<F: ?Sized + AstFold>(
 ) -> Result<InterpolateItem> {
     Ok(match interpolate_item {
         InterpolateItem::String(string) => InterpolateItem::String(string),
-        InterpolateItem::Expr(expr) => InterpolateItem::Expr(Box::new(fold.fold_expr(*expr)?)),
+        InterpolateItem::Expr { expr, format } => InterpolateItem::Expr {
+            expr: Box::new(fold.fold_expr(*expr)?),
+            format,
+        },
     })
 }
 

--- a/prql-compiler/src/ast/pl/stmt.rs
+++ b/prql-compiler/src/ast/pl/stmt.rs
@@ -9,9 +9,6 @@ use crate::error::Span;
 
 use super::*;
 
-/// A helper wrapper around Vec<Stmt> so we can impl Display.
-pub struct Statements(pub Vec<Stmt>);
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Stmt {
     #[serde(skip)]
@@ -21,6 +18,8 @@ pub struct Stmt {
     pub kind: StmtKind,
     #[serde(skip)]
     pub span: Option<Span>,
+
+    pub annotations: Vec<Annotation>,
 }
 
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Serialize, Deserialize)]
@@ -62,21 +61,19 @@ pub struct ModuleDef {
     pub stmts: Vec<Stmt>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Annotation {
+    pub name: Ident,
+    pub args: Vec<Expr>,
+
+    pub span: Option<Span>,
+}
+
 impl From<StmtKind> for anyhow::Error {
     // https://github.com/bluejekyll/enum-as-inner/issues/84
     #[allow(unreachable_code)]
     fn from(_: StmtKind) -> Self {
         anyhow!("Failed to convert statement")
-    }
-}
-
-impl Display for Statements {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for stmt in &self.0 {
-            write!(f, "{}", stmt)?;
-            write!(f, "\n\n")?;
-        }
-        Ok(())
     }
 }
 

--- a/prql-compiler/src/ast/rq/fold.rs
+++ b/prql-compiler/src/ast/rq/fold.rs
@@ -257,7 +257,10 @@ pub fn fold_interpolate_item<T: ?Sized + RqFold>(
 ) -> Result<InterpolateItem<Expr>> {
     Ok(match item {
         InterpolateItem::String(string) => InterpolateItem::String(string),
-        InterpolateItem::Expr(expr) => InterpolateItem::Expr(Box::new(fold.fold_expr(*expr)?)),
+        InterpolateItem::Expr { expr, format } => InterpolateItem::Expr {
+            expr: Box::new(fold.fold_expr(*expr)?),
+            format,
+        },
     })
 }
 

--- a/prql-compiler/src/codegen.rs
+++ b/prql-compiler/src/codegen.rs
@@ -440,9 +440,9 @@ fn display_interpolation(
         match &part {
             // We use double braces to escape braces
             pl::InterpolateItem::String(s) => r += s.replace('{', "{{").replace('}', "}}").as_str(),
-            pl::InterpolateItem::Expr(e) => {
+            pl::InterpolateItem::Expr { expr, .. } => {
                 r += "{";
-                r += &e.write(opt)?;
+                r += &expr.write(opt)?;
                 r += "}"
             }
         }

--- a/prql-compiler/src/parser/lexer.rs
+++ b/prql-compiler/src/parser/lexer.rs
@@ -31,6 +31,7 @@ pub enum Token {
     Or,          // ||
     Coalesce,    // ??
     DivInt,      // //
+    Annotate,    // #[
 }
 
 pub fn lexer() -> impl Parser<char, Vec<(Token, std::ops::Range<usize>)>, Error = Cheap<char>> {
@@ -49,9 +50,10 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, std::ops::Range<usize>)>, Error 
         just("||").then_ignore(end_expr()).to(Token::Or),
         just("??").to(Token::Coalesce),
         just("//").to(Token::DivInt),
+        just("#[").to(Token::Annotate),
     ));
 
-    let control = one_of("></%=+-*[]().,:|!{}@").map(Token::Control);
+    let control = one_of("></%=+-*[]().,:|!{}").map(Token::Control);
 
     let ident = ident_part().map(Token::Ident);
 
@@ -92,7 +94,9 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, std::ops::Range<usize>)>, Error 
     ))
     .recover_with(skip_then_retry_until([]).skip_start());
 
-    let comment = just('#').then(none_of('\n').repeated());
+    let comment = just('#')
+        .then(just('[').not().rewind())
+        .then(none_of('\n').repeated());
     let comments = comment
         .separated_by(new_line.then(whitespace.clone().or_not()))
         .at_least(1)
@@ -406,6 +410,7 @@ impl std::fmt::Display for Token {
             Self::Or => f.write_str("||"),
             Self::Coalesce => f.write_str("??"),
             Self::DivInt => f.write_str("//"),
+            Self::Annotate => f.write_str("#["),
 
             Self::Param(id) => write!(f, "${id}"),
 

--- a/prql-compiler/src/parser/lexer.rs
+++ b/prql-compiler/src/parser/lexer.rs
@@ -51,7 +51,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, std::ops::Range<usize>)>, Error 
         just("//").to(Token::DivInt),
     ));
 
-    let control = one_of("></%=+-*[]().,:|!{}").map(Token::Control);
+    let control = one_of("></%=+-*[]().,:|!{}@").map(Token::Control);
 
     let ident = ident_part().map(Token::Ident);
 

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -212,12 +212,16 @@ mod common {
         just(Token::Control(char)).ignored()
     }
 
-    pub fn into_stmt((name, kind): (String, StmtKind), span: Span) -> Stmt {
+    pub fn into_stmt(
+        (annotations, (name, kind)): (Vec<Annotation>, (String, StmtKind)),
+        span: Span,
+    ) -> Stmt {
         Stmt {
             id: None,
             name,
             kind,
             span: Some(span),
+            annotations,
         }
     }
 

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -714,8 +714,10 @@ Canada
         SString:
           - String: SUM(
           - Expr:
-              Ident:
-                - col
+              expr:
+                Ident:
+                  - col
+              format: ~
           - String: )
         "###);
         assert_yaml_snapshot!(parse_expr(r#"s"SUM({rel.`Col name`})""#).unwrap(), @r###"
@@ -723,9 +725,11 @@ Canada
         SString:
           - String: SUM(
           - Expr:
-              Ident:
-                - rel
-                - Col name
+              expr:
+                Ident:
+                  - rel
+                  - Col name
+              format: ~
           - String: )
         "###)
     }
@@ -1374,8 +1378,10 @@ Canada
                   SString:
                     - String: SUM(
                     - Expr:
-                        Ident:
-                          - X
+                        expr:
+                          Ident:
+                            - X
+                        format: ~
                     - String: )
                 params:
                   - name: X

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -304,6 +304,7 @@ mod test {
                       Integer: 10
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"take ..10"#).unwrap(), @r###"
@@ -323,6 +324,7 @@ mod test {
                           Integer: 10
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"take 1..10"#).unwrap(), @r###"
@@ -344,6 +346,7 @@ mod test {
                           Integer: 10
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -594,6 +597,7 @@ mod test {
                       - a
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
         assert_yaml_snapshot!(parse_expr(
             "join side:left country (id==employee_id)"
@@ -924,6 +928,7 @@ Canada
                           String: USA
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(
@@ -952,6 +957,7 @@ Canada
                           String: USA
             ty_expr: ~
             kind: Main
+          annotations: []
         "###
         );
     }
@@ -995,6 +1001,7 @@ Canada
                                 - count
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
         let aggregate = parse_single(
             r"group {title} (
@@ -1031,6 +1038,7 @@ Canada
                                       - salary
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -1223,6 +1231,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
         assert_yaml_snapshot!(parse_single("let identity = x ->  x\n").unwrap()
         , @r###"
@@ -1244,6 +1253,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
         assert_yaml_snapshot!(parse_single("let plus_one = x ->  (x + 1)\n").unwrap()
         , @r###"
@@ -1271,6 +1281,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
         assert_yaml_snapshot!(parse_single("let plus_one = x ->  x + 1\n").unwrap()
         , @r###"
@@ -1298,6 +1309,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single("let foo = x -> some_func (foo bar + 1) (plax) - baz\n").unwrap()
@@ -1344,6 +1356,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single("func return_constant ->  42\n").unwrap(), @r###"
@@ -1367,6 +1380,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"let count = X -> s"SUM({X})"
@@ -1395,6 +1409,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(
@@ -1454,6 +1469,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single("let add = x to:a ->  x + to\n").unwrap(), @r###"
@@ -1485,6 +1501,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
     }
 
@@ -1679,6 +1696,7 @@ Canada
                       - employees
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(
@@ -1744,6 +1762,7 @@ Canada
                             Integer: 50
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"
@@ -1757,6 +1776,7 @@ Canada
                 - String: SELECT * FROM employees
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(
@@ -1793,6 +1813,7 @@ Canada
                           alias: only_in_x
             ty_expr: ~
             kind: Let
+          annotations: []
         - name: main
           VarDef:
             value:
@@ -1805,6 +1826,7 @@ Canada
                       - x
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -1852,6 +1874,7 @@ Canada
                 env: {}
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
     }
 
@@ -1899,6 +1922,7 @@ Canada
                                   Param: 2.name
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -1983,6 +2007,7 @@ join `my-proj`.`dataset`.`table`
                             - table
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -2065,6 +2090,7 @@ join `my-proj`.`dataset`.`table`
                                     - num_of_articles
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -2106,6 +2132,7 @@ join `my-proj`.`dataset`.`table`
                               alias: age_plus_two_years
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_expr("@2011-02-01").unwrap(), @r###"
@@ -2151,6 +2178,7 @@ join `my-proj`.`dataset`.`table`
                     alias: x
             ty_expr: ~
             kind: Main
+          annotations: []
         "### )
     }
 
@@ -2189,6 +2217,7 @@ join `my-proj`.`dataset`.`table`
                           alias: amount
             ty_expr: ~
             kind: Main
+          annotations: []
         "### )
     }
 
@@ -2211,6 +2240,7 @@ join `my-proj`.`dataset`.`table`
                     alias: x
             ty_expr: ~
             kind: Main
+          annotations: []
         "###)
     }
 
@@ -2270,6 +2300,7 @@ join `my-proj`.`dataset`.`table`
                                 - _underscored_column
             ty_expr: ~
             kind: Main
+          annotations: []
         "###)
     }
 
@@ -2349,6 +2380,7 @@ join `my-proj`.`dataset`.`table`
                                 Integer: 2
             ty_expr: ~
             kind: Main
+          annotations: []
         "###)
     }
 
@@ -2386,6 +2418,7 @@ join s=salaries (==id)
                                 - id
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -2476,6 +2509,7 @@ join s=salaries (==id)
                       - tète
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -2568,6 +2602,7 @@ join s=salaries (==id)
                 - x
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"
@@ -2582,6 +2617,7 @@ join s=salaries (==id)
                 - x
             ty_expr: ~
             kind: Into
+          annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"
@@ -2595,6 +2631,7 @@ join s=salaries (==id)
                 - x
             ty_expr: ~
             kind: Main
+          annotations: []
         "###);
     }
 
@@ -2615,6 +2652,7 @@ join s=salaries (==id)
                     Integer: 2
             ty_expr: ~
             kind: Let
+          annotations: []
         - name: a
           VarDef:
             value:
@@ -2625,6 +2663,7 @@ join s=salaries (==id)
                     String: hello
             ty_expr: ~
             kind: Let
+          annotations: []
         "###);
     }
 }

--- a/prql-compiler/src/parser/snapshots/prql_compiler__parser__test__pipeline_parse_tree.snap
+++ b/prql-compiler/src/parser/snapshots/prql_compiler__parser__test__pipeline_parse_tree.snap
@@ -160,4 +160,5 @@ expression: "parse_single(include_str!(\"../../examples/compile-files/queries/va
                     Integer: 20
     ty_expr: ~
     kind: Main
+  annotations: []
 

--- a/prql-compiler/src/parser/stmt.rs
+++ b/prql-compiler/src/parser/stmt.rs
@@ -101,6 +101,7 @@ fn var_def() -> impl Parser<Token, (Vec<Annotation>, (String, StmtKind)), Error 
                 .then(expr().repeated())
                 .delimited_by(ctrl('('), ctrl(')')),
         )
+        .then_ignore(new_line())
         .map_with_span(|(name, args), span| {
             let span = Some(span);
             Annotation { name, args, span }

--- a/prql-compiler/src/parser/stmt.rs
+++ b/prql-compiler/src/parser/stmt.rs
@@ -95,13 +95,9 @@ fn query_def() -> impl Parser<Token, Stmt, Error = PError> {
 }
 
 fn var_def() -> impl Parser<Token, (Vec<Annotation>, (String, StmtKind)), Error = PError> {
-    let annotation = ctrl('@')
-        .ignore_then(
-            ident()
-                .then(expr().repeated())
-                .delimited_by(ctrl('('), ctrl(')')),
-        )
-        .then_ignore(new_line())
+    let annotation = just(Token::Annotate)
+        .ignore_then(ident().then(expr().repeated()))
+        .then_ignore(ctrl(']').then(new_line()))
         .map_with_span(|(name, args), span| {
             let span = Some(span);
             Annotation { name, args, span }

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -27,6 +27,8 @@ pub struct Decl {
     /// Some declarations (like relation columns) have an order to them.
     /// 0 means that the order is irrelevant.
     pub order: usize,
+
+    pub annotations: Vec<Annotation>,
 }
 
 /// The Declaration itself.
@@ -87,7 +89,13 @@ pub enum TableColumn {
 }
 
 impl Context {
-    pub fn declare(&mut self, ident: Ident, decl: DeclKind, id: Option<usize>) -> Result<()> {
+    pub fn declare(
+        &mut self,
+        ident: Ident,
+        decl: DeclKind,
+        id: Option<usize>,
+        annotations: Vec<Annotation>,
+    ) -> Result<()> {
         let existing = self.root_mod.get(&ident);
         if existing.is_some() {
             return Err(Error::new_simple(format!("duplicate declarations of {ident}")).into());
@@ -97,6 +105,7 @@ impl Context {
             kind: decl,
             declared_at: id,
             order: 0,
+            annotations,
         };
         self.root_mod.insert(ident, decl).unwrap();
         Ok(())
@@ -540,6 +549,7 @@ impl From<DeclKind> for Decl {
             kind,
             declared_at: None,
             order: 0,
+            annotations: Vec::new(),
         }
     }
 }

--- a/prql-compiler/src/semantic/lowering.rs
+++ b/prql-compiler/src/semantic/lowering.rs
@@ -791,7 +791,7 @@ impl Lowerer {
                 for item in items {
                     let item = Some(match item {
                         InterpolateItem::String(string) => str_lit(string),
-                        InterpolateItem::Expr(e) => self.lower_expr(*e)?,
+                        InterpolateItem::Expr { expr, .. } => self.lower_expr(*expr)?,
                     });
 
                     res = rq::maybe_binop(res, "std.concat", item);
@@ -856,9 +856,10 @@ impl Lowerer {
             .map(|i| {
                 Ok(match i {
                     InterpolateItem::String(s) => InterpolateItem::String(s),
-                    InterpolateItem::Expr(e) => {
-                        InterpolateItem::Expr(Box::new(self.lower_expr(*e)?))
-                    }
+                    InterpolateItem::Expr { expr, .. } => InterpolateItem::Expr {
+                        expr: Box::new(self.lower_expr(*expr)?),
+                        format: None,
+                    },
                 })
             })
             .try_collect()

--- a/prql-compiler/src/semantic/module.rs
+++ b/prql-compiler/src/semantic/module.rs
@@ -238,14 +238,14 @@ impl Module {
                         let self_decl = Decl {
                             declared_at: Some(input.id),
                             kind: DeclKind::InstanceOf(input.table.clone()),
-                            order: 0,
+                            ..Default::default()
                         };
                         sub_ns.names.insert(NS_SELF.to_string(), self_decl);
 
                         let sub_ns = Decl {
                             declared_at: Some(input.id),
                             kind: DeclKind::Module(sub_ns),
-                            order: 0,
+                            ..Default::default()
                         };
 
                         namespace.names.entry(input_name.clone()).or_insert(sub_ns)
@@ -267,6 +267,7 @@ impl Module {
                         kind,
                         declared_at,
                         order: col_index + 1,
+                        ..Default::default()
                     };
                     ns.names.insert(NS_INFER.to_string(), decl);
                 }
@@ -279,6 +280,7 @@ impl Module {
                         kind: DeclKind::Column(*target_id),
                         declared_at: None,
                         order: col_index + 1,
+                        ..Default::default()
                     };
                     ns.names.insert(name.name.clone(), decl);
                 }

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -70,7 +70,7 @@ impl Resolver {
                 StmtKind::QueryDef(d) => {
                     let decl = DeclKind::QueryDef(d);
                     self.context
-                        .declare(ident, decl, stmt.id)
+                        .declare(ident, decl, stmt.id, Vec::new())
                         .with_span(stmt.span)?;
                     continue;
                 }
@@ -116,7 +116,7 @@ impl Resolver {
                             redirects: Vec::new(),
                             shadowed: None,
                         }),
-                        order: 0,
+                        ..Default::default()
                     };
                     let ident = Ident::from_path(self.current_module_path.clone());
                     self.context.root_mod.insert(ident, decl)?;
@@ -148,7 +148,7 @@ impl Resolver {
             let decl = self.context.prepare_expr_decl(def.value);
 
             self.context
-                .declare(ident, decl, stmt.id)
+                .declare(ident, decl, stmt.id, stmt.annotations)
                 .with_span(stmt.span)?;
         }
         Ok(())
@@ -943,7 +943,7 @@ fn env_of_closure(closure: Func) -> (Module, Expr) {
         let v = Decl {
             declared_at: arg.id,
             kind: DeclKind::Expr(Box::new(arg)),
-            order: 0,
+            ..Default::default()
         };
         let param_name = param.name.split('.').last().unwrap();
         func_env.names.insert(param_name.to_string(), v);

--- a/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
+++ b/prql-compiler/src/semantic/snapshots/prql_compiler__semantic__resolver__test__functions_nested.snap
@@ -18,10 +18,12 @@ expression: "resolve_derive(r#\"\n            let lag_day = x -> s\"lag_day_todo
                   - SString:
                       - String: lag_day_todo(
                       - Expr:
-                          Ident:
-                            - _frame
-                            - a
-                            - b
+                          expr:
+                            Ident:
+                              - _frame
+                              - a
+                              - b
+                          format: ~
                       - String: )
               ty:
                 kind:

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -25,7 +25,7 @@ use crate::utils::{OrMap, VALID_IDENT};
 use super::gen_projection::try_into_exprs;
 use super::Context;
 
-pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<sql_ast::Expr> {
+pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<ExprOrSource> {
     Ok(match expr.kind {
         ExprKind::ColumnRef(cid) => translate_cid(cid, ctx)?,
 
@@ -33,12 +33,18 @@ pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<sql_ast::E
         // then convert to sql_ast::Expr. We can't use the `Item::sql_ast::Expr` code above
         // since we don't want to intersperse with spaces.
         ExprKind::SString(s_string_items) => {
-            let string = translate_sstring(s_string_items, ctx)?;
+            let text = translate_sstring(s_string_items, ctx)?;
 
-            sql_ast::Expr::Identifier(sql_ast::Ident::new(string))
+            ExprOrSource::Source {
+                text,
+                binding_strength: 100,
+            }
         }
-        ExprKind::Param(id) => sql_ast::Expr::Identifier(sql_ast::Ident::new(format!("${id}"))),
-        ExprKind::Literal(l) => translate_literal(l, ctx)?,
+        ExprKind::Param(id) => ExprOrSource::Source {
+            text: format!("${id}"),
+            binding_strength: 100,
+        },
+        ExprKind::Literal(l) => translate_literal(l, ctx)?.into(),
         ExprKind::Case(mut cases) => {
             let default = cases
                 .last()
@@ -49,7 +55,8 @@ pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<sql_ast::E
                     )
                 })
                 .map(|def| translate_expr(def.value.clone(), ctx))
-                .transpose()?;
+                .transpose()?
+                .map(|x| x.into_ast());
 
             if default.is_some() {
                 cases.pop();
@@ -62,8 +69,8 @@ pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<sql_ast::E
             let cases: Vec<_> = cases
                 .into_iter()
                 .map(|case| -> Result<_> {
-                    let cond = translate_expr(case.condition, ctx)?;
-                    let value = translate_expr(case.value, ctx)?;
+                    let cond = translate_expr(case.condition, ctx)?.into_ast();
+                    let value = translate_expr(case.value, ctx)?.into_ast();
                     Ok((cond, value))
                 })
                 .try_collect()?;
@@ -75,6 +82,7 @@ pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<sql_ast::E
                 results,
                 else_result,
             }
+            .into()
         }
         ExprKind::Operator { ref name, ref args } => {
             // A few special cases and then fall-through to the standard approach.
@@ -90,24 +98,19 @@ pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<sql_ast::E
                         if a.kind == ExprKind::Literal(Literal::Null)
                             || b.kind == ExprKind::Literal(Literal::Null)
                         {
-                            return process_null(name, args, ctx);
+                            return Ok(process_null(name, args, ctx)?.into());
                         } else if let Some(op) = operator_from_name(name) {
-                            return translate_binary_operator(a, b, op, ctx);
+                            return Ok(translate_binary_operator(a, b, op, ctx)?.into());
                         }
                     }
                 }
-                "std.neg" | "std.not" => {
-                    if let [arg] = args.as_slice() {
-                        return process_unary(name, arg, ctx);
-                    }
-                }
-                "std.concat" => return process_concat(&expr, ctx),
+                "std.concat" => return Ok(process_concat(&expr, ctx)?.into()),
                 _ => match try_into_between(expr.clone(), ctx)? {
-                    Some(between_expr) => return Ok(between_expr),
+                    Some(between_expr) => return Ok(between_expr.into()),
                     None => {
                         if let Some(op) = operator_from_name(name) {
                             if let [left, right] = args.as_slice() {
-                                return translate_binary_operator(left, right, op, ctx);
+                                return Ok(translate_binary_operator(left, right, op, ctx)?.into());
                             }
                         }
                     }
@@ -132,44 +135,16 @@ fn process_null(name: &str, args: &[Expr], ctx: &mut Context) -> Result<sql_ast:
         let strength =
             sql_ast::Expr::IsNull(Box::new(sql_ast::Expr::Value(Value::Null))).binding_strength();
         let expr = translate_operand(operand.clone(), strength, false, ctx)?;
+        let expr = Box::new(expr.into_ast());
         Ok(sql_ast::Expr::IsNull(expr))
     } else if name == "std.ne" {
         let strength = sql_ast::Expr::IsNotNull(Box::new(sql_ast::Expr::Value(Value::Null)))
             .binding_strength();
         let expr = translate_operand(operand.clone(), strength, false, ctx)?;
+        let expr = Box::new(expr.into_ast());
         Ok(sql_ast::Expr::IsNotNull(expr))
     } else {
         unreachable!()
-    }
-}
-
-fn process_unary(name: &str, arg: &Expr, ctx: &mut Context) -> Result<sql_ast::Expr> {
-    match name {
-        "std.neg" => {
-            let expr = translate_operand(
-                arg.clone(),
-                UnaryOperator::Minus.binding_strength(),
-                false,
-                ctx,
-            )?;
-            Ok(sql_ast::Expr::UnaryOp {
-                op: UnaryOperator::Minus,
-                expr,
-            })
-        }
-        "std.not" => {
-            let expr = translate_operand(
-                arg.clone(),
-                UnaryOperator::Not.binding_strength(),
-                false,
-                ctx,
-            )?;
-            Ok(sql_ast::Expr::UnaryOp {
-                op: UnaryOperator::Not,
-                expr,
-            })
-        }
-        _ => unreachable!(), // We've already covered all cases above
     }
 }
 
@@ -181,8 +156,7 @@ fn process_concat(expr: &Expr, ctx: &mut Context) -> Result<sql_ast::Expr> {
             .iter()
             .map(|a| {
                 translate_expr((*a).clone(), ctx)
-                    .map(FunctionArgExpr::Expr)
-                    .map(FunctionArg::Unnamed)
+                    .map(|x| FunctionArg::Unnamed(FunctionArgExpr::Expr(x.into_ast())))
             })
             .try_collect()?;
 
@@ -199,10 +173,10 @@ fn process_concat(expr: &Expr, ctx: &mut Context) -> Result<sql_ast::Expr> {
 
         let mut iter = concat_args.into_iter();
         let first_expr = iter.next().unwrap();
-        let mut current_expr = translate_expr(first_expr.clone(), ctx)?;
+        let mut current_expr = translate_expr(first_expr.clone(), ctx)?.into_ast();
 
         for arg in iter {
-            let translated_arg = translate_expr(arg.clone(), ctx)?;
+            let translated_arg = translate_expr(arg.clone(), ctx)?.into_ast();
             current_expr = sql_ast::Expr::BinaryOp {
                 left: Box::new(current_expr),
                 op: BinaryOperator::StringConcat,
@@ -224,6 +198,9 @@ fn translate_binary_operator(
     let left = translate_operand(left.clone(), strength, !op.associates_left(), ctx)?;
     let right = translate_operand(right.clone(), strength, !op.associates_right(), ctx)?;
 
+    let left = Box::new(left.into_ast());
+    let right = Box::new(right.into_ast());
+
     Ok(sql_ast::Expr::BinaryOp { left, op, right })
 }
 
@@ -238,10 +215,12 @@ fn collect_concat_args(expr: &Expr) -> Vec<&Expr> {
 
 /// Translate expr into a BETWEEN statement if possible, otherwise returns the expr unchanged.
 fn try_into_between(expr: Expr, ctx: &mut Context) -> Result<Option<sql_ast::Expr>, anyhow::Error> {
-    if let ExprKind::Operator { name, args } = &expr.kind {
-        if name == "std.and" {
-            if let [a, b] = args.as_slice() {
-                if let (
+    match expr.kind {
+        ExprKind::Operator { name, args } if name == "std.and" => {
+            let [a, b]: [_; 2] = args.try_into().unwrap();
+
+            match (a.kind, b.kind) {
+                (
                     ExprKind::Operator {
                         name: a_name,
                         args: a_args,
@@ -250,25 +229,31 @@ fn try_into_between(expr: Expr, ctx: &mut Context) -> Result<Option<sql_ast::Exp
                         name: b_name,
                         args: b_args,
                     },
-                ) = (&a.kind, &b.kind)
-                {
-                    if a_name == "std.gte" && b_name == "std.lte" {
-                        if let ([a_l, a_r], [b_l, b_r]) = (a_args.as_slice(), b_args.as_slice()) {
-                            // We need for the values on each arm to be the same; e.g. x
-                            // > 3 and x < 5
-                            if a_l == b_l {
-                                return Ok(Some(sql_ast::Expr::Between {
-                                    expr: translate_operand(a_l.clone(), 0, false, ctx)?,
-                                    negated: false,
-                                    low: translate_operand(a_r.clone(), 0, false, ctx)?,
-                                    high: translate_operand(b_r.clone(), 0, false, ctx)?,
-                                }));
-                            }
-                        }
+                ) if a_name == "std.gte" && b_name == "std.lte" => {
+                    let [a_l, a_r]: [_; 2] = a_args.try_into().unwrap();
+                    let [b_l, b_r]: [_; 2] = b_args.try_into().unwrap();
+
+                    // We need for the values on each arm to be the same; e.g. x
+                    // > 3 and x < 5
+                    if a_l == b_l {
+                        return Ok(Some(sql_ast::Expr::Between {
+                            expr: Box::new(
+                                translate_operand(a_l.clone(), 0, false, ctx)?.into_ast(),
+                            ),
+                            negated: false,
+                            low: Box::new(
+                                translate_operand(a_r.clone(), 0, false, ctx)?.into_ast(),
+                            ),
+                            high: Box::new(
+                                translate_operand(b_r.clone(), 0, false, ctx)?.into_ast(),
+                            ),
+                        }));
                     }
                 }
+                _ => (),
             }
         }
+        _ => (),
     }
     Ok(None)
 }
@@ -398,7 +383,7 @@ fn translate_datetime_literal_with_sqlite_function(
     })
 }
 
-pub(super) fn translate_cid(cid: CId, ctx: &mut Context) -> Result<sql_ast::Expr> {
+pub(super) fn translate_cid(cid: CId, ctx: &mut Context) -> Result<ExprOrSource> {
     if ctx.query.pre_projection {
         log::debug!("translating {cid:?} pre projection");
         let decl = ctx.anchor.column_decls.get(&cid).expect("bad RQ ids");
@@ -425,7 +410,7 @@ pub(super) fn translate_cid(cid: CId, ctx: &mut Context) -> Result<sql_ast::Expr
 
                 let table_ident = t.table_ref.name.clone().map(Ident::from_name);
                 let ident = translate_ident(table_ident, Some(column), ctx);
-                sql_ast::Expr::CompoundIdentifier(ident)
+                sql_ast::Expr::CompoundIdentifier(ident).into()
             }
         })
     } else {
@@ -455,7 +440,7 @@ pub(super) fn translate_cid(cid: CId, ctx: &mut Context) -> Result<sql_ast::Expr
         log::debug!("translating {cid:?} post projection: {ident:?}");
 
         let ident = sql_ast::Expr::CompoundIdentifier(ident);
-        Ok(ident)
+        Ok(ident.into())
     }
 }
 
@@ -480,7 +465,7 @@ pub(super) fn translate_sstring(
         .map(|s_string_item| match s_string_item {
             InterpolateItem::String(string) => Ok(string),
             InterpolateItem::Expr { expr, .. } => {
-                translate_expr(*expr, ctx).map(|expr| expr.to_string())
+                translate_expr(*expr, ctx).map(|expr| expr.into_source())
             }
         })
         .collect::<Result<Vec<String>>>()?
@@ -537,14 +522,14 @@ pub(super) fn top_of_i64(take: i64, ctx: &mut Context) -> Top {
     let kind = ExprKind::Literal(Literal::Integer(take));
     let expr = Expr { kind, span: None };
     Top {
-        quantity: Some(translate_expr(expr, ctx).unwrap()),
+        quantity: Some(translate_expr(expr, ctx).unwrap().into_ast()),
         with_ties: false,
         percent: false,
     }
 }
 
 pub(super) fn translate_select_item(cid: CId, ctx: &mut Context) -> Result<SelectItem> {
-    let expr = translate_cid(cid, ctx)?;
+    let expr = translate_cid(cid, ctx)?.into_ast();
 
     let inferred_name = match &expr {
         // sql_ast::Expr::Identifier is used for s-strings
@@ -573,11 +558,11 @@ pub(super) fn translate_select_item(cid: CId, ctx: &mut Context) -> Result<Selec
 }
 
 fn translate_windowed(
-    expr: sql_ast::Expr,
+    expr: ExprOrSource,
     window: Window,
     ctx: &mut Context,
     span: Option<Span>,
-) -> Result<sql_ast::Expr> {
+) -> Result<ExprOrSource> {
     let default_frame = {
         let (kind, range) = if window.sort.is_empty() {
             (WindowKind::Rows, Range::unbounded())
@@ -609,9 +594,11 @@ fn translate_windowed(
         },
     };
 
-    Ok(sql_ast::Expr::Identifier(sql_ast::Ident::new(format!(
-        "{expr} OVER ({window})"
-    ))))
+    let expr = expr.into_source();
+    Ok(ExprOrSource::Source {
+        text: format!("{expr} OVER ({window})"),
+        binding_strength: 100,
+    })
 }
 
 fn try_into_window_frame(frame: WindowFrame<Expr>) -> Result<sql_ast::WindowFrame> {
@@ -651,7 +638,7 @@ pub(super) fn translate_column_sort(
     ctx: &mut Context,
 ) -> Result<OrderByExpr> {
     Ok(OrderByExpr {
-        expr: translate_cid(sort.column, ctx)?,
+        expr: translate_cid(sort.column, ctx)?.into_ast(),
         asc: if matches!(sort.direction, SortDirection::Asc) {
             None // default order is ASC, so there is no need to emit it
         } else {
@@ -719,23 +706,23 @@ pub(super) fn translate_ident_part(ident: String, ctx: &Context) -> sql_ast::Ide
 }
 
 /// Wraps into parenthesis if binding strength would be less than min_strength
-fn translate_operand(
+pub(super) fn translate_operand(
     expr: Expr,
     parent_strength: i32,
     fix_associativity: bool,
     context: &mut Context,
-) -> Result<Box<sql_ast::Expr>> {
-    let expr = Box::new(translate_expr(expr, context)?);
+) -> Result<ExprOrSource> {
+    let expr = translate_expr(expr, context)?;
 
     let strength = expr.binding_strength();
 
     // Either the binding strength is less than its parent, or it's equal and we
     // need to correct for the associativity of the operator (e.g. `a - (b - c)`)
-    let needs_nesting =
+    let needs_parenthesis =
         strength < parent_strength || (strength == parent_strength && fix_associativity);
 
-    Ok(if needs_nesting {
-        Box::new(sql_ast::Expr::Nested(expr))
+    Ok(if needs_parenthesis {
+        expr.wrap_in_parenthesis()
     } else {
         expr
     })
@@ -768,6 +755,7 @@ trait SQLExpression {
             Associativity::Left | Associativity::Both
         )
     }
+
     /// Returns true iff `a + b + c = a + (b + c)`
     fn associates_right(&self) -> bool {
         matches!(
@@ -831,6 +819,61 @@ impl SQLExpression for UnaryOperator {
             UnaryOperator::Not => 4,
             _ => 9,
         }
+    }
+}
+
+/// A wrapper around sql_ast::Expr, that may have already been converted to source.
+pub enum ExprOrSource {
+    Expr(sql_ast::Expr),
+    Source { text: String, binding_strength: i32 },
+}
+
+impl ExprOrSource {
+    pub fn into_ast(self) -> sql_ast::Expr {
+        match self {
+            ExprOrSource::Expr(ast) => ast,
+            ExprOrSource::Source { text: source, .. } => {
+                // The s-string hack
+                sql_ast::Expr::Identifier(sql_ast::Ident::new(source))
+            }
+        }
+    }
+
+    pub fn into_source(self) -> String {
+        match self {
+            ExprOrSource::Expr(e) => e.to_string(),
+            ExprOrSource::Source { text, .. } => text.clone(),
+        }
+    }
+
+    fn wrap_in_parenthesis(self) -> Self {
+        match self {
+            ExprOrSource::Expr(expr) => ExprOrSource::Expr(sql_ast::Expr::Nested(Box::new(expr))),
+            ExprOrSource::Source { text, .. } => {
+                let text = format!("({text})");
+                ExprOrSource::Source {
+                    text,
+                    binding_strength: 100,
+                }
+            }
+        }
+    }
+}
+
+impl SQLExpression for ExprOrSource {
+    fn binding_strength(&self) -> i32 {
+        match self {
+            ExprOrSource::Expr(expr) => expr.binding_strength(),
+            ExprOrSource::Source {
+                binding_strength, ..
+            } => *binding_strength,
+        }
+    }
+}
+
+impl From<sql_ast::Expr> for ExprOrSource {
+    fn from(value: sql_ast::Expr) -> Self {
+        ExprOrSource::Expr(value)
     }
 }
 

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -237,16 +237,10 @@ fn try_into_between(expr: Expr, ctx: &mut Context) -> Result<Option<sql_ast::Exp
                     // > 3 and x < 5
                     if a_l == b_l {
                         return Ok(Some(sql_ast::Expr::Between {
-                            expr: Box::new(
-                                translate_operand(a_l, 0, false, ctx)?.into_ast(),
-                            ),
+                            expr: Box::new(translate_operand(a_l, 0, false, ctx)?.into_ast()),
                             negated: false,
-                            low: Box::new(
-                                translate_operand(a_r, 0, false, ctx)?.into_ast(),
-                            ),
-                            high: Box::new(
-                                translate_operand(b_r, 0, false, ctx)?.into_ast(),
-                            ),
+                            low: Box::new(translate_operand(a_r, 0, false, ctx)?.into_ast()),
+                            high: Box::new(translate_operand(b_r, 0, false, ctx)?.into_ast()),
                         }));
                     }
                 }

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -238,14 +238,14 @@ fn try_into_between(expr: Expr, ctx: &mut Context) -> Result<Option<sql_ast::Exp
                     if a_l == b_l {
                         return Ok(Some(sql_ast::Expr::Between {
                             expr: Box::new(
-                                translate_operand(a_l.clone(), 0, false, ctx)?.into_ast(),
+                                translate_operand(a_l, 0, false, ctx)?.into_ast(),
                             ),
                             negated: false,
                             low: Box::new(
-                                translate_operand(a_r.clone(), 0, false, ctx)?.into_ast(),
+                                translate_operand(a_r, 0, false, ctx)?.into_ast(),
                             ),
                             high: Box::new(
-                                translate_operand(b_r.clone(), 0, false, ctx)?.into_ast(),
+                                translate_operand(b_r, 0, false, ctx)?.into_ast(),
                             ),
                         }));
                     }
@@ -842,7 +842,7 @@ impl ExprOrSource {
     pub fn into_source(self) -> String {
         match self {
             ExprOrSource::Expr(e) => e.to_string(),
-            ExprOrSource::Source { text, .. } => text.clone(),
+            ExprOrSource::Source { text, .. } => text,
         }
     }
 

--- a/prql-compiler/src/sql/gen_expr.rs
+++ b/prql-compiler/src/sql/gen_expr.rs
@@ -479,7 +479,9 @@ pub(super) fn translate_sstring(
         .into_iter()
         .map(|s_string_item| match s_string_item {
             InterpolateItem::String(string) => Ok(string),
-            InterpolateItem::Expr(node) => translate_expr(*node, ctx).map(|expr| expr.to_string()),
+            InterpolateItem::Expr { expr, .. } => {
+                translate_expr(*expr, ctx).map(|expr| expr.to_string())
+            }
         })
         .collect::<Result<Vec<String>>>()?
         .join(""))

--- a/prql-compiler/src/sql/gen_projection.rs
+++ b/prql-compiler/src/sql/gen_projection.rs
@@ -29,7 +29,7 @@ pub(super) fn try_into_exprs(
 
         let ColumnDecl::RelationColumn(riid, _, RelationColumn::Wildcard) = decl else {
             // base case
-            res.push(translate_cid(cid, ctx)?);
+            res.push(translate_cid(cid, ctx)?.into_ast());
             continue;
         };
 

--- a/prql-compiler/src/sql/gen_query.rs
+++ b/prql-compiler/src/sql/gen_query.rs
@@ -167,7 +167,7 @@ fn translate_select_pipeline(
         let kind = ExprKind::Literal(Literal::Integer(offset));
         let expr = Expr { kind, span: None };
         Some(sqlparser::ast::Offset {
-            value: translate_expr(expr, ctx)?,
+            value: translate_expr(expr, ctx)?.into_ast(),
             rows: sqlparser::ast::OffsetRows::None,
         })
     };
@@ -319,7 +319,7 @@ fn translate_join(
 ) -> Result<Join> {
     let relation = translate_relation_expr(with, ctx)?;
 
-    let constraint = JoinConstraint::On(translate_expr(filter, ctx)?);
+    let constraint = JoinConstraint::On(translate_expr(filter, ctx)?.into_ast());
 
     Ok(Join {
         relation,
@@ -477,7 +477,7 @@ pub(super) fn translate_query_operator(
     args: Vec<Expr>,
     ctx: &mut Context,
 ) -> Result<sql_ast::Query> {
-    let from_s_string = translate_operator(name, args, ctx)?;
+    let (from_s_string, _) = translate_operator(name, args, ctx)?;
 
     let s_string = format!(" * FROM {from_s_string}");
 
@@ -493,7 +493,7 @@ pub(super) fn translate_query_operator(
 
 fn filter_of_conditions(exprs: Vec<Expr>, context: &mut Context) -> Result<Option<sql_ast::Expr>> {
     Ok(if let Some(cond) = all(exprs) {
-        Some(translate_expr(cond, context)?)
+        Some(translate_expr(cond, context)?.into_ast())
     } else {
         None
     })

--- a/prql-compiler/src/sql/operators.rs
+++ b/prql-compiler/src/sql/operators.rs
@@ -70,14 +70,18 @@ pub(super) fn translate_operator(
         .iter()
         .map(|item| {
             match item {
-                pl::InterpolateItem::Expr(expr) => {
+                pl::InterpolateItem::Expr { expr, .. } => {
                     // s-string exprs can only contain idents
                     let ident = expr.kind.as_ident();
                     let ident = ident.as_ref().unwrap();
 
                     // lookup args
                     let arg = args.get(ident.name.as_str());
-                    pl::InterpolateItem::<rq::Expr>::Expr(Box::new(arg.cloned().unwrap()))
+
+                    pl::InterpolateItem::<rq::Expr>::Expr {
+                        expr: Box::new(arg.cloned().unwrap()),
+                        format: None,
+                    }
                 }
                 pl::InterpolateItem::String(s) => pl::InterpolateItem::String(s.clone()),
             }

--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -37,73 +37,73 @@ let upper = column -> s"UPPER({column:0})"
 let read_parquet = source -> s"read_parquet({source:0})"
 let read_csv = source -> s"read_csv_auto({source:0})"
 
-@(binding_strength 11)
+#[binding_strength 11]
 let mul = l r -> null
 
-@(binding_strength 100)
+#[binding_strength 100]
 let div_i = l r -> s"FLOOR(FLOOR(ABS({l:11} / {r:11})) * SIGN({l:11} / {r:11}))"
 
-@(binding_strength 11)
+#[binding_strength 11]
 let div_f = l r -> s"({l} * 1.0 / {r})"
 
-@(binding_strength 11)
+#[binding_strength 11]
 let mod = l r -> s"{l} % {r}"
 
-@(binding_strength 10)
+#[binding_strength 10]
 let add = l r -> null
 
-@(binding_strength 10)
+#[binding_strength 10]
 let sub = l r -> null
 
-@(binding_strength 6)
+#[binding_strength 6]
 let eq = l r -> null
 
-@(binding_strength 6)
+#[binding_strength 6]
 let ne = l r -> null
 
-@(binding_strength 6)
+#[binding_strength 6]
 let gt = l r -> null
 
-@(binding_strength 6)
+#[binding_strength 6]
 let lt = l r -> null
 
-@(binding_strength 6)
+#[binding_strength 6]
 let gte = l r -> null
 
-@(binding_strength 6)
+#[binding_strength 6]
 let lte = l r -> null
 
-@(binding_strength 3)
+#[binding_strength 3]
 let and = l r -> null
 
-@(binding_strength 2)
+#[binding_strength 2]
 let or = l r -> null
 
 let coalesce = l r -> s"COALESCE({l:0}, {r:0})"
 
 let regex_search = text pattern -> s"REGEXP({text:0}, {pattern:0})"
 
-@(binding_strength 13)
+#[binding_strength 13]
 let neg = l -> s"-{l}"
 
-@(binding_strength 4)
+#[binding_strength 4]
 let not = l -> s"NOT {l}"
 
 module postgres {
-    @(binding_strength 100)
+    #[binding_strength 100]
     let div_i = l r -> s"trunc({l} / {r})::bigint"
 
-    @(binding_strength 100)
+    #[binding_strength 100]
     let round = n_digits column -> s"ROUND(({column:0})::numeric, {n_digits:0})"
 
-    @(binding_strength 9)
+    #[binding_strength 9]
     let regex_search = text pattern -> s"{text} ~ {pattern}"
 }
 
 module sqlite {
     let div_i = l r -> s"ROUND(ABS({l} / {r}) - 0.5) * SIGN({l} / {r})"
 
-    @(binding_strength 9)
+    #[binding_strength 9]
     let regex_search = text pattern -> s"{text} REGEXP {pattern}"
 }
 
@@ -112,7 +112,7 @@ module mssql {
 }
 
 module mysql {
-    @(binding_strength 11)
+    #[binding_strength 11]
     let div_f = l r -> s"CAST({l:0} AS FLOAT) / {r}"
 
     let mod = l r -> s"FLOOR(MOD({l:0}, {r:0}))"

--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -4,6 +4,14 @@
 #! It can contain only:
 #! - functions declarations that don't have named params and s-string-only body,
 #! - module declarations whose names correspond to sql dialect names.
+#!
+#! Functions can define `binding_strength` annotation, which signifies how much
+#! precedence does the top-level operation in the s-string provide.
+#! This value defaults to 100 (high precedence).
+#!
+#! S-strings can define required binding strength of the interpolated expression.
+#! This value defaults to binding strength of the function.
+
 
 
 # Aggregation functions
@@ -115,8 +123,11 @@ module mysql {
     #[binding_strength 11]
     let div_f = l r -> s"CAST({l:0} AS FLOAT) / {r}"
 
+    #[binding_strength 100]
     let mod = l r -> s"FLOOR(MOD({l:0}, {r:0}))"
-    let regex_search = text pattern -> s"({text} REGEXP {pattern})"
+
+    #[binding_strength 9]
+    let regex_search = text pattern -> s"{text} REGEXP {pattern}"
 }
 
 module bigquery {

--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -7,64 +7,104 @@
 
 
 # Aggregation functions
-let min = column -> s"MIN({column})"
-let max = column -> s"MAX({column})"
-let sum = column -> s"SUM({column})"
-let avg = column -> s"AVG({column})"
-let stddev = column -> s"STDDEV({column})"
-let average = column -> s"AVG({column})"
-let count = non_null -> s"COUNT({non_null})"
-let count_distinct = column -> s"COUNT(DISTINCT {column})"
+let min = column -> s"MIN({column:0})"
+let max = column -> s"MAX({column:0})"
+let sum = column -> s"SUM({column:0})"
+let avg = column -> s"AVG({column:0})"
+let stddev = column -> s"STDDEV({column:0})"
+let average = column -> s"AVG({column:0})"
+let count = non_null -> s"COUNT({non_null:0})"
+let count_distinct = column -> s"COUNT(DISTINCT {column:0})"
 
 # Window functions
-let lag = offset column -> s"LAG({column}, {offset})"
-let lead = offset column -> s"LEAD({column}, {offset})"
-let first = offset column -> s"FIRST_VALUE({column}, {offset})"
-let last = offset column -> s"LAST_VALUE({column}, {offset})"
+let lag = offset column -> s"LAG({column:0}, {offset:0})"
+let lead = offset column -> s"LEAD({column:0}, {offset:0})"
+let first = offset column -> s"FIRST_VALUE({column:0}, {offset:0})"
+let last = offset column -> s"LAST_VALUE({column:0}, {offset:0})"
 let rank = -> s"RANK()"
 let rank_dense = -> s"DENSE_RANK()"
 let row_number = -> s"ROW_NUMBER()"
 
 # Other functions
-let round = n_digits column -> s"ROUND({column}, {n_digits})"
-let as = `type` column -> s"CAST({column} AS {type})"
+let round = n_digits column -> s"ROUND({column:0}, {n_digits:0})"
+let as = `type` column -> s"CAST({column:0} AS {type:0})"
 
 # String functions
-let lower = column -> s"LOWER({column})"
-let upper = column -> s"UPPER({column})"
+let lower = column -> s"LOWER({column:0})"
+let upper = column -> s"UPPER({column:0})"
 
 # Source-reading functions, primarily for DuckDB
-let read_parquet = source -> s"read_parquet({source})"
-let read_csv = source -> s"read_csv_auto({source})"
+let read_parquet = source -> s"read_parquet({source:0})"
+let read_csv = source -> s"read_csv_auto({source:0})"
 
+@(binding_strength 11)
 let mul = l r -> null
-let div_i = l r -> s"FLOOR(FLOOR(ABS({l} / {r})) * SIGN({l} / {r}))"
+
+@(binding_strength 100)
+let div_i = l r -> s"FLOOR(FLOOR(ABS({l:11} / {r:11})) * SIGN({l:11} / {r:11}))"
+
+@(binding_strength 11)
 let div_f = l r -> s"({l} * 1.0 / {r})"
+
+@(binding_strength 11)
 let mod = l r -> s"{l} % {r}"
+
+@(binding_strength 10)
 let add = l r -> null
+
+@(binding_strength 10)
 let sub = l r -> null
+
+@(binding_strength 6)
 let eq = l r -> null
+
+@(binding_strength 6)
 let ne = l r -> null
+
+@(binding_strength 6)
 let gt = l r -> null
+
+@(binding_strength 6)
 let lt = l r -> null
+
+@(binding_strength 6)
 let gte = l r -> null
+
+@(binding_strength 6)
 let lte = l r -> null
+
+@(binding_strength 3)
 let and = l r -> null
+
+@(binding_strength 2)
 let or = l r -> null
-let coalesce = l r -> s"COALESCE({l}, {r})"
-let regex_search = text pattern -> s"REGEXP({text}, {pattern})"
-let neg = l -> null
-let not = l -> null
+
+let coalesce = l r -> s"COALESCE({l:0}, {r:0})"
+
+let regex_search = text pattern -> s"REGEXP({text:0}, {pattern:0})"
+
+@(binding_strength 13)
+let neg = l -> s"-{l}"
+
+@(binding_strength 4)
+let not = l -> s"NOT {l}"
 
 module postgres {
+    @(binding_strength 100)
     let div_i = l r -> s"trunc({l} / {r})::bigint"
-    let round = n_digits column -> s"ROUND(({column})::numeric, {n_digits})"
-    let regex_search = text pattern -> s"({text} ~ {pattern})"
+
+    @(binding_strength 100)
+    let round = n_digits column -> s"ROUND(({column:0})::numeric, {n_digits:0})"
+
+    @(binding_strength 9)
+    let regex_search = text pattern -> s"{text} ~ {pattern}"
 }
 
 module sqlite {
     let div_i = l r -> s"ROUND(ABS({l} / {r}) - 0.5) * SIGN({l} / {r})"
-    let regex_search = text pattern -> s"({text} REGEXP {pattern})"
+
+    @(binding_strength 9)
+    let regex_search = text pattern -> s"{text} REGEXP {pattern}"
 }
 
 module mssql {
@@ -72,18 +112,17 @@ module mssql {
 }
 
 module mysql {
-    let div_f = l r -> s"(CAST({l} AS FLOAT) / {r})"
-    let mod = l r -> s"FLOOR(MOD({l}, {r}))"
+    @(binding_strength 11)
+    let div_f = l r -> s"CAST({l:0} AS FLOAT) / {r}"
+
+    let mod = l r -> s"FLOOR(MOD({l:0}, {r:0}))"
     let regex_search = text pattern -> s"({text} REGEXP {pattern})"
 }
 
 module bigquery {
-    let regex_search = text pattern -> s"REGEXP_CONTAINS({text}, {pattern})"
+    let regex_search = text pattern -> s"REGEXP_CONTAINS({text:0}, {pattern:0})"
 }
 
 module duckdb {
-    # TODO: uncomment when updated on latest DuckDB version
-    # let div_i = l r -> s"({l} // {r})"
-
-    let regex_search = text pattern -> s"REGEXP_MATCHES({text}, {pattern})"
+    let regex_search = text pattern -> s"REGEXP_MATCHES({text:0}, {pattern:0})"
 }

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -59,7 +59,7 @@ fn test_precedence() {
     select temp_c = (temp - 32) / 1.8
     "###).unwrap()), @r###"
     SELECT
-      (temp - 32 * 1.0 / 1.8) AS temp_c
+      ((temp - 32) * 1.0 / 1.8) AS temp_c
     FROM
       x
     "###);

--- a/web/book/tests/snapshots/snapshot__language-features__regex__regex-expressions__3.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__regex__regex-expressions__3.snap
@@ -7,5 +7,5 @@ SELECT
 FROM
   tracks
 WHERE
-  (name ~ '\(I Can''t Help\) Falling')
+  name ~ '\(I Can''t Help\) Falling'
 

--- a/web/book/tests/snapshots/snapshot__language-features__regex__regex-expressions__4.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__regex__regex-expressions__4.snap
@@ -7,5 +7,5 @@ SELECT
 FROM
   tracks
 WHERE
-  (name REGEXP 'With You')
+  name REGEXP 'With You'
 

--- a/web/book/tests/snapshots/snapshot__language-features__regex__regex-expressions__5.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__regex__regex-expressions__5.snap
@@ -7,7 +7,5 @@ SELECT
 FROM
   tracks
 WHERE
-  (
-    name REGEXP 'But Why Isn''t Your Syntax More Similar\?'
-  )
+  name REGEXP 'But Why Isn''t Your Syntax More Similar\?'
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__0.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__0.snap
@@ -4,7 +4,7 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\n\nfrom citie
 ---
 SELECT
   *,
-  (temp_f - 32 * 1.0 / 1.8) AS temp_c
+  ((temp_f - 32) * 1.0 / 1.8) AS temp_c
 FROM
   cities
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__1.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__1.snap
@@ -4,8 +4,8 @@ expression: "let interp = low:0 high x -> (x - low) / (high - low)\n\nfrom stude
 ---
 SELECT
   *,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_1,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_2
+  ((sat_score - 0) * 1.0 / (1600 - 0)) AS sat_proportion_1,
+  ((sat_score - 0) * 1.0 / (1600 - 0)) AS sat_proportion_2
 FROM
   students
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__piping__0.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__piping__0.snap
@@ -4,8 +4,8 @@ expression: "let interp = low:0 high x -> (x - low) / (high - low)\n\nfrom stude
 ---
 SELECT
   *,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_1,
-  (sat_score - 0 * 1.0 / 1600 - 0) AS sat_proportion_2
+  ((sat_score - 0) * 1.0 / (1600 - 0)) AS sat_proportion_1,
+  ((sat_score - 0) * 1.0 / (1600 - 0)) AS sat_proportion_2
 FROM
   students
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__piping__1.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__piping__1.snap
@@ -4,7 +4,7 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\n\nfrom citie
 ---
 SELECT
   *,
-  (temp_f - 32 * 1.0 / 1.8) AS temp_c
+  ((temp_f - 32) * 1.0 / 1.8) AS temp_c
 FROM
   cities
 

--- a/web/book/tests/snapshots/snapshot__queries__functions__piping__2.snap
+++ b/web/book/tests/snapshots/snapshot__queries__functions__piping__2.snap
@@ -4,7 +4,9 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\nlet interp =
 ---
 SELECT
   *,
-  ((temp_c - 32 * 1.0 / 1.8) - 0 * 1.0 / 100 - 0) AS boiling_proportion
+  (
+    (((temp_c - 32) * 1.0 / 1.8) - 0) * 1.0 / (100 - 0)
+  ) AS boiling_proportion
 FROM
   kettles
 

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -169,8 +169,8 @@ showcase_section:
         SELECT
           *,
           started + unfinished AS finished,
-          (started + unfinished * 1.0 / started) AS fin_share,
-          ( (started + unfinished * 1.0 / started) * 1.0 / 1 - (started + unfinished * 1.0 / started) ) AS fin_ratio
+          ((started + unfinished) * 1.0 / started) AS fin_share,
+          ( ((started + unfinished) * 1.0 / started) * 1.0 / (1 - ((started + unfinished) * 1.0 / started)) ) AS fin_ratio
         FROM
           track_plays
 


### PR DESCRIPTION
Closes #2694

Closes #2693

Adds parsing of s-string formats:
```
s"Hello {first_name:format}"
```
... where `format` can be any string and does not yet have a user-facing function.


Adds parsing of annotations:
```
#[my_annotation arg1 arg2]
let a = ...
```
... where `arg1`, `arg2` and so on can be any expression. They don't yet have any user-facing function.


