### PR TITLE
fix: Try removing `compile-files` for SO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,13 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compile-files"
-version = "0.8.1"
-dependencies = [
- "prql-compiler",
-]
-
-[[package]]
 name = "concolor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
   # Macros
   "prql-compiler/prql-compiler-macros", #
   # An example
-  "prql-compiler/examples/compile-files", #
+  # "prql-compiler/examples/compile-files", #
   # Bindings
   "bindings/prql-elixir/native/prql",
   "bindings/prql-java",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ members = [
   "prql-compiler/prqlc", #
   # Macros
   "prql-compiler/prql-compiler-macros", #
-  # An example
-  # "prql-compiler/examples/compile-files", #
   # Bindings
   "bindings/prql-elixir/native/prql",
   "bindings/prql-java",
@@ -15,11 +13,12 @@ members = [
   "bindings/prql-lib",
   "bindings/prql-python", #
   # The book / docs
-  "web/book",
+  "web/book", #
+  # An example
+  # This is temporarily removed because it was causing a stack overflow in
+  # Windows; ref https://github.com/PRQL/prql/pull/2713
+  # "prql-compiler/examples/compile-files", #
 ]
-# Note we don't have a `default-members = ["prql-compiler"]`, since that causes
-# commands like `cargo test` to only run tests from the default package. And
-# `cargo insta test` doesn't have a `--workspace` flag.
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
Something is causing a Stack Overflow on Windows; maaaybe it could be this line? https://github.com/PRQL/prql/pull/2700/files#diff-2e1623f80d59e3d48345bf175c77cecd15f88c8c7edb81a03ead35194b839720R16
