### PR TITLE
test: Disable Elixir tests in Cargo

### DIFF
--- a/bindings/prql-elixir/native/prql/Cargo.toml
+++ b/bindings/prql-elixir/native/prql/Cargo.toml
@@ -12,8 +12,10 @@ version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false
 name = "prql"
 path = "src/lib.rs"
+test = false
 
 [dependencies]
 prql-compiler = {path = "../../../../prql-compiler", default-features = false, version = "0.8.1"}


### PR DESCRIPTION
There aren't any, and they slightly slow down `cargo test`
