### PR TITLE
fix: `DISTINCT ON` includes `ORDER BY`

### DIFF
--- a/prql-compiler/src/sql/srq/preprocess.rs
+++ b/prql-compiler/src/sql/srq/preprocess.rs
@@ -133,6 +133,7 @@ pub(in crate::sql) fn distinct(
                     res.push(SqlTransform::Distinct);
                 } else if ctx.dialect.supports_distinct_on() {
                     res.push(SqlTransform::DistinctOn(partition));
+                    res.push(SqlTransform::Sort(sort));
                 } else {
                     // convert `take range` into:
                     //   derive _rn = s"ROW NUMBER"

--- a/prql-compiler/src/tests/test.rs
+++ b/prql-compiler/src/tests/test.rs
@@ -1500,6 +1500,8 @@ fn test_distinct_on() {
       DISTINCT ON (department) *
     FROM
       employees
+    ORDER BY
+      age
     "###);
 
     assert_display_snapshot!((compile(r###"

--- a/web/book/tests/snapshots/snapshot__language-features__distinct__distinct-on__0.snap
+++ b/web/book/tests/snapshots/snapshot__language-features__distinct__distinct-on__0.snap
@@ -6,4 +6,6 @@ SELECT
   DISTINCT ON (department) *
 FROM
   employees
+ORDER BY
+  age
 


### PR DESCRIPTION
Closes https://github.com/PRQL/prql/issues/2711

Note that this doesn't have `ORDER BY department` from the example in that issue; I don't think that's necessary.
