### PR TITLE
devops: ensure using LF linefeed for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
After merging #2710, the CI test on Windows was failed.
https://github.com/PRQL/prql/actions/runs/5166686886/jobs/9307044629#step:11:223

I'm guessing this is due to the incredible default setting in Git for Windows that rewrites the linefeed code from LF to CRLF at checkout, and I think forcing LF would make the test pass.
https://github.com/PRQL/prql/blob/69571f1bd44e90e77e5a514a72d218ba9947caeb/prql-compiler/tests/docs/main.rs#L55

I used https://github.com/prettier/prettier/blob/7ad852636dbd83bf570a4983a060002c7c3a3984/.gitattributes as a reference for this setting.