### PR TITLE
build: pin the rust-toolchain version to 1.68.2

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,7 +64,10 @@ jobs:
   update-rust-toolchain:
     runs-on: ubuntu-latest
     # Don't run on forks; will attempt to create a PR into the fork...
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    # if: ${{ !github.event.pull_request.head.repo.fork }}
+
+    # Disable until 1.72.0 is released, see https://github.com/rust-lang/rust/pull/112154
+    if: false
 
     # Note that this doesn't change the minimum supported version, only the
     # default to run on. The minimum is defined by Cargo.toml's metadata.msrv.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.68.2"
 components = ["rustfmt", "clippy"]
 # We want two targets: wasm32, and the default target for the platform, which we
 # don't list here. (i.e. we use each platform to test each platform)


### PR DESCRIPTION
Close #2721

For building prqlc for windows, Rust 1.69 to 1.71 (unreleased) should not be used.