### PR TITLE
test: Add comments re CRLF, make test robust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
+# Currently required for:
+# - Elixir tests at
+#   https://github.com/PRQL/prql/blob/5eb4063dbd36bdac07529797dd2cec8c55127263/.github/workflows/test-elixir.yaml#L31
+# - Previously for Readme tests, those those now should support either lf or
+#   crlf, at https://github.com/PRQL/prql/blob/6d4662b4e6e0f07dc3cd8eb5c19cc78fc199d0b2/web/book/tests/documentation/readme.rs#L9
 * text=auto eol=lf

--- a/.github/workflows/test-elixir.yaml
+++ b/.github/workflows/test-elixir.yaml
@@ -28,11 +28,6 @@ jobs:
         elixir: ["1.14.2"]
     runs-on: ${{matrix.os}}
     steps:
-      # fix CRLF issue on windows
-      - run: |
-          git config --global core.autocrlf false
-        working-directory: /
-
       # Step: Check out the code.
       - name: Checkout code
         uses: actions/checkout@v3

--- a/web/book/tests/documentation/readme.rs
+++ b/web/book/tests/documentation/readme.rs
@@ -6,7 +6,7 @@ use super::compile;
 fn test_readme_examples() {
     let contents = include_str!("../../../../README.md");
     // Similar to code at https://github.com/PRQL/prql/blob/65706a115a84997c608eaeda38b1aef1240fcec3/web/book/tests/snapshot.rs#L152, but specialized for the Readme.
-    let re = Regex::new(r"(?s)```(elm|prql)\n(?P<prql>.+?)\n```").unwrap();
+    let re = Regex::new(r"(?s)```(elm|prql)\r?\n(?P<prql>.+?)\r?\n```").unwrap();
     assert_ne!(re.find_iter(contents).count(), 0);
     re.captures_iter(contents).for_each(|capture| {
         compile(&capture["prql"]).unwrap();


### PR DESCRIPTION
- Removes the CI hack in Elixir tests, as that should no longer be needed, and hide the test failing for folks developing on Windows
- Makes the Readme tests robust to either scheme
- Adds some comments

Overall not sure what's best to do here — make tests robust to either vs. mandate one. Probably the first is better, so we don't depend on local configs, but also more work. The current state is very reasonable AFAIU.
