### PR TITLE
refactor: Remove additional result handling in prqlc

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -164,19 +164,8 @@ impl Command {
     fn run_io_command(&mut self) -> std::result::Result<(), anyhow::Error> {
         let (mut file_tree, main_path) = self.read_input()?;
 
-        let res = self.execute(&mut file_tree, &main_path);
-
-        match res {
-            Ok(buf) => {
-                self.write_output(&buf)?;
-            }
-            Err(e) => {
-                eprint!("{:}", e);
-                std::process::exit(1)
-            }
-        }
-
-        Ok(())
+        self.execute(&mut file_tree, &main_path)
+            .and_then(|buf| Ok(self.write_output(&buf)?))
     }
 
     fn execute<'a>(&self, sources: &'a mut SourceTree, main_path: &'a str) -> Result<Vec<u8>> {


### PR DESCRIPTION
I think this is already handled at https://github.com/prql/prql/blob/85c9d261af302b06761c52641970eae2785102f5/prql-compiler/prqlc/src/cli.rs#L27, so this is unnecessary.

I found when trying to get `prqlc fmt` to work for files.