### PR TITLE
docs(book): update some sections about std lib

### DIFF
--- a/web/book/src/language-features/standard-library/README.md
+++ b/web/book/src/language-features/standard-library/README.md
@@ -7,14 +7,13 @@ Currently s-strings are an escape-hatch for any function that isn't in our
 standard library. If we find ourselves using them for something frequently,
 raise an issue and we'll add it to the stdlib.
 
-```admonish note
-Currently the stdlib implementation doesn't support different DB implementations itself;
-those need to be built deeper into the compiler. We'll resolve this at some point. Until
-then, we'll only add functions here that are broadly supported by most DBs.
-```
-
 Here's the source of the current
 [PRQL `std`](https://github.com/PRQL/prql/blob/main/prql-compiler/src/semantic/std.prql):
+
+```admonish note
+PRQL 0.9.0 has started supporting different DB implementations for standard library functions.
+The source is the [`std.sql`](https://github.com/PRQL/prql/blob/main/prql-compiler/src/sql/std.sql.prql).
+```
 
 ```prql no-eval
 {{#include ../../../../../prql-compiler/src/semantic/std.prql}}
@@ -28,5 +27,27 @@ derive {
   gross_salary = (salary + payroll_tax | as int),
   gross_salary_rounded = (gross_salary | round 0),
   time = s"NOW()",  # an s-string, given no `now` function exists in PRQL
+}
+```
+
+Example of different implementations of division and integer division:
+
+```prql
+prql target:sql.sqlite
+
+from [{x = 13, y = 5}]
+select {
+  quotient = x / y,
+  int_quotient = x // y,
+}
+```
+
+```prql
+prql target:sql.mysql
+
+from [{x = 13, y = 5}]
+select {
+  quotient = x / y,
+  int_quotient = x // y,
 }
 ```

--- a/web/book/src/syntax/expressions-and-operators.md
+++ b/web/book/src/syntax/expressions-and-operators.md
@@ -26,7 +26,7 @@ operations and for function calls (see the discussion below.)
 | identifier dot | `.`                         |     1      |               |
 |          unary | `-` `+` `!` `==`            |     2      |               |
 |          range | `..`                        |     3      |               |
-|            mul | `*` `/` `%`                 |     4      | left-to-right |
+|            mul | `*` `/` `//` `%`            |     4      | left-to-right |
 |            add | `+` `-`                     |     5      | left-to-right |
 |        compare | `==` `!=` `<=` `>=` `<` `>` |     6      | left-to-right |
 |       coalesce | `??`                        |     7      | left-to-right |

--- a/web/book/tests/documentation/snapshots/documentation__book__language-features__standard-library__README__standard-library__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__language-features__standard-library__README__standard-library__1.snap
@@ -1,0 +1,15 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "prql target:sql.sqlite\n\nfrom [{x = 13, y = 5}]\nselect {\n  quotient = x / y,\n  int_quotient = x // y,\n}\n"
+---
+WITH table_0 AS (
+  SELECT
+    13 AS x,
+    5 AS y
+)
+SELECT
+  (x * 1.0 / y) AS quotient,
+  ROUND(ABS(x / y) - 0.5) * SIGN(x) * SIGN(y) AS int_quotient
+FROM
+  table_0
+

--- a/web/book/tests/documentation/snapshots/documentation__book__language-features__standard-library__README__standard-library__2.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__language-features__standard-library__README__standard-library__2.snap
@@ -1,0 +1,15 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "prql target:sql.mysql\n\nfrom [{x = 13, y = 5}]\nselect {\n  quotient = x / y,\n  int_quotient = x // y,\n}\n"
+---
+WITH table_0 AS (
+  SELECT
+    13 AS x,
+    5 AS y
+)
+SELECT
+  (x / y) AS quotient,
+  (x DIV y) AS int_quotient
+FROM
+  table_0
+


### PR DESCRIPTION
Minor updates to documentation.

I really wanted to write about the division operator, but I couldn't decide where to put it because the pages about operator were separated into `language-features/standard-library` and `syntax/expressions-and-operators.md`.

Perhaps it might be a good to rename `syntax/expressions-and-operators.md` and move the information on operators to `language-features/standard-library`.

For example, in the DuckDB documentation, operators are introduced with functions.
https://duckdb.org/docs/sql/functions/overview