### PR TITLE
ci: Turn off debuginfo in CI

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -8,6 +8,10 @@ on:
       - "**.md"
   workflow_call:
 
+env:
+  # This reduces the size of the cargo cache by ~25%.
+  RUSTFLAGS: "-C debuginfo=0"
+
 concurrency:
   # See notes in `pull-request.yaml`
   group: ${{ github.workflow }}-${{ github.ref }}-web
@@ -30,7 +34,6 @@ jobs:
       - name: Setup hugo
         uses: peaceiris/actions-hugo@v2.6.0
 
-      # Book setup, duplicated from `pull-request.yaml`
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: mdbook

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -30,9 +30,9 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: 0.8.1
+          prefix-key: debug-info-off
           key: ${{ inputs.target_option }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: 📎 Clippy
         uses: richb-hanover/cargo@v1.1.0
         with:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -13,6 +13,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR_FORCE: 1
+  # This reduces the size of the cargo cache by ~25%.
+  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   test-rust:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -32,9 +32,9 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: debug-info-off
+          prefix-key: 0.8.1
           key: ${{ inputs.target_option }}
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: 📎 Clippy
         uses: richb-hanover/cargo@v1.1.0
         with:

--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -8,6 +8,10 @@ on:
       - .github/workflows/test-taskfile.yaml
   workflow_call:
 
+env:
+  # This reduces the size of the cargo cache by ~25%.
+  RUSTFLAGS: "-C debuginfo=0"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-taskfile
   cancel-in-progress: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,3 @@ opt-level = 3
 [workspace.metadata.release]
 allow-branch = ["*"]
 consolidate-commits = true
-
-[profile.dev]
-debug = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ opt-level = 3
 [workspace.metadata.release]
 allow-branch = ["*"]
 consolidate-commits = true
+
+[profile.dev]
+debug = 0


### PR DESCRIPTION
This will help with cache churn, will help with https://github.com/PRQL/prql/issues/2639 a bit. 

Re the cache — currently we're OK iff we only have one Cache key being run. As soon as the Cache key changes — basically any dependency upgrade — we get churn. And while we run PRs based on the old cache key, that can kick out the new cache too. But it's not pathological — as soon as the old cache has been evicted, it can never return, since we only save new caches from `main`.