### PR TITLE
docs: Update main crate docstring

### DIFF
--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! - Compile PRQL queries to SQL at build time.
 //!
-//!     Use the `prql-compiler-macros` crate; for example:
+//!     For inline strings, use the `prql-compiler-macros` crate; for example:
 //!     ```ignore
 //!     let sql: &str = prql_to_sql!("from albums | select {title, artist_id}");
 //!     ```

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -1,5 +1,5 @@
-//! Compiler for PRQL language.
-//! Targets SQL and exposes PL and RQ abstract syntax trees.
+//! Compiler for PRQL language. Targets SQL and exposes PL and RQ abstract
+//! syntax trees.
 //!
 //! You probably want to start with [compile] wrapper function.
 //!
@@ -34,9 +34,7 @@
 //!
 //! ## Common use-cases
 //!
-//! I want to ...
-//! - ... compile PRQL queries at run time, because I cannot commit them into
-//!     the source tree.
+//! - Compile PRQL queries to SQL at run time.
 //!
 //!     ```
 //!     # fn main() -> Result<(), prql_compiler::ErrorMessages> {
@@ -49,23 +47,21 @@
 //!     # }
 //!     ```
 //!
-//! - ... compile PRQL queries to SQL at build time.
+//! - Compile PRQL queries to SQL at build time.
 //!
-//!     Use `prql-compiler-macros` crate (unreleased), which can be used like
-//!     this:
+//!     Use the `prql-compiler-macros` crate; for example:
 //!     ```ignore
 //!     let sql: &str = prql_to_sql!("from albums | select {title, artist_id}");
 //!     ```
 //!
-//! - ... compile .prql files to .sql files at build time.
+//!     Alternatively, to compile `.prql` files to `.sql` files at build time,
+//!     call `prql-compiler` from `build.rs`. See [this example
+//!     project](https://github.com/PRQL/prql/tree/main/prql-compiler/examples/compile-files).
 //!
-//!     Call this crate from `build.rs`. See
-//!     [this example project](https://github.com/PRQL/prql/tree/main/prql-compiler/examples/compile-files).
-//!
-//! - ... compile, format & debug PRQL from command line.
+//! - Compile, format & debug PRQL from command line.
 //!
 //!     ```sh
-//!     $ cargo install prqlc
+//!     $ cargo install --locked prqlc
 //!     $ prqlc compile query.prql
 //!     ```
 //!

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -54,9 +54,9 @@
 //!     let sql: &str = prql_to_sql!("from albums | select {title, artist_id}");
 //!     ```
 //!
-//!     Alternatively, to compile `.prql` files to `.sql` files at build time,
-//!     call `prql-compiler` from `build.rs`. See [this example
-//!     project](https://github.com/PRQL/prql/tree/main/prql-compiler/examples/compile-files).
+//!     For compiling whole files (`.prql` to `.sql`), call `prql-compiler`
+//!     from `build.rs`.
+//!     See [this example project](https://github.com/PRQL/prql/tree/main/prql-compiler/examples/compile-files).
 //!
 //! - Compile, format & debug PRQL from command line.
 //!


### PR DESCRIPTION
I think `prql-compiler-macros` is now published. And I refined the style a bit.

Does the `compile-files` example need a macro within it? It complicates the example slightly — we're saying "if you want to compile files, then use `prql-compiler`, rather than `prql-compiler-macros` but write your own macro"??
