### PR TITLE
docs: Move Terminology

### DIFF
--- a/prql-compiler/README.md
+++ b/prql-compiler/README.md
@@ -33,19 +33,3 @@ let opts = &Options {
 let sql = compile(&prql, opts).unwrap();
 assert_eq!("SELECT name, age FROM employees", sql);
 ```
-
-## Terminology
-
-[_Relation_](<https://en.wikipedia.org/wiki/Relation_(database)>): Standard
-definition of a relation in context of databases:
-
-- An ordered set of tuples of form `(d_0, d_1, d_2, ...)`.
-- Set of all `d_x` is called an attribute or a column. It has a name and a type
-  domain `D_x`.
-
-_Frame_: descriptor of a relation. Contains list of columns (with names and
-types). Does not contain data.
-
-[_Table_](<https://en.wikipedia.org/wiki/Table_(database)#Tables_versus_relations>):
-persistently stored relation. Some uses of this term actually mean to say
-"relation".

--- a/web/book/src/internals/README.md
+++ b/web/book/src/internals/README.md
@@ -3,10 +3,22 @@
 This chapter explains PRQL's semantics: how expressions are interpreted and
 their meaning. It's intended for advanced users and compiler contributors.
 
-- [Name resolving](./name-resolving.md)
-- [Functions](./functional-lang.md)
-- [Syntax highlighting](./syntax-highlighting.md)
-
 It's also worth checking out the
 [`prql-compiler` docs](https://docs.rs/prql-compiler/latest/prql_compiler/) for
 more details on its API.
+
+## Terminology
+
+[_Relation_](<https://en.wikipedia.org/wiki/Relation_(database)>): Standard
+definition of a relation in context of databases:
+
+- An ordered set of tuples of form `(d_0, d_1, d_2, ...)`.
+- Set of all `d_x` is called an attribute or a column. It has a name and a type
+  domain `D_x`.
+
+_Frame_: descriptor of a relation. Contains list of columns (with names and
+types). Does not contain data.
+
+[_Table_](<https://en.wikipedia.org/wiki/Table_(database)#Tables_versus_relations>):
+persistently stored relation. Some uses of this term actually mean to say
+"relation".

--- a/web/book/src/internals/README.md
+++ b/web/book/src/internals/README.md
@@ -16,8 +16,6 @@ definition of a relation in context of databases:
 - Set of all `d_x` is called an attribute or a column. It has a name and a type
   domain `D_x`.
 
-_Frame_: descriptor of a relation. Contains list of columns (with names and
-types). Does not contain data.
 
 [_Table_](<https://en.wikipedia.org/wiki/Table_(database)#Tables_versus_relations>):
 persistently stored relation. Some uses of this term actually mean to say

--- a/web/book/src/internals/README.md
+++ b/web/book/src/internals/README.md
@@ -16,7 +16,6 @@ definition of a relation in context of databases:
 - Set of all `d_x` is called an attribute or a column. It has a name and a type
   domain `D_x`.
 
-
 [_Table_](<https://en.wikipedia.org/wiki/Table_(database)#Tables_versus_relations>):
 persistently stored relation. Some uses of this term actually mean to say
 "relation".


### PR DESCRIPTION
I'm not sure where this should go, but its current place I don't think is that coherent any longer.

I also removed the index in the book for Internals — I think better to have no index than an out-of-date one. Would be great if there were a tool to build this automatically!
