### PR TITLE
ci: Align env variables (v2)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,12 +24,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-pull-request
   cancel-in-progress: true
 
-env:
-  CARGO_TERM_COLOR: always
-  CLICOLOR_FORCE: 1
-  # This reduces the size of the cargo cache by ~25%.
-  RUSTFLAGS: "-C debuginfo=0"
-
 jobs:
   test-rust:
     strategy:
@@ -140,6 +134,14 @@ jobs:
         with:
           target: ${{ matrix.target }}
           profile: dev
+  # These are the same env variables as in `test-rust.yaml`. Custom actions
+  # don't allow setting env variables for the whole job, so we do it here. (We
+  # could change the `build-prqlc` action to a workflow...).
+  env:
+    CARGO_TERM_COLOR: always
+    CLICOLOR_FORCE: 1
+    # This reduces the size of the cargo cache by ~25%.
+    RUSTFLAGS: "-C debuginfo=0"
 
   automerge-dependabot:
     # This would arguably fit more naturally in `pull-request-target`, but it's

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -134,14 +134,14 @@ jobs:
         with:
           target: ${{ matrix.target }}
           profile: dev
-  # These are the same env variables as in `test-rust.yaml`. Custom actions
-  # don't allow setting env variables for the whole job, so we do it here. (We
-  # could change the `build-prqlc` action to a workflow...).
-  env:
-    CARGO_TERM_COLOR: always
-    CLICOLOR_FORCE: 1
-    # This reduces the size of the cargo cache by ~25%.
-    RUSTFLAGS: "-C debuginfo=0"
+    # These are the same env variables as in `test-rust.yaml`. Custom actions
+    # don't allow setting env variables for the whole job, so we do it here. (We
+    # could change the `build-prqlc` action to a workflow...).
+    env:
+      CARGO_TERM_COLOR: always
+      CLICOLOR_FORCE: 1
+      # This reduces the size of the cargo cache by ~25%.
+      RUSTFLAGS: "-C debuginfo=0"
 
   automerge-dependabot:
     # This would arguably fit more naturally in `pull-request-target`, but it's

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -10,6 +10,12 @@ on:
         type: string
         default: ""
 
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  # This reduces the size of the cargo cache by ~25%.
+  RUSTFLAGS: "-C debuginfo=0"
+
 jobs:
   test-rust:
     runs-on: ${{ inputs.os }}


### PR DESCRIPTION
Last approach didn't work, as env vars aren't inherited by a called workflow, only a called action
