### PR TITLE
ci: Replace `key` in cache

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -23,7 +23,7 @@ runs:
       with:
         # Share cache with `test-rust`
         save-if: false
-        shared-key: rust
+        shared-key: rust-${{ inputs.target_option }}
         prefix-key: 0.8.1
 
     - if: runner.os == 'Linux'

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -33,8 +33,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: 0.8.1
-          shared-key: rust
-          key: ${{ inputs.target_option }}
+          shared-key: rust-${{ inputs.target_option }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: 📎 Clippy
         uses: richb-hanover/cargo@v1.1.0


### PR DESCRIPTION
This doesn't seem to work if `shared-key` is active, so we append ourselves now
