### PR TITLE
devops: Remove old notes, fix image name

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -57,7 +57,7 @@ jobs:
             ${{ github.ref == 'refs/heads/main' || startsWith(github.ref,
             'refs/tags/') }}
           cache-from: |
-            ${{ env.DOCKER_METADATA_OUTPUT_TAGS }}
+            ${{ steps.meta.outputs.tags }}
             type=gha
           cache-to: |
             type=inline

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -7,16 +7,6 @@ on:
       - .github/workflows/build-devcontainer.yaml
       - Taskfile.yml
   push:
-    # We could push this on the stable branch (currently named `web`) if we
-    # needed a clearer release schedule.
-    # We don't run on every merge to main because:
-    # - I'm not sure whether starting a new devcontainer pulls a new image every
-    #   time, which would be annoying when there are no changes (maybe it's the
-    #   same but relies on the cache working perfertly)
-    # - The arm64 build is very very slow, takes 2-3 hours, so we don't want to
-    #   run it excessively.
-    #
-    # If the cache works reliably, we can remove this path restriction and run on every merge.
     branches:
       - main
     paths:
@@ -38,7 +28,11 @@ jobs:
       - uses: docker/metadata-action@v4
         id: meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/prql-devcontainer-base
+          # We need to put `prql` in explictly because it needs to be lowercase;
+          # https://github.com/orgs/community/discussions/25768
+
+          # images: ghcr.io/${{ github.repository_owner }}/prql-devcontainer-base
+          images: ghcr.io/prql/prql-devcontainer-base
           # We could use explicit tags (but mostly we just want the most recent version).
           tags: |
             type=raw,latest
@@ -66,8 +60,9 @@ jobs:
           push:
             ${{ github.ref == 'refs/heads/main' || startsWith(github.ref,
             'refs/tags/') }}
+          # As above re `prql`
           cache-from: |
-            ghcr.io/${{ github.repository_owner }}/prql-devcontainer-base
+            ghcr.io/prql/prql-devcontainer-base
             type=gha
           cache-to: |
             type=inline

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -56,7 +56,6 @@ jobs:
           push:
             ${{ github.ref == 'refs/heads/main' || startsWith(github.ref,
             'refs/tags/') }}
-          # As above re `prql`
           cache-from: |
             ${{ env.DOCKER_METADATA_OUTPUT_TAGS }}
             type=gha

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -28,11 +28,7 @@ jobs:
       - uses: docker/metadata-action@v4
         id: meta
         with:
-          # We need to put `prql` in explictly because it needs to be lowercase;
-          # https://github.com/orgs/community/discussions/25768
-
-          # images: ghcr.io/${{ github.repository_owner }}/prql-devcontainer-base
-          images: ghcr.io/prql/prql-devcontainer-base
+          images: ghcr.io/${{ github.repository_owner }}/prql-devcontainer-base
           # We could use explicit tags (but mostly we just want the most recent version).
           tags: |
             type=raw,latest
@@ -62,7 +58,7 @@ jobs:
             'refs/tags/') }}
           # As above re `prql`
           cache-from: |
-            ghcr.io/prql/prql-devcontainer-base
+            DOCKER_METADATA_OUTPUT_TAGS
             type=gha
           cache-to: |
             type=inline

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -58,7 +58,7 @@ jobs:
             'refs/tags/') }}
           # As above re `prql`
           cache-from: |
-            DOCKER_METADATA_OUTPUT_TAGS
+            ${{ env.DOCKER_METADATA_OUTPUT_TAGS }}
             type=gha
           cache-to: |
             type=inline


### PR DESCRIPTION
I think those notes are out of date now, and we push on `main`?

And the caching was broken because of https://github.com/PRQL/prql/actions/runs/5218122950/jobs/9418621711#step:6:151

> #4 ERROR: failed to configure registry cache importer: invalid reference format: repository name must be lowercase
