### PR TITLE
ci: Merge Test & Compile steps

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -49,13 +49,6 @@ jobs:
         with:
           command: fmt
           args: --all --check
-        # We split up the test compilation as recommended in
-        # https://matklad.github.io/2021/09/04/fast-rust-builds.html
-      - name: 🏭 Compile
-        uses: richb-hanover/cargo@v1.1.0
-        with:
-          command: test
-          args: ${{ inputs.target_option }} --all-features --no-run --locked
       - name: Run docker compose
         # docker compose v2.18.0 breaks; we can remove when the latest version on the runners is v2.18.1
         run: |
@@ -73,6 +66,10 @@ jobs:
           resource: "tcp:5432 tcp:3306 tcp:1433"
           timeout: 60000
         if: ${{ inputs.os == 'ubuntu-latest' }}
+        # We previously split up the test compilation as recommended in
+        # https://matklad.github.io/2021/09/04/fast-rust-builds.html, but the
+        # binary is different for `cargo insta test`, so it ends up compiling
+        # twice.
       - name: 📋 Test
         uses: richb-hanover/cargo@v1.1.0
         with:


### PR DESCRIPTION
Because we're running `cargo insta test`, the recommended approach doesn't actually get a benefit from pre-compiling. (Open to reverting if there's a way of managing it...)
