### PR TITLE
ci: Use explicit target in cargo tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         # We use a matrix here to mirror `test-all`, so they share a cache.
         os: [ubuntu-latest]
-        target: ["x86_64-unknown-linux-musl", "wasm32-unknown-unknown"]
+        target: ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
     uses: ./.github/workflows/test-rust.yaml
     with:
       os: ${{ matrix.os }}
@@ -116,7 +116,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            target: x86_64-unknown-linux-gnu
           # TODO: Until we have tests for these, we don't have a cache for them.
           # If we can add tests, then re-enable them. They run on `release.yaml`
           # regardless.

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,11 +30,11 @@ jobs:
       matrix:
         # We use a matrix here to mirror `test-all`, so they share a cache.
         os: [ubuntu-latest]
-        target_option: ["", "--target=wasm32-unknown-unknown"]
+        target: ["x86_64-unknown-linux-musl", "wasm32-unknown-unknown"]
     uses: ./.github/workflows/test-rust.yaml
     with:
       os: ${{ matrix.os }}
-      target_option: ${{ matrix.target_option }}
+      target: ${{ matrix.target }}
 
   lint-megalinter:
     uses: ./.github/workflows/lint-megalinter.yaml

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            target: x86_64-unknown-linux-gnu
           # TODO: potentially enable these
           # - os: ubuntu-latest
           #   target: aarch64-unknown-linux-musl

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -46,21 +46,30 @@ jobs:
   test-rust:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        target_option: [""]
-        # Only run wasm on ubuntu, given it's the same rust target. (There is a
-        # possibility of having a failure on just one platform, but it's quite
-        # unlikely. If we do observe this, we can expand, or introduce a
-        # `test-actually-all.yaml` which accounts for these corner cases without
-        # using runners & cache space)
         include:
           - os: ubuntu-latest
-            target_option: --target=wasm32-unknown-unknown
+            target: x86_64-unknown-linux-musl
+          # TODO: potentially enable these
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-musl
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          # Only run wasm on ubuntu, given it's the same rust target. (There is a
+          # possibility of having a failure on just one platform, but it's quite
+          # unlikely. If we do observe this, we can expand, or introduce a
+          # `test-actually-all.yaml` which accounts for these corner cases without
+          # using runners & cache space)
+          - os: ubuntu-latest
+            target: wasm32-unknown-unknown
 
     uses: ./.github/workflows/test-rust.yaml
     with:
       os: ${{ matrix.os }}
-      target_option: ${{ matrix.target_option }}
+      target: ${{ matrix.target }}
 
   test-php:
     uses: ./.github/workflows/test-php.yaml

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -6,7 +6,7 @@ on:
     inputs:
       os:
         type: string
-      target_option:
+      target:
         type: string
         default: ""
 
@@ -25,7 +25,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: wasm-bindgen-cli
-        if: inputs.target_option == '--target=wasm32-unknown-unknown'
+        if: inputs.target== 'wasm32-unknown-unknown'
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-insta
@@ -33,7 +33,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: 0.8.1
-          shared-key: rust-${{ inputs.target_option }}
+          shared-key: rust-${{ inputs.target}}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: 📎 Clippy
         uses: richb-hanover/cargo@v1.1.0
@@ -42,7 +42,7 @@ jobs:
           # Note that `--all-targets` doesn't refer to targets like
           # `wasm32-unknown-unknown`; it refers to lib / bin / tests etc.
           args:
-            --all-targets --all-features ${{ inputs.target_option }} -- -D
+            --all-targets --all-features --target=${{ inputs.target }} -- -D
             warnings
       - name: ⌨️ Fmt
         uses: richb-hanover/cargo@v1.1.0
@@ -73,6 +73,6 @@ jobs:
           # - External DB integration tests — `--features=test-external-dbs`.
           # - Unreferenced snapshots - `--unreferenced=auto`.
           args:
-            test ${{ inputs.target_option }} ${{ inputs.target_option == '' &&
-            inputs.os == 'ubuntu-latest' && '--unreferenced=auto
-            --features=test-external-dbs' || '' }}
+            test ${{ inputs.target}} ${{ inputs.target==
+            'x86_64-unknown-linux-musl' && inputs.os == 'ubuntu-latest' &&
+            '--unreferenced=auto --features=test-external-dbs' || '' }}

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -22,10 +22,15 @@ jobs:
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
+      - if: inputs.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: wasm-bindgen-cli
-        if: inputs.target== 'wasm32-unknown-unknown'
+        if: inputs.target == 'wasm32-unknown-unknown'
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-insta

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-
+      - run: rustup target add ${{ inputs.target }}
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: wasm-bindgen-cli
@@ -78,6 +78,6 @@ jobs:
           # - External DB integration tests — `--features=test-external-dbs`.
           # - Unreferenced snapshots - `--unreferenced=auto`.
           args:
-            test ${{ inputs.target}} ${{ inputs.target==
+            test --target=${{ inputs.target }} ${{ inputs.target==
             'x86_64-unknown-linux-musl' && inputs.os == 'ubuntu-latest' &&
             '--unreferenced=auto --features=test-external-dbs' || '' }}


### PR DESCRIPTION
Using an implicit vs explicit target uses a different cache, even when they're the same
