### PR TITLE
devops: Add `tweak` to semantic prefixes

### DIFF
--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -23,6 +23,7 @@ jobs:
           # - "internal" for code quality / ergonomics improvements
           # - "devops" for developer ergonomics
           # - "web" for playground / website (but not docs)
+          # - "tweak" for tiny changes
           types: |
             feat
             fix
@@ -35,9 +36,11 @@ jobs:
             ci
             chore
             revert
+
             internal
             devops
             web
+            tweak
 
   backport:
     # Backport to `web` branch on `pr-backport-web`


### PR DESCRIPTION
For tiny things that don't need reviews or changelog entries; some projects would bundle these with other things; I often prefer to sumbit them separately & automerge
