### PR TITLE
ci: Use `ci` profile

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -45,7 +45,7 @@ runs:
       with:
         command: build
         args:
-          --package prqlc --profile ${{ inputs.profile }} --locked --target=${{
+          --package=prqlc --profile=${{ inputs.profile }} --locked --target=${{
           inputs.target }}
 
     - name: Create artifact for Linux and macOS

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -23,7 +23,7 @@ runs:
       with:
         # Share cache with `test-rust`
         save-if: false
-        shared-key: rust-${{ inputs.target_option }}
+        shared-key: rust-${{ inputs.target }}
         prefix-key: 0.8.1
 
     - if: runner.os == 'Linux'

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: Build target
     required: true
   profile:
-    description: Build profile option; `dev` or `release`.
+    description: Build profile option; `ci` (similar to `dev`) or `release`.
     required: true
 outputs:
   artifact-name:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -135,15 +135,14 @@ jobs:
       - uses: ./.github/actions/build-prqlc
         with:
           target: ${{ matrix.target }}
-          profile: dev
-    # These are the same env variables as in `test-rust.yaml`. Custom actions
-    # don't allow setting env variables for the whole job, so we do it here. (We
-    # could change the `build-prqlc` action to a workflow...).
+          profile: ci
+    # These are the same env variables as in `test-rust.yaml`, which is required
+    # for cache sharing. Custom actions don't allow setting env variables for
+    # the whole job, so we do it here. (We could change the `build-prqlc` action
+    # to a workflow...).
     env:
       CARGO_TERM_COLOR: always
       CLICOLOR_FORCE: 1
-      # This reduces the size of the cargo cache by ~25%.
-      RUSTFLAGS: "-C debuginfo=0"
 
   automerge-dependabot:
     # This would arguably fit more naturally in `pull-request-target`, but it's

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -36,8 +36,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR_FORCE: 1
-  # This reduces the size of the cargo cache by ~25%.
-  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   build-web:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -13,8 +13,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR_FORCE: 1
-  # This reduces the size of the cargo cache by ~25%.
-  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   test-rust:
@@ -47,8 +45,8 @@ jobs:
           # Note that `--all-targets` doesn't refer to targets like
           # `wasm32-unknown-unknown`; it refers to lib / bin / tests etc.
           args:
-            --all-targets --all-features --target=${{ inputs.target }} -- -D
-            warnings
+            --all-targets --all-features --target=${{ inputs.target }}
+            --profile=ci -- -D warnings
       - name: ⌨️ Fmt
         uses: richb-hanover/cargo@v1.1.0
         with:
@@ -78,6 +76,6 @@ jobs:
           # - External DB integration tests — `--features=test-external-dbs`.
           # - Unreferenced snapshots - `--unreferenced=auto`.
           args:
-            test --target=${{ inputs.target }} ${{ inputs.target==
+            test --profile=ci --target=${{ inputs.target }} ${{ inputs.target==
             'x86_64-unknown-linux-musl' && inputs.os == 'ubuntu-latest' &&
             '--unreferenced=auto --features=test-external-dbs' || '' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,8 @@ opt-level = 3
 [workspace.metadata.release]
 allow-branch = ["*"]
 consolidate-commits = true
+
+# Turn off debuginfo in CI, which saves ~25% of cache space.
+[profile.ci]
+debug = false
+inherits = "dev"


### PR DESCRIPTION
I thought I did this last night, but found this unmerged branch. It seems that the profile overrides the env var, so we need to turn off `debuginfo` in a profile. 

So this switches from using the env vars to a profile