### PR TITLE
ci: set manual trigger for some GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint-megalinter.yaml
+++ b/.github/workflows/lint-megalinter.yaml
@@ -7,6 +7,7 @@ name: lint-megalinter
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 env: # Comment env block if you do not want to apply fixes
   # Apply linter fixes configuration

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/nightly.yaml"
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   cargo-audit:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   # This seems to require a custom suffix; I _think_ because this calls

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -27,6 +27,7 @@ on:
       - ".github/workflows/test-all.yaml"
   # Called by pull-request when specifically requested
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   # See notes in `pull-request.yaml`

--- a/.github/workflows/test-dotnet.yaml
+++ b/.github/workflows/test-dotnet.yaml
@@ -7,6 +7,7 @@ on:
       - "bindings/prql-lib/**"
       - ".github/workflows/test-dotnet.yaml"
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   # See notes in `pull-request.yaml`

--- a/.github/workflows/test-elixir.yaml
+++ b/.github/workflows/test-elixir.yaml
@@ -6,6 +6,7 @@ on:
       - "bindings/prql-elixir/**"
       - ".github/workflows/test-elixir.yaml"
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-elixir

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -7,6 +7,7 @@ on:
       - "bindings/prql-lib/**"
       - ".github/workflows/test-java.yaml"
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-java

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -6,6 +6,7 @@ on:
       - "bindings/prql-js/**"
       - ".github/workflows/test-js.yaml"
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-js

--- a/.github/workflows/test-lib.yaml
+++ b/.github/workflows/test-lib.yaml
@@ -7,6 +7,7 @@ on:
       - "bindings/prql-lib/**"
       - ".github/workflows/test-lib.yaml"
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   # See notes in `pull-request.yaml`

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -7,6 +7,7 @@ on:
       - "bindings/prql-lib/**"
       - ".github/workflows/test-php.yaml"
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   # See notes in `pull-request.yaml`

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -6,6 +6,7 @@ on:
       - "bindings/prql-python/**"
       - ".github/workflows/test-python.yaml"
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   # See notes in `pull-request.yaml`

--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -7,6 +7,7 @@ on:
       - Taskfile.yml
       - .github/workflows/test-taskfile.yaml
   workflow_call:
+  workflow_dispatch:
 
 env:
   RUSTFLAGS: "-C debuginfo=0"


### PR DESCRIPTION
Since GitHubActions does not trigger GitHubActions, I noticed that the duckdb-rs cache was not present in the PR immediately after the duckdb-rs version was raised and the test took a long time in #2804.

In such cases, it would be useful to be able to manually trigger GitHubActions in the main branch to update the cache. It may also be possible to trigger any workflow on any branch without creating a PR, thus avoiding unnecessary test runs.