### PR TITLE
ci: Pass `target` to compile command

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -63,8 +63,9 @@ jobs:
         with:
           command: test
           args:
-            "--no-run --locked ${{ inputs.target == 'x86_64-unknown-linux-gnu'
-            && '--features=test-external-dbs' || '' }}"
+            "--no-run --locked --target=${{ inputs.target }} ${{ inputs.target
+            == 'x86_64-unknown-linux-gnu' && '--features=test-external-dbs' ||
+            '' }}"
       - name: Run docker compose
         run: docker compose up -d
         working-directory: ./prql-compiler/tests/integration


### PR DESCRIPTION
This is causing double compilation at https://github.com/PRQL/prql/actions/runs/5250150964/jobs/9484499860, probably also the reason for the bloat in cache size.
