### PR TITLE
feat: Implement `DISTINCT ON` and `DIV` operator for ClickHouse dialect

### DIFF
--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -245,6 +245,11 @@ impl DialectHandler for ClickHouseDialect {
     fn ident_quote(&self) -> char {
         '`'
     }
+
+    fn supports_distinct_on(&self) -> bool {
+        // https://clickhouse.com/docs/en/sql-reference/statements/select/distinct
+        true
+    }
 }
 
 impl DialectHandler for BigQueryDialect {

--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -115,6 +115,9 @@ module clickhouse {
   @{binding_strength=11}
   let div_f = l r -> s"({l} / {r})"
 
+  @{binding_strength=11}
+  let div_i = l r -> s"({l} DIV {r})"
+
   let regex_search = text pattern -> s"match({text:0}, {pattern:0})"
 }
 


### PR DESCRIPTION
Implement `distinct on` and `DIV` operator for ClickHouse.