### PR TITLE
refactor!: remove the `sql.hive` target

### DIFF
--- a/bindings/prql-elixir/lib/prql.ex
+++ b/bindings/prql-elixir/lib/prql.ex
@@ -16,7 +16,6 @@ defmodule PRQL do
           | :ansi
           | :bigquery
           | :clickhouse
-          | :hive
           | :sqlite
           | :snowflake
   @type format_opt :: {:format, boolean()}
@@ -37,7 +36,7 @@ defmodule PRQL do
 
     * `:target` - Dialect used for generate SQL. Accepted values are
     `:generic`, `:mssql`, `:mysql`, `:postgres`, `:ansi`, `:bigquery`,
-    `:clickhouse`, `:hive`, `:sqlite`, `:snowflake`
+    `:clickhouse`, `:sqlite`, `:snowflake`
 
     * `:format` - Formats the output, defaults to `true`
 

--- a/bindings/prql-elixir/lib/prql/native.ex
+++ b/bindings/prql-elixir/lib/prql/native.ex
@@ -25,7 +25,6 @@ defmodule PRQL.Native.CompileOptions do
           | :ansi
           | :bigquery
           | :clickhouse
-          | :hive
           | :sqlite
           | :snowflake
 

--- a/bindings/prql-elixir/native/prql/src/lib.rs
+++ b/bindings/prql-elixir/native/prql/src/lib.rs
@@ -18,7 +18,6 @@ mod atoms {
       bigquery,
       clickhouse,
       generic,
-      hive,
       mssql,
       mysql,
       postgres,
@@ -53,8 +52,6 @@ fn target_from_atom(a: Atom) -> prql_compiler::Target {
         ClickHouse
     } else if a == atoms::generic() {
         Generic
-    } else if a == atoms::hive() {
-        Hive
     } else if a == atoms::mssql() {
         MsSql
     } else if a == atoms::mysql() {

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -52,7 +52,6 @@ fn test_get_targets() {
     sql.clickhouse
     sql.duckdb
     sql.generic
-    sql.hive
     sql.mssql
     sql.mysql
     sql.postgres

--- a/prql-compiler/src/sql/dialect.rs
+++ b/prql-compiler/src/sql/dialect.rs
@@ -48,7 +48,6 @@ pub enum Dialect {
     DuckDb,
     #[default]
     Generic,
-    Hive,
     MsSql,
     MySql,
     Postgres,
@@ -71,7 +70,7 @@ impl Dialect {
             Dialect::Snowflake => Box::new(SnowflakeDialect),
             Dialect::DuckDb => Box::new(DuckDbDialect),
             Dialect::Postgres => Box::new(PostgresDialect),
-            Dialect::Ansi | Dialect::Generic | Dialect::Hive => Box::new(GenericDialect),
+            Dialect::Ansi | Dialect::Generic => Box::new(GenericDialect),
         }
     }
 
@@ -86,8 +85,6 @@ impl Dialect {
             Dialect::MsSql | Dialect::Ansi | Dialect::BigQuery | Dialect::Snowflake => {
                 SupportLevel::Unsupported
             }
-            // TODO: remove?
-            Dialect::Hive => SupportLevel::Nascent,
         }
     }
 

--- a/prql-compiler/src/sql/std.sql.prql
+++ b/prql-compiler/src/sql/std.sql.prql
@@ -131,11 +131,6 @@ module duckdb {
   let regex_search = text pattern -> s"REGEXP_MATCHES({text:0}, {pattern:0})"
 }
 
-module hive {
-  @{binding_strength=11}
-  let div_f = l r -> s"({l} * 1.0 / {r})"
-}
-
 module mssql {
   @{binding_strength=11}
   let div_f = l r -> s"({l} * 1.0 / {r})"

--- a/web/book/src/language-features/target.md
+++ b/web/book/src/language-features/target.md
@@ -49,7 +49,6 @@ additional dialects.
 - `sql.mssql`
 - `sql.ansi`
 - `sql.bigquery`
-- `sql.hive`
 - `sql.snowflake`
 
 ## Version


### PR DESCRIPTION
From #2831

Since no special features are implemented for the Hive dialect, it probably makes sense to remove this now.

## Note

Remember to update prql-vscode later.
https://github.com/PRQL/prql-vscode/blob/bba543afcbbbd1bc3066cb760e30240d088c5a8a/package.json#L154

-> Done PRQL/prql-vscode#239