### PR TITLE
docs: Update CHANGELOG.md - array & tuple discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ will become the public version at the next release._
 
   We now have Arrays, which use the `[]` syntax.
 
-  We've made this change to incorporate arrays without having syntax that's the
-  opposite of almost every major language — specifically using `{}` for an array
-  type and `[]` for a tuple type. (Though we recognize that `{}` for tuples is
-  also rare (Hi, Erlang!), but didn't want to further load parentheses with
-  meaning)
+  We made this syntax change to incorporate arrays. Almost every major language
+  uses `[]` for arrays. We are adopting that convention, and will use `{}`
+  for tuples. (Though we recognize that `{}` for tuples is also rare (Hi,
+  Erlang!), but didn't want to further load parentheses with meaning.)
+  
+  To convert previous PRQL queries to this new syntax simply change `[ ... ]`
+  to `{ ... }`. 
 
   As part of this, we've also formalized tuples as containing both individual
   items (`select {foo, baz}`), and assignments (`select {foo=bar, baz=fuz}`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ will become the public version at the next release._
   We now have Arrays, which use the `[]` syntax.
 
   We made this syntax change to incorporate arrays. Almost every major language
-  uses `[]` for arrays. We are adopting that convention, and will use `{}`
-  for tuples. (Though we recognize that `{}` for tuples is also rare (Hi,
-  Erlang!), but didn't want to further load parentheses with meaning.)
-  
-  To convert previous PRQL queries to this new syntax simply change `[ ... ]`
-  to `{ ... }`. 
+  uses `[]` for arrays. We are adopting that convention, and will use `{}` for
+  tuples. (Though we recognize that `{}` for tuples is also rare (Hi, Erlang!),
+  but didn't want to further load parentheses with meaning.)
+
+  To convert previous PRQL queries to this new syntax simply change `[ ... ]` to
+  `{ ... }`.
 
   As part of this, we've also formalized tuples as containing both individual
   items (`select {foo, baz}`), and assignments (`select {foo=bar, baz=fuz}`).


### PR DESCRIPTION
I think this explanation/justification for switching from [] to {} is less confusing than the original

Also - are Arrays the same as "Relation Literals"? If so, the latter section should make a bigger nod toward using the new [] syntax.