### PR TITLE
test: use `allow_duplicates` in integration test

### DIFF
--- a/prql-compiler/tests/integration/main.rs
+++ b/prql-compiler/tests/integration/main.rs
@@ -1,6 +1,5 @@
 #![cfg(not(target_family = "wasm"))]
 
-use std::collections::BTreeMap;
 use std::{env, fs};
 
 use anyhow::Context;
@@ -8,7 +7,6 @@ use insta::{assert_snapshot, glob};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use similar_asserts::assert_eq;
 use strum::IntoEnumIterator;
 use tokio::runtime::Runtime;
 
@@ -319,45 +317,35 @@ fn test_rdbms() {
 
         let prql = fs::read_to_string(path).unwrap();
 
-        let mut results = BTreeMap::new();
-        for con in &mut connections {
-            if !con.dialect.should_run_query(&prql) {
-                continue;
+        // for each of the dialects
+        insta::allow_duplicates! {
+            for con in &mut connections {
+                if !con.dialect.should_run_query(&prql) {
+                    continue;
+                }
+                let dialect = con.dialect;
+                let options = Options::default().with_target(Sql(Some(dialect)));
+                let mut rows = prql_compiler::compile(&prql, &options)
+                    .and_then(|sql| Ok(con.protocol.run_query(sql.as_str(), runtime)?))
+                    .context(format!("Executing {test_name} for {dialect}"))
+                    .unwrap();
+
+                // TODO: I think these could possibly be moved to the DbConnection impls
+                replace_booleans(&mut rows);
+                remove_trailing_zeros(&mut rows);
+
+                let result = rows
+                    .iter()
+                    // Make a CSV so it's easier to compare
+                    .map(|r| r.iter().join(","))
+                    .join("\n");
+
+                // Add message so we know which dialect fails. The debug_expr of
+                // the snapshot is `Running on $first_dialect` but hopefully
+                // that's not too confusing.
+                assert_snapshot!("results", &result, &format!("\n# Running on dialect `{}`\n\n{}", &con.dialect, &prql));
             }
-            let dialect = con.dialect;
-            let options = Options::default().with_target(Sql(Some(dialect)));
-            let mut rows = prql_compiler::compile(&prql, &options)
-                .and_then(|sql| Ok(con.protocol.run_query(sql.as_str(), runtime)?))
-                .context(format!("Executing {test_name} for {dialect}"))
-                .unwrap();
-
-            // TODO: I think these could possiblbly be delegated to the DBConnection impls
-            replace_booleans(&mut rows);
-            remove_trailing_zeros(&mut rows);
-
-            let result = rows
-                .iter()
-                // Make a CSV so it's easier to compare
-                .map(|r| r.iter().join(","))
-                .join("\n");
-
-            results.insert(dialect.to_string(), result);
         }
-
-        let (first_dialect, first_result) =
-            results.pop_first().expect("No results for {test_name}");
-
-        // Check the first result against the snapshot
-        assert_snapshot!("results", first_result, &prql);
-
-        // Then check every other result against the first result
-        results.iter().for_each(|(dialect, result)| {
-            assert_eq!(
-                *first_result, *result,
-                "{} == {}: {test_name}",
-                first_dialect, dialect
-            );
-        })
     })
 }
 

--- a/prql-compiler/tests/integration/snapshots/integration__results@pipelines.prql.snap
+++ b/prql-compiler/tests/integration/snapshots/integration__results@pipelines.prql.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/tests/integration/main.rs
-expression: "# skip_mssql (https://github.com/PRQL/prql/issues/2448)\n# skip_mysql (regex not yet implemented)\n# skip_sqlite (regex not yet implemented)\n# booleans cannot be selected directly. instead CASE is needed (https://dba.stackexchange.com/a/2774)\nfrom tracks\n\nfilter (name ~= \"Love\")\nfilter ((milliseconds / 1000 / 60) | in 3..4)\nsort track_id\ntake 1..15\nselect {name, composer}\n"
+expression: "\n# Running on dialect `duckdb`\n\n# sqlite:skip (Only works on Sqlite implementations which have the extension\n# installed\n# https://stackoverflow.com/questions/24037982/how-to-use-regexp-in-sqlite)\n\nfrom tracks\n\nfilter (name ~= \"Love\")\nfilter ((milliseconds / 1000 / 60) | in 3..4)\nsort track_id\ntake 1..15\nselect {name, composer}\n"
 input_file: prql-compiler/tests/integration/queries/pipelines.prql
 ---
 My Love,Jauperi/Zeu Góes
@@ -18,4 +18,3 @@ Loves Been Good To Me,rod mckuen
 Love Or Confusion,Jimi Hendrix
 May This Be Love,Jimi Hendrix
 Do You Love Me,Paul Stanley, Bob Ezrin, Kim Fowley
-


### PR DESCRIPTION
At risk of over-refining this file, this delegates the repeated checking of snapshots to insta
