### PR TITLE
fix(grammars/lezer): update syntax for 0.9.0

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -17,9 +17,9 @@ Pipeline { expr_call (pipe+ expr_call)* }
 
 pipe { "|" | ~ambig_newline newline }
 
-List { "[" newline? list_item (("," newline? ) list_item)* ","? newline? "]" }
+Tuple { "[" newline? tuple_item (("," newline? ) tuple_item)* ","? newline? "]" }
 
-list_item { Assign_call | expr_call | Case_branch }
+tuple_item { Assign_call | expr_call | Case_branch }
 
 expr_call { Expr | Func_call }
 // Ideally we would force a space after `Ident` to prevent an invalid s-string
@@ -29,7 +29,7 @@ expr_call { Expr | Func_call }
 Func_call { Ident ( (Named_arg | Assign | Expr))+ }
 
 // !term is required here, otherwise `[x+emp_no, -3]` is parsed as `x` & `+emp_no`
-term { !term Ident | Number | List | Date | Nested_pipeline | Op_unary term | String | S_string | F_string | Range }
+term { !term Ident | Number | Tuple | Date | Nested_pipeline | Op_unary term | String | S_string | F_string | Range }
 
 // Not quite sure why `!term` is required here
 Expr { !term term (( Op_bin) term)* }

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -65,7 +65,7 @@ Op_bin { Op_bin_only | Op_unary }
   Number { number_part "."? number_part? }
   space { " "+ }
   Comment { "#" ![\n]* }
-  Op_bin_only { "*" | "/" | "%" | "!=" | ">=" | "<=" | "~=" | ">" | "<" | "??" | "&&" | "||" }
+  Op_bin_only { "*" | "/" | "//" | "%" | "!=" | ">=" | "<=" | "~=" | ">" | "<" | "??" | "&&" | "||" }
   Op_unary { "-" | "+" | "==" }
   end { @eof }
   newline { "\n" }

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -17,7 +17,7 @@ Pipeline { expr_call (pipe+ expr_call)* }
 
 pipe { "|" | ~ambig_newline newline }
 
-Tuple { "[" newline? tuple_item (("," newline? ) tuple_item)* ","? newline? "]" }
+Tuple { "{" newline? tuple_item (("," newline? ) tuple_item)* ","? newline? "}" }
 
 tuple_item { Assign_call | expr_call | Case_branch }
 

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -1,5 +1,6 @@
 // TODO:
 // - `case` transform
+// - `Array`
 // - Do we want to highlight built-in transforms like `from` differently to
 //   normal functions?
 // - A few small TODOs included below

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -97,7 +97,7 @@ Op_bin { Op_bin_only | Op_unary }
 
 Table_def { @specialize<ident_part, "let"> ident_part "=" Nested_pipeline ( newline+ | end ) }
 
-Func_def { @specialize<ident_part, "func"> Func_def_name Func_def_param* "->" expr_call ( newline+ | end ) }
+Func_def { @specialize<ident_part, "let"> Func_def_name "=" Func_def_param* "->" expr_call ( newline+ | end ) }
 Type_def { "<" Type_term ( "|" Type_term)* ">" }
 Type_term { ident_part Type_def? }
 Func_def_name { ident_part Type_def? }

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -1,4 +1,6 @@
 // TODO:
+// - Support function definitions
+// - Support relation literals
 // - `case` transform
 // - `Array`
 // - Do we want to highlight built-in transforms like `from` differently to
@@ -8,7 +10,7 @@
 @top Query { Statements }
 @skip { space | Comment }
 
-Statements { newline* Query_def? ( Func_def | Table_def)* Pipeline_stmt? end }
+Statements { newline* Query_def? (Table_def)* Pipeline_stmt? end }
 
 Query_def { @specialize<ident_part, "prql"> Named_arg* newline+ }
 
@@ -97,7 +99,7 @@ Op_bin { Op_bin_only | Op_unary }
 
 Table_def { @specialize<ident_part, "let"> ident_part "=" Nested_pipeline ( newline+ | end ) }
 
-Func_def { @specialize<ident_part, "let"> Func_def_name "=" Func_def_param* "->" expr_call ( newline+ | end ) }
+// Func_def { @specialize<ident_part, "let"> Func_def_name "=" Func_def_param* "->" expr_call ( newline+ | end ) }
 Type_def { "<" Type_term ( "|" Type_term)* ">" }
 Type_term { ident_part Type_def? }
 Func_def_name { ident_part Type_def? }


### PR DESCRIPTION
Part of #2840