### PR TITLE
docs(book): fix footnote for sql.generic target

### DIFF
--- a/web/book/src/language-features/target.md
+++ b/web/book/src/language-features/target.md
@@ -51,26 +51,6 @@ additional dialects.
 - `sql.bigquery`
 - `sql.snowflake`
 
-## Version
-
-PRQL allows specifying a version of the language in the PRQL header, like:
-
-```prql
-prql version:"0.8.1"
-
-from employees
-```
-
-This has two roles, one of which is implemented:
-
-- The compiler will raise an error if the compiler is older than the query
-  version. This prevents confusing errors when queries use newer features of the
-  language but the compiler hasn't yet been upgraded.
-- The compiler will compile for the major version of the query. This allows the
-  language to evolve without breaking existing queries, or forcing multiple
-  installations of the compiler. This isn't yet implemented, but is a gating
-  feature for PRQL 1.0.
-
 ## Priority of targets
 
 The compile target of a query is defined in the query's header or as an argument
@@ -93,3 +73,23 @@ specified in the compiler option.
 echo 'prql target:sql.generic
       from foo' | prqlc compile --target sql.any
 ```
+
+## Version
+
+PRQL allows specifying a version of the language in the PRQL header, like:
+
+```prql
+prql version:"0.8.1"
+
+from employees
+```
+
+This has two roles, one of which is implemented:
+
+- The compiler will raise an error if the compiler is older than the query
+  version. This prevents confusing errors when queries use newer features of the
+  language but the compiler hasn't yet been upgraded.
+- The compiler will compile for the major version of the query. This allows the
+  language to evolve without breaking existing queries, or forcing multiple
+  installations of the compiler. This isn't yet implemented, but is a gating
+  feature for PRQL 1.0.


### PR DESCRIPTION
If the code block is at the end, the footnote does not seem to work correctly.