### PR TITLE
devops: `run-playground` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -297,13 +297,14 @@ tasks:
     desc: Build & serve the playground.
     dir: web/playground
     cmds:
-      - task: install-playground-npm-dependencies
+      - npm install --install-links=false
       - npm start
 
-  run-pg:
-    desc: Serve the playground without building it
+  run-playground-cached:
+    desc: Build & serve the playground, without rebuilding rust code.
     dir: web/playground
     cmds:
+      - task: install-playground-npm-dependencies
       - npm start
 
   install-playground-npm-dependencies:


### PR DESCRIPTION
I hadn't realized that #2801 stopped building the rust code by default. This changes it slightly so running `run-playground-cached` avoids building the rust code.

It removes `run-pg`, since the JS build without the rust build takes just a few seconds
