### PR TITLE
ci: build release artifacts nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -184,3 +184,27 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+
+  build-prqlc:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/build-prqlc
+        with:
+          target: ${{ matrix.target }}
+          profile: release

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -208,3 +208,24 @@ jobs:
         with:
           target: ${{ matrix.target }}
           profile: release
+
+  build-python-wheels:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64
+          - os: ubuntu-latest
+            target: aarch64
+          - os: ubuntu-latest
+            target: source
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v3
+      - name: Build wheel
+        uses: ./.github/actions/build-prql-python
+        with:
+          target: ${{ matrix.target }}

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.7"
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
       - name: Install nox
         run: pipx install nox
         shell: bash

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -23,10 +23,6 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64
-          - os: ubuntu-latest
-            target: aarch64
-          - os: ubuntu-latest
-            target: source
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
@@ -54,13 +50,7 @@ jobs:
           python-version: "3.7"
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
+          python-version: "3.x"
       - name: Install nox
         run: pipx install nox
         shell: bash

--- a/bindings/prql-python/noxfile.py
+++ b/bindings/prql-python/noxfile.py
@@ -8,9 +8,7 @@ from nox.sessions import Session
 
 VERSIONS: List[str] = [
     "3.7",
-    "3.8",
-    "3.9",
-    "3.10",
+    "3.11",
 ]
 
 nox.options.stop_on_first_error = False


### PR DESCRIPTION
ref #2639, PRQL/pyprql#209

Set up nightly builds of prqlc and prql-python wheels to be the same as at the time of release.
Doing this with every push was clearly excessive.