### PR TITLE
chore: bump clio from 0.3.1 to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,10 +764,11 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clio"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f8d4adf1833f1d75ee8b5af282fe742de6631f6741d1b02656c3c5c46b7206"
+checksum = "20a7c15685caad17ac973fde985e95c8a0b7a4206de22f6b5fb58a70f430b2cc"
 dependencies = [
+ "atty",
  "cfg-if",
  "clap 4.3.0",
  "libc",
@@ -2955,7 +2956,6 @@ dependencies = [
  "anstream",
  "anyhow",
  "ariadne",
- "atty",
  "clap 4.3.0",
  "clap_complete_command",
  "clio",

--- a/prql-compiler/prqlc/Cargo.toml
+++ b/prql-compiler/prqlc/Cargo.toml
@@ -14,10 +14,9 @@ metadata.msrv = "1.65.0"
 anstream = {version = "0.3.2", features = ["auto"]}
 anyhow = {version = "1.0.57"}
 ariadne = "0.3.0"
-atty = "0.2.14"
 clap = {version = "4.3.0", features = ["derive", "env", "wrap_help"]}
 clap_complete_command = "0.5.1"
-clio = {version = "0.3.1", features = ['clap-parse']}
+clio = {version = "0.3.3", features = ['clap-parse']}
 color-eyre = "0.6.1"
 colorchoice = "1.0.0"
 colorchoice-clap = "1.0.0"

--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -12,7 +12,6 @@ use std::env;
 use std::io::Read;
 use std::io::Write;
 use std::ops::Range;
-use std::path::Path;
 use std::path::PathBuf;
 use std::process::exit;
 use std::str::FromStr;
@@ -408,7 +407,7 @@ impl Command {
         // Don't wait without a prompt when running `prqlc compile` —
         // it's confusing whether it's waiting for input or not. This
         // offers the prompt.
-        if input.path() == Path::new("-") && atty::is(atty::Stream::Stdin) {
+        if input.is_tty() {
             #[cfg(unix)]
             eprintln!("Enter PRQL, then press ctrl-d to compile:\n");
             #[cfg(windows)]


### PR DESCRIPTION
This bumps clio to version 0.3.2

It needs a rust version bump as clio now use [`PathBuf::as_mut_os_string`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.as_mut_os_string) which is only stablized in 1.70.0.

Clio 0.3.2 added `is_tty()` which means that `atty` goes to being a transative dependency.