### PR TITLE
fix(prqlc): debug ast should be compile with release flag

### DIFF
--- a/prql-compiler/prqlc/src/cli.rs
+++ b/prql-compiler/prqlc/src/cli.rs
@@ -151,7 +151,6 @@ pub enum DebugCommand {
     Annotate(IoArgs),
 
     /// Print info about the AST data structure
-    #[cfg(debug_assertions)]
     Ast,
 }
 


### PR DESCRIPTION
https://github.com/PRQL/prql/pull/2878#discussion_r1235516922

This change fixes build failure in prqlc release build.