### PR TITLE
fix: prqlc compile_help test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: trailing-whitespace
       - id: end-of-file-fixer
         exclude: '(.*\.snap|.*render-link.html|head.hbs)'
       - id: check-yaml

--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -112,13 +112,13 @@ fn compile_help() {
 
     -t, --target <TARGET>
             Target to compile to
-
+            
             [env: PRQLC_TARGET=]
             [default: sql.any]
 
         --color <WHEN>
             Controls when to use color
-
+            
             [default: auto]
             [possible values: auto, always, never]
 


### PR DESCRIPTION
The test introduced in 0d6481633a0be823ed7880af85e16de067031df1 never
worked because a pre-commit hook had automatically stripped the trailing
whitespace. This wasn't spotted in the CI because cargo-insta 1.30.0 has
a bug that it returns exit code 0 even if there's a test failure.[1]

This commit restores the necessary trailing whitespace and disables the
trailing-whitespace pre-commit hook (we already run `cargo fmt` anyway,
which is intelligent enough to preserve trailing whitespace in strings).

[1]: https://github.com/mitsuhiko/insta/issues/392