### PR TITLE
fix(website): download profile images

### DIFF
--- a/web/website/themes/prql-theme/layouts/partials/section-comments.html
+++ b/web/website/themes/prql-theme/layouts/partials/section-comments.html
@@ -53,10 +53,17 @@
                         d="M22.46 6c-.77.35-1.6.58-2.46.69c.88-.53 1.56-1.37 1.88-2.38c-.83.5-1.75.85-2.72 1.05C18.37 4.5 17.26 4 16 4c-2.35 0-4.27 1.92-4.27 4.29c0 .34.04.67.11.98C8.28 9.09 5.11 7.38 3 4.79c-.37.63-.58 1.37-.58 2.15c0 1.49.75 2.81 1.91 3.56c-.71 0-1.37-.2-1.95-.5v.03c0 2.08 1.48 3.82 3.44 4.21a4.22 4.22 0 0 1-1.93.07a4.28 4.28 0 0 0 4 2.98a8.521 8.521 0 0 1-5.33 1.84c-.34 0-.68-.02-1.02-.06C3.44 20.29 5.7 21 8.12 21C16 21 20.33 14.46 20.33 8.79c0-.19 0-.37-.01-.56c.84-.6 1.56-1.36 2.14-2.23Z"
                       ></path>
                     </svg>
-                    <img
-                      class="tweet-author-image"
-                      src="{{ .profile_image_url_https }}"
-                    />
+                    {{/* The Firefox tracking protection blocks images hosted on pbs.twitter.com, see https://bugzilla.mozilla.org/show_bug.cgi?id=1458915
+                      So we just download the images when building the website.
+                    */}}
+                    {{ $imageSrc := (resources.GetRemote "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png" | resources.Copy "default.png").RelPermalink }}
+                    {{ $localImgPath := printf "cached-avatars/%s.png" .screen_name }}
+                    {{ with resources.GetRemote .profile_image_url_https }}
+                      {{ $imageSrc = (resources.Copy $localImgPath .).RelPermalink }}
+                    {{ else }}
+                      {{ warnf "[section-comments.html] couldn't fetch remote image %v" .profile_image_url_https }}
+                    {{ end }}
+                    <img class="tweet-author-image" src="{{ $imageSrc }}" />
                     <div class="tweet-author-info">
                       <p class="tweet-author-name">{{ .name }}</p>
                       <a


### PR DESCRIPTION
The website embeds images from Twitter for the testimonials. The Firefox tracking protection on strict mode apparently blocks these images.[1] This commit adapts the Hugo template to download the images on site build as a workaround.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1458915