### PR TITLE
fix(book): fix illogical sentence

### DIFF
--- a/web/book/src/language-features/s-strings.md
+++ b/web/book/src/language-features/s-strings.md
@@ -1,9 +1,9 @@
 # S-strings
 
 An s-string inserts SQL directly, as an escape hatch when there's something that
-PRQL doesn't yet implement. For example, there's no `version()` function in SQL
-that returns the Postgres version, so if we want to use that, we use an
-s-string:
+PRQL doesn't yet implement. For example, there's a `version()` function in
+PostgreSQL that returns the PostgreSQL version, so if we want to use that, we
+use an s-string:
 
 ```prql
 from my_table


### PR DESCRIPTION
If there is **no** such function in SQL an s-string won't help you.