### PR TITLE
refactor!: clean up the public API

### DIFF
--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use enum_as_inner::EnumAsInner;
 
 use serde::{Deserialize, Serialize};
@@ -497,13 +497,5 @@ impl<T> Default for WindowFrame<T> {
             kind: WindowKind::Rows,
             range: Range::unbounded(),
         }
-    }
-}
-
-impl From<TransformKind> for anyhow::Error {
-    // https://github.com/bluejekyll/enum-as-inner/issues/84
-    #[allow(unreachable_code)]
-    fn from(kind: TransformKind) -> Self {
-        anyhow!("Failed to convert `{kind:?}`")
     }
 }

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -500,14 +500,6 @@ impl<T> Default for WindowFrame<T> {
     }
 }
 
-impl From<ExprKind> for anyhow::Error {
-    // https://github.com/bluejekyll/enum-as-inner/issues/84
-    #[allow(unreachable_code)]
-    fn from(kind: ExprKind) -> Self {
-        anyhow!("Failed to convert `{}`", Expr::from(kind))
-    }
-}
-
 impl From<TransformKind> for anyhow::Error {
     // https://github.com/bluejekyll/enum-as-inner/issues/84
     #[allow(unreachable_code)]

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -227,7 +227,7 @@ pub struct Func {
 }
 
 impl Func {
-    pub fn as_debug_name(&self) -> &str {
+    pub(crate) fn as_debug_name(&self) -> &str {
         let ident = self.name_hint.as_ref();
 
         ident.map(|n| n.name.as_str()).unwrap_or("<anonymous>")

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use enum_as_inner::EnumAsInner;
-use semver::VersionReq;
 
 use serde::{Deserialize, Serialize};
 
@@ -89,15 +88,6 @@ pub enum ExprKind {
     /// When used instead of function body, the function will be translated to a RQ operator.
     /// Contains ident of the RQ operator.
     Internal(String),
-}
-
-impl ExprKind {
-    pub fn parse_version(self) -> std::result::Result<VersionReq, Self> {
-        match self {
-            Self::Literal(Literal::String(ref s)) => VersionReq::parse(s).map_err(|_| self),
-            _ => Err(self),
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -297,13 +297,13 @@ impl<T> Range<T> {
 }
 
 impl Range {
-    pub fn from_ints(start: Option<i64>, end: Option<i64>) -> Self {
+    pub(crate) fn from_ints(start: Option<i64>, end: Option<i64>) -> Self {
         let start = start.map(|x| Box::new(Expr::from(ExprKind::Literal(Literal::Integer(x)))));
         let end = end.map(|x| Box::new(Expr::from(ExprKind::Literal(Literal::Integer(x)))));
         Range { start, end }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         fn as_int(bound: &Option<Box<Expr>>) -> Option<i64> {
             bound
                 .as_ref()

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -461,22 +461,6 @@ impl Expr {
             .with_span(self.span)
         })
     }
-
-    pub fn collect_and(mut exprs: Vec<Expr>) -> Expr {
-        let mut aggregate = if let Some(first) = exprs.pop() {
-            first
-        } else {
-            return Expr::from(ExprKind::Literal(Literal::Boolean(true)));
-        };
-        while let Some(e) = exprs.pop() {
-            aggregate = Expr::from(ExprKind::Binary(BinaryExpr {
-                left: Box::new(e),
-                op: BinOp::And,
-                right: Box::new(aggregate),
-            }))
-        }
-        aggregate
-    }
 }
 
 impl From<ExprKind> for Expr {

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -298,8 +298,8 @@ impl<T> Range<T> {
 
 impl Range {
     pub(crate) fn from_ints(start: Option<i64>, end: Option<i64>) -> Self {
-        let start = start.map(|x| Box::new(Expr::from(ExprKind::Literal(Literal::Integer(x)))));
-        let end = end.map(|x| Box::new(Expr::from(ExprKind::Literal(Literal::Integer(x)))));
+        let start = start.map(|x| Box::new(Expr::new(ExprKind::Literal(Literal::Integer(x)))));
+        let end = end.map(|x| Box::new(Expr::new(ExprKind::Literal(Literal::Integer(x)))));
         Range { start, end }
     }
 
@@ -430,7 +430,7 @@ pub enum JoinSide {
 
 impl Expr {
     pub fn null() -> Expr {
-        Expr::from(ExprKind::Literal(Literal::Null))
+        Expr::new(ExprKind::Literal(Literal::Null))
     }
 
     pub(crate) fn try_cast<T, F, S2: ToString>(
@@ -446,15 +446,15 @@ impl Expr {
             Error::new(Reason::Expected {
                 who: who.map(|s| s.to_string()),
                 expected: expected.to_string(),
-                found: format!("`{}`", Expr::from(i)),
+                found: format!("`{}`", Expr::new(i)),
             })
             .with_span(self.span)
         })
     }
 }
 
-impl From<ExprKind> for Expr {
-    fn from(kind: ExprKind) -> Self {
+impl Expr {
+    pub fn new(kind: ExprKind) -> Self {
         Expr {
             id: None,
             kind,

--- a/prql-compiler/src/ast/pl/expr.rs
+++ b/prql-compiler/src/ast/pl/expr.rs
@@ -433,7 +433,7 @@ impl Expr {
         Expr::from(ExprKind::Literal(Literal::Null))
     }
 
-    pub fn try_cast<T, F, S2: ToString>(
+    pub(crate) fn try_cast<T, F, S2: ToString>(
         self,
         f: F,
         who: Option<&str>,

--- a/prql-compiler/src/ast/pl/utils.rs
+++ b/prql-compiler/src/ast/pl/utils.rs
@@ -5,7 +5,7 @@ pub fn new_binop(left: Option<Expr>, op: BinOp, right: Option<Expr>) -> Option<E
         (Some(left), Some(right)) => {
             let left = Box::new(left);
             let right = Box::new(right);
-            Some(Expr::from(ExprKind::Binary(BinaryExpr { left, op, right })))
+            Some(Expr::new(ExprKind::Binary(BinaryExpr { left, op, right })))
         }
         (left, right) => left.or(right),
     }

--- a/prql-compiler/src/codegen.rs
+++ b/prql-compiler/src/codegen.rs
@@ -695,8 +695,8 @@ mod test {
 
     #[test]
     fn test_pipeline() {
-        let short = pl::Expr::from(pl::ExprKind::Ident(pl::Ident::from_path(vec!["short"])));
-        let long = pl::Expr::from(pl::ExprKind::Ident(pl::Ident::from_path(vec![
+        let short = pl::Expr::new(pl::ExprKind::Ident(pl::Ident::from_path(vec!["short"])));
+        let long = pl::Expr::new(pl::ExprKind::Ident(pl::Ident::from_path(vec![
             "some_module",
             "submodule",
             "a_really_long_name",
@@ -708,13 +708,13 @@ mod test {
         };
 
         // short pipelines should be inlined
-        let pipeline = pl::Expr::from(pl::ExprKind::Pipeline(pl::Pipeline {
+        let pipeline = pl::Expr::new(pl::ExprKind::Pipeline(pl::Pipeline {
             exprs: vec![short.clone(), short.clone(), short.clone()],
         }));
         assert_snapshot!(pipeline.write(opt.clone()).unwrap(), @"(short | short | short)");
 
         // long pipelines should be indented
-        let pipeline = pl::Expr::from(pl::ExprKind::Pipeline(pl::Pipeline {
+        let pipeline = pl::Expr::new(pl::ExprKind::Pipeline(pl::Pipeline {
             exprs: vec![short.clone(), long.clone(), long, short.clone()],
         }));
         // colons are a workaround to avoid trimming
@@ -730,7 +730,7 @@ mod test {
         // sometimes, there is just not enough space
         opt.rem_width = 4;
         opt.indent = 100;
-        let pipeline = pl::Expr::from(pl::ExprKind::Pipeline(pl::Pipeline { exprs: vec![short] }));
+        let pipeline = pl::Expr::new(pl::ExprKind::Pipeline(pl::Pipeline { exprs: vec![short] }));
         assert!(pipeline.write(opt).is_none());
     }
 

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -231,7 +231,7 @@ mod common {
     pub fn into_expr(kind: ExprKind, span: Span) -> Expr {
         Expr {
             span: Some(span),
-            ..Expr::from(kind)
+            ..Expr::new(kind)
         }
     }
 

--- a/prql-compiler/src/semantic/context.rs
+++ b/prql-compiler/src/semantic/context.rs
@@ -301,7 +301,7 @@ impl Context {
         let fq_cols = if module.names.contains_key(NS_INFER) {
             // Columns can be inferred, which means that we don't know all column names at
             // compile time: use ExprKind::All
-            vec![Expr::from(ExprKind::All {
+            vec![Expr::new(ExprKind::All {
                 within: mod_ident.clone(),
                 except: Vec::new(),
             })]
@@ -312,7 +312,7 @@ impl Context {
                 .filter(|(_, decl)| matches!(&decl.kind, DeclKind::Column(_)))
                 .sorted_by_key(|(_, decl)| decl.order)
                 .map(|(name, _)| mod_ident.clone() + Ident::from_name(name))
-                .map(|fq_col| Expr::from(ExprKind::Ident(fq_col)))
+                .map(|fq_col| Expr::new(ExprKind::Ident(fq_col)))
                 .collect_vec()
         };
 
@@ -320,7 +320,7 @@ impl Context {
         // We wrap the expr into DeclKind::Expr and save it into context.
         let cols_expr = Expr {
             flatten: true,
-            ..Expr::from(ExprKind::Tuple(fq_cols))
+            ..Expr::new(ExprKind::Tuple(fq_cols))
         };
         let cols_expr = DeclKind::Expr(Box::new(cols_expr));
         let save_as = "_wildcard_match";

--- a/prql-compiler/src/semantic/eval/mod.rs
+++ b/prql-compiler/src/semantic/eval/mod.rs
@@ -89,7 +89,7 @@ impl AstFold for Evaluator {
                 let mut res = self.fold_expr(pipeline.exprs.remove(0))?;
                 for expr in pipeline.exprs {
                     let func_call =
-                        Expr::from(ExprKind::FuncCall(FuncCall::new_simple(expr, vec![res])));
+                        Expr::new(ExprKind::FuncCall(FuncCall::new_simple(expr, vec![res])));
 
                     res = self.fold_expr(func_call)?;
                 }
@@ -320,7 +320,7 @@ impl Evaluator {
         // restore relation for outer calls
         self.context = prev_relation;
 
-        Ok(Expr::from(ExprKind::Array(output_array)))
+        Ok(Expr::new(ExprKind::Array(output_array)))
     }
 
     fn eval_within_context(&mut self, expr: Expr, context: Expr) -> Result<Expr> {
@@ -366,7 +366,7 @@ fn rows_to_cols(expr: Expr) -> Result<Expr> {
     for field in relation_rows.first().unwrap().kind.as_tuple().unwrap() {
         arg_tuple.push(Expr {
             alias: field.alias.clone(),
-            ..Expr::from(ExprKind::Array(Vec::new()))
+            ..Expr::new(ExprKind::Array(Vec::new()))
         });
     }
 
@@ -378,7 +378,7 @@ fn rows_to_cols(expr: Expr) -> Result<Expr> {
             arg_tuple[index].kind.as_array_mut().unwrap().push(field);
         }
     }
-    Ok(Expr::from(ExprKind::Tuple(arg_tuple)))
+    Ok(Expr::new(ExprKind::Tuple(arg_tuple)))
 }
 
 /// Converts `{a = [1, 2], b = [false, true]}`
@@ -398,14 +398,14 @@ fn cols_to_rows(expr: Expr) -> Result<Expr> {
             })
         }
 
-        rows.push(Expr::from(ExprKind::Tuple(row)));
+        rows.push(Expr::new(ExprKind::Tuple(row)));
     }
 
-    Ok(Expr::from(ExprKind::Array(rows)))
+    Ok(Expr::new(ExprKind::Array(rows)))
 }
 
 fn std_module() -> Expr {
-    Expr::from(ExprKind::Tuple(
+    Expr::new(ExprKind::Tuple(
         [
             new_func("floor", &["x"]),
             new_func("add", &["x", "y"]),
@@ -449,7 +449,7 @@ fn new_func(name: &str, params: &[&str]) -> Expr {
     }));
     Expr {
         alias: Some(name.to_string()),
-        ..Expr::from(kind)
+        ..Expr::new(kind)
     }
 }
 
@@ -462,7 +462,7 @@ fn zip_relations(l: Expr, r: Expr) -> ExprKind {
         let l_fields = l.kind.into_tuple().unwrap();
         let r_fields = r.kind.into_tuple().unwrap();
 
-        res.push(Expr::from(ExprKind::Tuple([l_fields, r_fields].concat())));
+        res.push(Expr::new(ExprKind::Tuple([l_fields, r_fields].concat())));
     }
 
     ExprKind::Array(res)

--- a/prql-compiler/src/semantic/module.rs
+++ b/prql-compiler/src/semantic/module.rs
@@ -424,7 +424,7 @@ mod tests {
         let mut module = Module::default();
 
         let ident = Ident::from_name("test_name");
-        let expr: Expr = ExprKind::Literal(Literal::Integer(42)).into();
+        let expr: Expr = Expr::new(ExprKind::Literal(Literal::Integer(42)));
         let decl: Decl = DeclKind::Expr(Box::new(expr)).into();
 
         assert!(module.insert(ident.clone(), decl.clone()).is_ok());
@@ -442,7 +442,7 @@ mod tests {
         let mut module = Module::default();
 
         let ident = Ident::from_name("test_name");
-        let expr: Expr = ExprKind::Literal(Literal::Integer(42)).into();
+        let expr: Expr = Expr::new(ExprKind::Literal(Literal::Integer(42)));
         let decl: Decl = DeclKind::Expr(Box::new(expr)).into();
 
         module.insert(ident.clone(), decl.clone()).unwrap();

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -1015,7 +1015,11 @@ pub(super) mod test {
             .kind
             .into_transform_call()
             .unwrap_or_else(|e| panic!("Failed to convert `{}`", Expr::from(e)));
-        let exprs = derive.kind.into_derive()?;
+        let exprs = derive
+            .kind
+            .into_derive()
+            .unwrap_or_else(|e| panic!("Failed to convert `{e:?}`"));
+
         let exprs = IdEraser {}.fold_exprs(exprs).unwrap();
         Ok(exprs)
     }

--- a/prql-compiler/src/semantic/resolver.rs
+++ b/prql-compiler/src/semantic/resolver.rs
@@ -1011,7 +1011,10 @@ pub(super) mod test {
 
     fn resolve_derive(query: &str) -> Result<Vec<Expr>> {
         let expr = parse_and_resolve(query)?;
-        let derive = expr.kind.into_transform_call()?;
+        let derive = expr
+            .kind
+            .into_transform_call()
+            .unwrap_or_else(|e| panic!("Failed to convert `{}`", Expr::from(e)));
         let exprs = derive.kind.into_derive()?;
         let exprs = IdEraser {}.fold_exprs(exprs).unwrap();
         Ok(exprs)

--- a/prql-compiler/src/semantic/transforms.rs
+++ b/prql-compiler/src/semantic/transforms.rs
@@ -207,14 +207,14 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
             match pattern.kind {
                 ExprKind::Range(Range { start, end }) => {
                     let start = start.map(|start| {
-                        Expr::from(ExprKind::Binary(BinaryExpr {
+                        Expr::new(ExprKind::Binary(BinaryExpr {
                             left: Box::new(value.clone()),
                             op: BinOp::Gte,
                             right: start,
                         }))
                     });
                     let end = end.map(|end| {
-                        Expr::from(ExprKind::Binary(BinaryExpr {
+                        Expr::new(ExprKind::Binary(BinaryExpr {
                             left: Box::new(value),
                             op: BinOp::Lte,
                             right: end,
@@ -222,8 +222,8 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
                     });
 
                     let res = new_binop(start, BinOp::And, end);
-                    let res = res
-                        .unwrap_or_else(|| Expr::from(ExprKind::Literal(Literal::Boolean(true))));
+                    let res =
+                        res.unwrap_or_else(|| Expr::new(ExprKind::Literal(Literal::Boolean(true))));
                     return Ok(res);
                 }
                 ExprKind::Tuple(_) => {
@@ -252,7 +252,7 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
             for item in list {
                 res = new_binop(res, BinOp::And, Some(item));
             }
-            let res = res.unwrap_or_else(|| Expr::from(ExprKind::Literal(Literal::Boolean(true))));
+            let res = res.unwrap_or_else(|| Expr::new(ExprKind::Literal(Literal::Boolean(true))));
 
             return Ok(res);
         }
@@ -266,7 +266,7 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
             let list_items = list_items
                 .into_iter()
                 .map(|item| {
-                    Expr::from(ExprKind::FuncCall(FuncCall::new_simple(
+                    Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
                         func.clone(),
                         vec![item],
                     )))
@@ -288,10 +288,10 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
 
             let mut res = Vec::new();
             for (a, b) in std::iter::zip(a, b) {
-                res.push(Expr::from(ExprKind::Tuple(vec![a, b])));
+                res.push(Expr::new(ExprKind::Tuple(vec![a, b])));
             }
 
-            return Ok(Expr::from(ExprKind::Tuple(res)));
+            return Ok(Expr::new(ExprKind::Tuple(res)));
         }
 
         "_eq" => {
@@ -357,13 +357,13 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
             let frame =
                 resolver.declare_table_for_literal(expr_id, Some(columns), Some(input_name));
 
-            let res = Expr::from(ExprKind::Array(
+            let res = Expr::new(ExprKind::Array(
                 res.rows
                     .into_iter()
                     .map(|row| {
-                        Expr::from(ExprKind::Tuple(
+                        Expr::new(ExprKind::Tuple(
                             row.into_iter()
-                                .map(|lit| Expr::from(ExprKind::Literal(lit)))
+                                .map(|lit| Expr::new(ExprKind::Literal(lit)))
                                 .collect(),
                         ))
                     })
@@ -392,7 +392,7 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
         frame: WindowFrame::default(),
         sort: Vec::new(),
     };
-    Ok(Expr::from(ExprKind::TransformCall(transform_call)))
+    Ok(Expr::new(ExprKind::TransformCall(transform_call)))
 }
 
 /// Wraps non-tuple Exprs into a singleton Tuple.
@@ -447,10 +447,10 @@ fn fold_by_simulating_eval(
     // thats why we trick the resolver with a dummy node that acts as table
     // chunk and instruct resolver to apply the transform on that.
 
-    let mut dummy = Expr::from(ExprKind::Ident(Ident::from_name(param_name)));
+    let mut dummy = Expr::new(ExprKind::Ident(Ident::from_name(param_name)));
     dummy.lineage = Some(val_lineage);
 
-    let pipeline = Expr::from(ExprKind::FuncCall(FuncCall::new_simple(
+    let pipeline = Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
         pipeline,
         vec![dummy],
     )));
@@ -467,9 +467,9 @@ fn fold_by_simulating_eval(
 
     // extract reference to the dummy node
     // let mut tbl_node = extract_ref_to_first(&mut pipeline);
-    // *tbl_node = Expr::from(ExprKind::Ident("x".to_string()));
+    // *tbl_node = Expr::new(ExprKind::Ident("x".to_string()));
 
-    let pipeline = Expr::from(ExprKind::Func(Box::new(Func {
+    let pipeline = Expr::new(ExprKind::Func(Box::new(Func {
         name_hint: None,
         body: Box::new(pipeline),
         return_ty: None,

--- a/prql-compiler/src/semantic/type_resolver.rs
+++ b/prql-compiler/src/semantic/type_resolver.rs
@@ -118,7 +118,7 @@ fn coerce_kind_to_set(resolver: &mut Resolver, expr: ExprKind) -> Result<Ty> {
 
         _ => {
             return Err(
-                Error::new_simple(format!("not a type expression: {}", Expr::from(expr))).into(),
+                Error::new_simple(format!("not a type expression: {}", Expr::new(expr))).into(),
             )
         }
     })


### PR DESCRIPTION
These are some refactor commits to clean up the public API ... they are breaking changes.

This PR contains 8 commits, you'll want to review the changes commit by commit.
For the reasoning about the `Expr::from` to `Expr::new` change please refer to the last commit message.

I want these commits to be merged *as they are*, that is I **do not** want this PR to be squashed. Let me know if that's ok with you, then I can mark the PR as ready.