### PR TITLE
refactor: move parser tests to parser and `Span` to ast

### DIFF
--- a/prql-compiler/src/ast/mod.rs
+++ b/prql-compiler/src/ast/mod.rs
@@ -2,3 +2,6 @@
 //!
 pub mod pl;
 pub mod rq;
+mod span;
+
+pub use span::Span;

--- a/prql-compiler/src/ast/span.rs
+++ b/prql-compiler/src/ast/span.rs
@@ -1,0 +1,90 @@
+use serde::de::Visitor;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Formatter};
+use std::ops::Range;
+
+#[derive(Clone, PartialEq, Eq, Copy)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+
+    pub source_id: u16,
+}
+
+impl From<Span> for Range<usize> {
+    fn from(a: Span) -> Self {
+        a.start..a.end
+    }
+}
+
+impl Debug for Span {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}-{}", self.source_id, self.start, self.end)
+    }
+}
+
+impl Serialize for Span {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let str = format!("{self:?}");
+        serializer.serialize_str(&str)
+    }
+}
+
+impl<'de> Deserialize<'de> for Span {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct SpanVisitor {}
+
+        impl<'de> Visitor<'de> for SpanVisitor {
+            type Value = Span;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "A span string of form `file_id:x-y`")
+            }
+
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                use serde::de;
+
+                if let Some((file_id, char_span)) = v.split_once(':') {
+                    let file_id = file_id
+                        .parse::<u16>()
+                        .map_err(|e| de::Error::custom(e.to_string()))?;
+
+                    if let Some((start, end)) = char_span.split_once('-') {
+                        let start = start
+                            .parse::<usize>()
+                            .map_err(|e| de::Error::custom(e.to_string()))?;
+                        let end = end
+                            .parse::<usize>()
+                            .map_err(|e| de::Error::custom(e.to_string()))?;
+
+                        return Ok(Span {
+                            start,
+                            end,
+                            source_id: file_id,
+                        });
+                    }
+                }
+
+                Err(de::Error::custom("malformed span"))
+            }
+
+            fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_str(&v)
+            }
+        }
+
+        deserializer.deserialize_string(SpanVisitor {})
+    }
+}

--- a/prql-compiler/src/error.rs
+++ b/prql-compiler/src/error.rs
@@ -2,8 +2,7 @@ use anstream::adapter::strip_str;
 pub use anyhow::Result;
 
 use ariadne::{Cache, Config, Label, Report, ReportKind, Source};
-use serde::de::Visitor;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -13,13 +12,7 @@ use std::{collections::HashMap, io::stderr};
 
 use crate::SourceTree;
 
-#[derive(Clone, PartialEq, Eq, Copy)]
-pub struct Span {
-    pub start: usize,
-    pub end: usize,
-
-    pub source_id: u16,
-}
+pub use crate::ast::Span;
 
 #[derive(Debug, Clone)]
 pub struct Error {
@@ -399,12 +392,6 @@ impl Display for Reason {
     }
 }
 
-impl From<Span> for Range<usize> {
-    fn from(a: Span) -> Self {
-        a.start..a.end
-    }
-}
-
 impl Add<usize> for Span {
     type Output = Span;
 
@@ -460,77 +447,5 @@ impl<T, E: WithErrorInfo> WithErrorInfo for Result<T, E> {
 
     fn push_hint<S: Into<String>>(self, hint: S) -> Self {
         self.map_err(|e| e.push_hint(hint))
-    }
-}
-
-impl Debug for Span {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}-{}", self.source_id, self.start, self.end)
-    }
-}
-
-impl Serialize for Span {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let str = format!("{self:?}");
-        serializer.serialize_str(&str)
-    }
-}
-
-impl<'de> Deserialize<'de> for Span {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct SpanVisitor {}
-
-        impl<'de> Visitor<'de> for SpanVisitor {
-            type Value = Span;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "A span string of form `file_id:x-y`")
-            }
-
-            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                use serde::de;
-
-                if let Some((file_id, char_span)) = v.split_once(':') {
-                    let file_id = file_id
-                        .parse::<u16>()
-                        .map_err(|e| de::Error::custom(e.to_string()))?;
-
-                    if let Some((start, end)) = char_span.split_once('-') {
-                        let start = start
-                            .parse::<usize>()
-                            .map_err(|e| de::Error::custom(e.to_string()))?;
-                        let end = end
-                            .parse::<usize>()
-                            .map_err(|e| de::Error::custom(e.to_string()))?;
-
-                        return Ok(Span {
-                            start,
-                            end,
-                            source_id: file_id,
-                        });
-                    }
-                }
-
-                Err(de::Error::custom("malformed span"))
-            }
-
-            fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                self.visit_str(&v)
-            }
-        }
-
-        deserializer.deserialize_string(SpanVisitor {})
     }
 }

--- a/prql-compiler/src/lib.rs
+++ b/prql-compiler/src/lib.rs
@@ -90,8 +90,9 @@ pub mod sql;
 mod tests;
 mod utils;
 
+pub use ast::Span;
 pub use error::{
-    downcast, Error, ErrorMessage, ErrorMessages, MessageKind, Reason, SourceLocation, Span,
+    downcast, Error, ErrorMessage, ErrorMessages, MessageKind, Reason, SourceLocation,
 };
 
 use once_cell::sync::Lazy;

--- a/prql-compiler/src/parser/mod.rs
+++ b/prql-compiler/src/parser/mod.rs
@@ -2743,4 +2743,43 @@ join s=salaries (==id)
         )
         .unwrap();
     }
+
+    #[test]
+    fn check_valid_version() {
+        let stmt = format!(
+            r#"
+        prql version:"{}"
+        "#,
+            env!("CARGO_PKG_VERSION_MAJOR")
+        );
+        assert!(parse_single(&stmt).is_ok());
+
+        let stmt = format!(
+            r#"
+            prql version:"{}.{}"
+            "#,
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            env!("CARGO_PKG_VERSION_MINOR")
+        );
+        assert!(parse_single(&stmt).is_ok());
+
+        let stmt = format!(
+            r#"
+            prql version:"{}.{}.{}"
+            "#,
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            env!("CARGO_PKG_VERSION_MINOR"),
+            env!("CARGO_PKG_VERSION_PATCH"),
+        );
+        assert!(parse_single(&stmt).is_ok());
+    }
+
+    #[test]
+    fn check_invalid_version() {
+        let stmt = format!(
+            "prql version:{}\n",
+            env!("CARGO_PKG_VERSION_MAJOR").parse::<usize>().unwrap() + 1
+        );
+        assert!(parse_single(&stmt).is_err());
+    }
 }

--- a/prql-compiler/src/semantic/mod.rs
+++ b/prql-compiler/src/semantic/mod.rs
@@ -164,7 +164,7 @@ pub mod test {
     use insta::assert_yaml_snapshot;
 
     use crate::ast::rq::Query;
-    use crate::parser::{parse, parse_single};
+    use crate::parser::parse;
 
     use super::{resolve, resolve_and_lower, Context};
 
@@ -295,44 +295,5 @@ pub mod test {
         "###,
         )
         .is_err());
-    }
-
-    #[test]
-    fn check_valid_version() {
-        let stmt = format!(
-            r#"
-        prql version:"{}"
-        "#,
-            env!("CARGO_PKG_VERSION_MAJOR")
-        );
-        assert!(parse_single(&stmt).is_ok());
-
-        let stmt = format!(
-            r#"
-            prql version:"{}.{}"
-            "#,
-            env!("CARGO_PKG_VERSION_MAJOR"),
-            env!("CARGO_PKG_VERSION_MINOR")
-        );
-        assert!(parse_single(&stmt).is_ok());
-
-        let stmt = format!(
-            r#"
-            prql version:"{}.{}.{}"
-            "#,
-            env!("CARGO_PKG_VERSION_MAJOR"),
-            env!("CARGO_PKG_VERSION_MINOR"),
-            env!("CARGO_PKG_VERSION_PATCH"),
-        );
-        assert!(parse_single(&stmt).is_ok());
-    }
-
-    #[test]
-    fn check_invalid_version() {
-        let stmt = format!(
-            "prql version:{}\n",
-            env!("CARGO_PKG_VERSION_MAJOR").parse::<usize>().unwrap() + 1
-        );
-        assert!(parse_single(&stmt).is_err());
     }
 }


### PR DESCRIPTION
This is the followup PR for #2992. The first 8 commits are from that other PR. This PR will be rebased once the other PR has been merged so that only the last ~6~ 2 commits remain. (this is a workaround since GitHub unfortunately doesn't support stacked PRs)