### PR TITLE
fix(test): skip compile_help test on Windows

### DIFF
--- a/prql-compiler/prqlc/tests/test.rs
+++ b/prql-compiler/prqlc/tests/test.rs
@@ -6,9 +6,7 @@ use std::env::current_dir;
 use std::path::PathBuf;
 use std::process::Command;
 
-// Windows has slightly different outputs (e.g. `prqlc.exe` instead of `prqlc`),
-// so we exclude.
-#[cfg(not(target_family = "windows"))]
+#[cfg(not(windows))] // Windows has slightly different output (e.g. `prqlc.exe`), so we exclude.
 #[test]
 fn help() {
     assert_cmd_snapshot!(prqlc_command().arg("--help"), @r###"
@@ -81,6 +79,7 @@ fn compile() {
     "###);
 }
 
+#[cfg(not(windows))] // Windows has slightly different output (e.g. `prqlc.exe`), so we exclude.
 #[test]
 fn compile_help() {
     let mut cmd = prqlc_command();


### PR DESCRIPTION
This caused the test failure in  #2996.