### PR TITLE
ci: check internal links in mdbook after build

### DIFF
--- a/.github/workflows/check-links-book.yaml
+++ b/.github/workflows/check-links-book.yaml
@@ -5,10 +5,6 @@
 name: check-links-book
 
 on:
-  pull_request:
-    paths:
-      - "web/book/**"
-      - ".github/workflows/check-links-book.yaml"
   workflow_call:
 
 env:
@@ -20,7 +16,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            src:
+              - '.github/workflows/check-links-book.yaml'
+              - 'web/book/**'
+
   check:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-links-book.yaml
+++ b/.github/workflows/check-links-book.yaml
@@ -1,0 +1,53 @@
+# We also have a check-links-markdown job, however it will not spot mdbook
+# mistakes such as forgetting to list an .md file in SUMMARY.md.
+# Running a link checker on the generated HTML is more reliable.
+
+name: check-links-book
+
+on:
+  pull_request:
+    paths:
+      - "web/book/**"
+      - ".github/workflows/check-links-book.yaml"
+  workflow_call:
+
+env:
+  RUSTFLAGS: "-C debuginfo=0"
+
+concurrency:
+  # See notes in `pull-request.yaml`
+  group: ${{ github.workflow }}-${{ github.ref }}-check-links
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: mdbook
+
+      # the link checker
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: hyperlink
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: 0.8.1
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: arduino/setup-task@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build the mdbook
+        run: mdbook build web/book/
+
+      - name: Check links
+        run: hyperlink web/book/book/

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -40,7 +40,7 @@ jobs:
           command: bench
           args: --timings --all-targets
 
-  check-links:
+  check-links-markdown:
     # We run only on modified files and only on our resources in PRs; here we
     # run on all links and all files.
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -73,6 +73,9 @@ jobs:
           # We also run without this in the nightly workflow
           check-modified-files-only: "yes"
 
+  check-links-book:
+    uses: ./.github/workflows/check-links-book.yaml
+
   check-ok-to-merge:
     # This doesn't run anything, but offers a task for us to tell GitHub
     # everything in this workflow has passed and, unlike including each task in
@@ -93,6 +96,7 @@ jobs:
     if: always()
     needs:
       - check-links-markdown
+      - check-links-book
       - lint-megalinter
       - nightly
       - publish-web

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/nightly.yaml
     if: contains(github.event.pull_request.labels.*.name, 'pr-nightly')
 
-  check-links:
+  check-links-markdown:
     # Another option is https://github.com/lycheeverse/lychee, but it was
     # weirdly difficult to exclude a directory, and I managed to get
     # rate-limited by GH because of it scanning node_modules.
@@ -92,7 +92,7 @@ jobs:
     # Check out `test-all.yaml` for more ideas on organizing these.
     if: always()
     needs:
-      - check-links
+      - check-links-markdown
       - lint-megalinter
       - nightly
       - publish-web
@@ -103,10 +103,10 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
-          # We don't include `check-links`, since occasionally we'll want to merge
+          # We don't include `check-links-markdown`, since occasionally we'll want to merge
           # something which temporarily fails that, such as if we're changing the
           # location of a file in this repo which is linked to.
-          allowed-failures: check-links
+          allowed-failures: check-links-markdown
           allowed-skips: test-all, publish-web, nightly
           jobs: ${{ toJSON(needs) }}
 


### PR DESCRIPTION
We already run `markdown-link-check` in our CI, however by virtue of it running against `.md` files it cannot detect links that are broken due to mdbook-specifics (such as forgetting to list the .md file in SUMMARY.md or [the README.md bug](https://github.com/rust-lang/mdBook/issues/984)). I already fixed 5 such broken links in #3017 and #2990 ... we should really detect these broken links in the CI.

This PR therefore adds a new `link-check-book` job to our CI that builds the mdbook and then checks the generated HTML for broken links with the [hyperlink](https://crates.io/crates/hyperlink) link checker.