### PR TITLE
fix(docs): fix two links broken by crate move

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ To stay in touch with PRQL:
 
 This repo is composed of:
 
-- **[prql-compiler](./prql-compiler/)** — the compiler, written in rust, whose
-  main role is to compile PRQL into SQL. It also includes
+- **[prql-compiler](./crates/prql_compiler/)** — the compiler, written in rust,
+  whose main role is to compile PRQL into SQL. It also includes
   [prqlc](./crates/prqlc/), the CLI.
 - **[web](./web/)** — our web content: the [Book][prql book],
   [Website][prql website], and [Playground][prql playground].

--- a/crates/prql_compiler/src/lib.rs
+++ b/crates/prql_compiler/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //!     For compiling whole files (`.prql` to `.sql`), call `prql-compiler`
 //!     from `build.rs`.
-//!     See [this example project](https://github.com/PRQL/prql/tree/main/prql-compiler/examples/compile-files).
+//!     See [this example project](https://github.com/PRQL/prql/tree/main/crates/prql_compiler/examples/compile-files).
 //!
 //! - Compile, format & debug PRQL from command line.
 //!


### PR DESCRIPTION
This commit fixes two links I forgot to update in
ef89bba0ca3f35c5b1cc1aa48cf814fe6ed5d4a4.