### PR TITLE
refactor: make Main a StmtKind in prql_ast

### DIFF
--- a/crates/prql_ast/src/stmt.rs
+++ b/crates/prql_ast/src/stmt.rs
@@ -17,7 +17,6 @@ pub struct QueryDef {
 pub enum VarDefKind {
     Let,
     Into,
-    Main,
 }
 
 // The following code is tested by the tests_misc crate to match stmt.rs in prql_compiler.
@@ -35,6 +34,7 @@ pub struct Stmt {
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Serialize, Deserialize)]
 pub enum StmtKind {
     QueryDef(Box<QueryDef>),
+    Main(Box<Expr>),
     VarDef(VarDef),
     TypeDef(TypeDef),
     ModuleDef(ModuleDef),
@@ -42,7 +42,7 @@ pub enum StmtKind {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct VarDef {
-    pub name: Option<String>,
+    pub name: String,
     pub value: Box<Expr>,
     pub ty_expr: Option<Box<Expr>>,
     pub kind: VarDefKind,

--- a/crates/prql_compiler/src/ast/pl/from_ast.rs
+++ b/crates/prql_compiler/src/ast/pl/from_ast.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use prql_ast::{expr::ExprKind, stmt::StmtKind};
+use prql_ast::{
+    expr::ExprKind,
+    stmt::{StmtKind, VarDefKind},
+};
 
 use crate::ast::pl;
 
@@ -122,11 +125,17 @@ impl From<StmtKind> for pl::StmtKind {
     fn from(value: prql_ast::stmt::StmtKind) -> Self {
         match value {
             StmtKind::QueryDef(v) => Self::QueryDef(v),
+            StmtKind::Main(v) => Self::VarDef(pl::VarDef {
+                name: None,
+                value: map_box_into(v),
+                ty_expr: None,
+                kind: pl::VarDefKind::Main,
+            }),
             StmtKind::VarDef(v) => Self::VarDef(pl::VarDef {
-                name: v.name,
+                name: Some(v.name),
                 value: map_box_into(v.value),
                 ty_expr: v.ty_expr.map(map_box_into),
-                kind: v.kind,
+                kind: v.kind.into(),
             }),
             StmtKind::TypeDef(v) => Self::TypeDef(pl::TypeDef {
                 name: v.name,
@@ -136,6 +145,15 @@ impl From<StmtKind> for pl::StmtKind {
                 name: v.name,
                 stmts: map_vec_into(v.stmts),
             }),
+        }
+    }
+}
+
+impl From<VarDefKind> for pl::VarDefKind {
+    fn from(value: VarDefKind) -> Self {
+        match value {
+            VarDefKind::Let => Self::Let,
+            VarDefKind::Into => Self::Into,
         }
     }
 }

--- a/crates/prql_compiler/src/ast/pl/stmt.rs
+++ b/crates/prql_compiler/src/ast/pl/stmt.rs
@@ -3,9 +3,16 @@ use serde::{Deserialize, Serialize};
 
 use prql_ast::Span;
 
-pub use prql_ast::stmt::{QueryDef, VarDefKind};
+pub use prql_ast::stmt::QueryDef;
 
 use super::expr::Expr;
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub enum VarDefKind {
+    Let,
+    Into,
+    Main,
+}
 
 // The following code is tested by the tests_misc crate to match stmt.rs in prql_ast.
 

--- a/crates/prql_parser/src/lib.rs
+++ b/crates/prql_parser/src/lib.rs
@@ -172,60 +172,48 @@ take 20
 
         assert_yaml_snapshot!(parse_single(r#"take 10"#).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - take
-                args:
-                  - Literal:
-                      Integer: 10
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - take
+              args:
+                - Literal:
+                    Integer: 10
           annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"take ..10"#).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - take
-                args:
-                  - Range:
-                      start: ~
-                      end:
-                        Literal:
-                          Integer: 10
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - take
+              args:
+                - Range:
+                    start: ~
+                    end:
+                      Literal:
+                        Integer: 10
           annotations: []
         "###);
 
         assert_yaml_snapshot!(parse_single(r#"take 1..10"#).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - take
-                args:
-                  - Range:
-                      start:
-                        Literal:
-                          Integer: 1
-                      end:
-                        Literal:
-                          Integer: 10
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - take
+              args:
+                - Range:
+                    start:
+                      Literal:
+                        Integer: 1
+                    end:
+                      Literal:
+                        Integer: 10
           annotations: []
         "###);
     }
@@ -465,18 +453,14 @@ take 20
         select a"#
         ).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - select
-                args:
-                  - Ident:
-                      - a
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - select
+              args:
+                - Ident:
+                    - a
           annotations: []
         "###);
         assert_yaml_snapshot!(parse_expr(
@@ -797,53 +781,45 @@ Canada
         assert_yaml_snapshot!(
             parse_single(r#"filter country == "USA""#).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - filter
-                args:
-                  - Binary:
-                      left:
-                        Ident:
-                          - country
-                      op: Eq
-                      right:
-                        Literal:
-                          String: USA
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - filter
+              args:
+                - Binary:
+                    left:
+                      Ident:
+                        - country
+                    op: Eq
+                    right:
+                      Literal:
+                        String: USA
           annotations: []
         "###);
 
         assert_yaml_snapshot!(
             parse_single(r#"filter (upper country) == "USA""#).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - filter
-                args:
-                  - Binary:
-                      left:
-                        FuncCall:
-                          name:
-                            Ident:
-                              - upper
-                          args:
-                            - Ident:
-                                - country
-                      op: Eq
-                      right:
-                        Literal:
-                          String: USA
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - filter
+              args:
+                - Binary:
+                    left:
+                      FuncCall:
+                        name:
+                          Ident:
+                            - upper
+                        args:
+                          - Ident:
+                              - country
+                    op: Eq
+                    right:
+                      Literal:
+                        String: USA
           annotations: []
         "###
         );
@@ -860,34 +836,30 @@ Canada
         assert_yaml_snapshot!(
             aggregate, @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - group
-                args:
-                  - Tuple:
-                      - Ident:
-                          - title
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - aggregate
-                      args:
-                        - Tuple:
-                            - FuncCall:
-                                name:
-                                  Ident:
-                                    - sum
-                                args:
-                                  - Ident:
-                                      - salary
-                            - Ident:
-                                - count
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - group
+              args:
+                - Tuple:
+                    - Ident:
+                        - title
+                - FuncCall:
+                    name:
+                      Ident:
+                        - aggregate
+                    args:
+                      - Tuple:
+                          - FuncCall:
+                              name:
+                                Ident:
+                                  - sum
+                              args:
+                                - Ident:
+                                    - salary
+                          - Ident:
+                              - count
           annotations: []
         "###);
         let aggregate = parse_single(
@@ -899,32 +871,28 @@ Canada
         assert_yaml_snapshot!(
             aggregate, @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - group
-                args:
-                  - Tuple:
-                      - Ident:
-                          - title
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - aggregate
-                      args:
-                        - Tuple:
-                            - FuncCall:
-                                name:
-                                  Ident:
-                                    - sum
-                                args:
-                                  - Ident:
-                                      - salary
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - group
+              args:
+                - Tuple:
+                    - Ident:
+                        - title
+                - FuncCall:
+                    name:
+                      Ident:
+                        - aggregate
+                    args:
+                      - Tuple:
+                          - FuncCall:
+                              name:
+                                Ident:
+                                  - sum
+                              args:
+                                - Ident:
+                                    - salary
           annotations: []
         "###);
     }
@@ -1233,20 +1201,16 @@ Canada
 
         assert_yaml_snapshot!(parse_single("func return_constant ->  42\n").unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Func:
-                return_ty: ~
-                body:
-                  Literal:
-                    Integer: 42
-                params:
-                  - name: return_constant
-                    default_value: ~
-                named_params: []
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Func:
+              return_ty: ~
+              body:
+                Literal:
+                  Integer: 42
+              params:
+                - name: return_constant
+                  default_value: ~
+              named_params: []
           annotations: []
         "###);
 
@@ -1675,18 +1639,14 @@ Canada
             ty_expr: ~
             kind: Let
           annotations: []
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - from
-                args:
-                  - Ident:
-                      - x
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - from
+              args:
+                - Ident:
+                    - x
           annotations: []
         "###);
     }
@@ -1746,40 +1706,36 @@ Canada
         }
         "#).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - mytable
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - filter
-                      args:
-                        - Tuple:
-                            - Binary:
-                                left:
-                                  Ident:
-                                    - first_name
-                                op: Eq
-                                right:
-                                  Param: "1"
-                            - Binary:
-                                left:
-                                  Ident:
-                                    - last_name
-                                op: Eq
-                                right:
-                                  Param: 2.name
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - mytable
+                - FuncCall:
+                    name:
+                      Ident:
+                        - filter
+                    args:
+                      - Tuple:
+                          - Binary:
+                              left:
+                                Ident:
+                                  - first_name
+                              op: Eq
+                              right:
+                                Param: "1"
+                          - Binary:
+                              left:
+                                Ident:
+                                  - last_name
+                              op: Eq
+                              right:
+                                Param: 2.name
           annotations: []
         "###);
     }
@@ -1810,61 +1766,57 @@ join `my-proj`.`dataset`.`table`
 
         assert_yaml_snapshot!(parse_single(prql).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - a/*.parquet
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - aggregate
-                      args:
-                        - Tuple:
-                            - FuncCall:
-                                name:
-                                  Ident:
-                                    - max
-                                args:
-                                  - Ident:
-                                      - c
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - join
-                      args:
-                        - Ident:
-                            - schema.table
-                        - Unary:
-                            op: EqSelf
-                            expr:
-                              Ident:
-                                - id
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - join
-                      args:
-                        - Ident:
-                            - my-proj.dataset.table
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - join
-                      args:
-                        - Ident:
-                            - my-proj
-                            - dataset
-                            - table
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - a/*.parquet
+                - FuncCall:
+                    name:
+                      Ident:
+                        - aggregate
+                    args:
+                      - Tuple:
+                          - FuncCall:
+                              name:
+                                Ident:
+                                  - max
+                              args:
+                                - Ident:
+                                    - c
+                - FuncCall:
+                    name:
+                      Ident:
+                        - join
+                    args:
+                      - Ident:
+                          - schema.table
+                      - Unary:
+                          op: EqSelf
+                          expr:
+                            Ident:
+                              - id
+                - FuncCall:
+                    name:
+                      Ident:
+                        - join
+                    args:
+                      - Ident:
+                          - my-proj.dataset.table
+                - FuncCall:
+                    name:
+                      Ident:
+                        - join
+                    args:
+                      - Ident:
+                          - my-proj
+                          - dataset
+                          - table
           annotations: []
         "###);
     }
@@ -1880,74 +1832,70 @@ join `my-proj`.`dataset`.`table`
         sort {issued_at, -amount, +num_of_articles}
         ").unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - invoices
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - sort
-                      args:
-                        - Ident:
-                            - issued_at
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - sort
-                      args:
-                        - Unary:
-                            op: Neg
-                            expr:
-                              Ident:
-                                - issued_at
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - sort
-                      args:
-                        - Tuple:
-                            - Ident:
-                                - issued_at
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - sort
-                      args:
-                        - Tuple:
-                            - Unary:
-                                op: Neg
-                                expr:
-                                  Ident:
-                                    - issued_at
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - sort
-                      args:
-                        - Tuple:
-                            - Ident:
-                                - issued_at
-                            - Unary:
-                                op: Neg
-                                expr:
-                                  Ident:
-                                    - amount
-                            - Unary:
-                                op: Add
-                                expr:
-                                  Ident:
-                                    - num_of_articles
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - invoices
+                - FuncCall:
+                    name:
+                      Ident:
+                        - sort
+                    args:
+                      - Ident:
+                          - issued_at
+                - FuncCall:
+                    name:
+                      Ident:
+                        - sort
+                    args:
+                      - Unary:
+                          op: Neg
+                          expr:
+                            Ident:
+                              - issued_at
+                - FuncCall:
+                    name:
+                      Ident:
+                        - sort
+                    args:
+                      - Tuple:
+                          - Ident:
+                              - issued_at
+                - FuncCall:
+                    name:
+                      Ident:
+                        - sort
+                    args:
+                      - Tuple:
+                          - Unary:
+                              op: Neg
+                              expr:
+                                Ident:
+                                  - issued_at
+                - FuncCall:
+                    name:
+                      Ident:
+                        - sort
+                    args:
+                      - Tuple:
+                          - Ident:
+                              - issued_at
+                          - Unary:
+                              op: Neg
+                              expr:
+                                Ident:
+                                  - amount
+                          - Unary:
+                              op: Add
+                              expr:
+                                Ident:
+                                  - num_of_articles
           annotations: []
         "###);
     }
@@ -1959,37 +1907,33 @@ join `my-proj`.`dataset`.`table`
         derive {age_plus_two_years = (age + 2years)}
         ").unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - employees
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - derive
-                      args:
-                        - Tuple:
-                            - Binary:
-                                left:
-                                  Ident:
-                                    - age
-                                op: Add
-                                right:
-                                  Literal:
-                                    ValueAndUnit:
-                                      n: 2
-                                      unit: years
-                              alias: age_plus_two_years
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - employees
+                - FuncCall:
+                    name:
+                      Ident:
+                        - derive
+                    args:
+                      - Tuple:
+                          - Binary:
+                              left:
+                                Ident:
+                                  - age
+                              op: Add
+                              right:
+                                Literal:
+                                  ValueAndUnit:
+                                    n: 2
+                                    unit: years
+                            alias: age_plus_two_years
           annotations: []
         "###);
 
@@ -2023,19 +1967,15 @@ join `my-proj`.`dataset`.`table`
         derive x = r#"r-string test"#
         "###).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - derive
-                args:
-                  - Ident:
-                      - r
-                    alias: x
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - derive
+              args:
+                - Ident:
+                    - r
+                  alias: x
           annotations: []
         "### )
     }
@@ -2047,34 +1987,30 @@ join `my-proj`.`dataset`.`table`
         derive amount = amount ?? 0
         "###).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - employees
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - derive
-                      args:
-                        - Binary:
-                            left:
-                              Ident:
-                                - amount
-                            op: Coalesce
-                            right:
-                              Literal:
-                                Integer: 0
-                          alias: amount
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - employees
+                - FuncCall:
+                    name:
+                      Ident:
+                        - derive
+                    args:
+                      - Binary:
+                          left:
+                            Ident:
+                              - amount
+                          op: Coalesce
+                          right:
+                            Literal:
+                              Integer: 0
+                        alias: amount
           annotations: []
         "### )
     }
@@ -2085,19 +2021,15 @@ join `my-proj`.`dataset`.`table`
         derive x = true
         "###).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - derive
-                args:
-                  - Literal:
-                      Boolean: true
-                    alias: x
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - derive
+              args:
+                - Literal:
+                    Boolean: true
+                  alias: x
           annotations: []
         "###)
     }
@@ -2111,53 +2043,49 @@ join `my-proj`.`dataset`.`table`
         select {_employees._underscored_column}
         "###).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - employees
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - join
-                      args:
-                        - Ident:
-                            - _salary
-                        - Unary:
-                            op: EqSelf
-                            expr:
-                              Ident:
-                                - employee_id
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - filter
-                      args:
-                        - Binary:
-                            left:
-                              Ident:
-                                - first_name
-                            op: Eq
-                            right:
-                              Param: "1"
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - select
-                      args:
-                        - Tuple:
-                            - Ident:
-                                - _employees
-                                - _underscored_column
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - employees
+                - FuncCall:
+                    name:
+                      Ident:
+                        - join
+                    args:
+                      - Ident:
+                          - _salary
+                      - Unary:
+                          op: EqSelf
+                          expr:
+                            Ident:
+                              - employee_id
+                - FuncCall:
+                    name:
+                      Ident:
+                        - filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident:
+                              - first_name
+                          op: Eq
+                          right:
+                            Param: "1"
+                - FuncCall:
+                    name:
+                      Ident:
+                        - select
+                    args:
+                      - Tuple:
+                          - Ident:
+                              - _employees
+                              - _underscored_column
           annotations: []
         "###)
     }
@@ -2172,72 +2100,68 @@ join `my-proj`.`dataset`.`table`
         filter num_eyes < 2
         "###).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - people
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - filter
-                      args:
-                        - Binary:
-                            left:
-                              Ident:
-                                - age
-                            op: Gte
-                            right:
-                              Literal:
-                                Integer: 100
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - filter
-                      args:
-                        - Binary:
-                            left:
-                              Ident:
-                                - num_grandchildren
-                            op: Lte
-                            right:
-                              Literal:
-                                Integer: 10
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - filter
-                      args:
-                        - Binary:
-                            left:
-                              Ident:
-                                - salary
-                            op: Gt
-                            right:
-                              Literal:
-                                Integer: 0
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - filter
-                      args:
-                        - Binary:
-                            left:
-                              Ident:
-                                - num_eyes
-                            op: Lt
-                            right:
-                              Literal:
-                                Integer: 2
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - people
+                - FuncCall:
+                    name:
+                      Ident:
+                        - filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident:
+                              - age
+                          op: Gte
+                          right:
+                            Literal:
+                              Integer: 100
+                - FuncCall:
+                    name:
+                      Ident:
+                        - filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident:
+                              - num_grandchildren
+                          op: Lte
+                          right:
+                            Literal:
+                              Integer: 10
+                - FuncCall:
+                    name:
+                      Ident:
+                        - filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident:
+                              - salary
+                          op: Gt
+                          right:
+                            Literal:
+                              Integer: 0
+                - FuncCall:
+                    name:
+                      Ident:
+                        - filter
+                    args:
+                      - Binary:
+                          left:
+                            Ident:
+                              - num_eyes
+                          op: Lt
+                          right:
+                            Literal:
+                              Integer: 2
           annotations: []
         "###)
     }
@@ -2249,33 +2173,29 @@ from employees
 join s=salaries (==id)
         "###).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Pipeline:
-                exprs:
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - from
-                      args:
-                        - Ident:
-                            - employees
-                  - FuncCall:
-                      name:
-                        Ident:
-                          - join
-                      args:
-                        - Ident:
-                            - salaries
-                          alias: s
-                        - Unary:
-                            op: EqSelf
-                            expr:
-                              Ident:
-                                - id
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Pipeline:
+              exprs:
+                - FuncCall:
+                    name:
+                      Ident:
+                        - from
+                    args:
+                      - Ident:
+                          - employees
+                - FuncCall:
+                    name:
+                      Ident:
+                        - join
+                    args:
+                      - Ident:
+                          - salaries
+                        alias: s
+                      - Unary:
+                          op: EqSelf
+                          expr:
+                            Ident:
+                              - id
           annotations: []
         "###);
     }
@@ -2355,18 +2275,14 @@ join s=salaries (==id)
         let source = "from tète";
         assert_yaml_snapshot!(parse_single(source).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              FuncCall:
-                name:
-                  Ident:
-                    - from
-                args:
-                  - Ident:
-                      - tète
-            ty_expr: ~
-            kind: Main
+        - Main:
+            FuncCall:
+              name:
+                Ident:
+                  - from
+              args:
+                - Ident:
+                    - tète
           annotations: []
         "###);
     }
@@ -2408,13 +2324,9 @@ join s=salaries (==id)
         x
         "#).unwrap(), @r###"
         ---
-        - VarDef:
-            name: ~
-            value:
-              Ident:
-                - x
-            ty_expr: ~
-            kind: Main
+        - Main:
+            Ident:
+              - x
           annotations: []
         "###);
     }

--- a/crates/prql_parser/src/snapshots/prql_parser__test__pipeline_parse_tree.snap
+++ b/crates/prql_parser/src/snapshots/prql_parser__test__pipeline_parse_tree.snap
@@ -1,164 +1,160 @@
 ---
-source: prql-compiler/src/parser/prql_parser/mod.rs
+source: crates/prql_parser/src/lib.rs
 expression: "parse_single(r#\"\nfrom employees\nfilter country == \"USA\"                      # Each line transforms the previous result.\nderive {                                     # This adds columns / variables.\n  gross_salary = salary + payroll_tax,\n  gross_cost = gross_salary + benefits_cost  # Variables can use other variables.\n}\nfilter gross_cost > 0\ngroup {title, country} (                     # For each group use a nested pipeline\n  aggregate {                                # Aggregate each group to a single row\n    average salary,\n    average gross_salary,\n    sum salary,\n    sum gross_salary,\n    average gross_cost,\n    sum_gross_cost = sum gross_cost,\n    ct = count salary,\n  }\n)\nsort sum_gross_cost\nfilter ct > 200\ntake 20\n        \"#).unwrap()"
 ---
-- VarDef:
-    name: ~
-    value:
-      Pipeline:
-        exprs:
-          - FuncCall:
-              name:
-                Ident:
-                  - from
-              args:
-                - Ident:
-                    - employees
-          - FuncCall:
-              name:
-                Ident:
-                  - filter
-              args:
-                - Binary:
-                    left:
-                      Ident:
-                        - country
-                    op: Eq
-                    right:
-                      Literal:
-                        String: USA
-          - FuncCall:
-              name:
-                Ident:
-                  - derive
-              args:
-                - Tuple:
-                    - Binary:
-                        left:
-                          Ident:
-                            - salary
-                        op: Add
-                        right:
-                          Ident:
-                            - payroll_tax
-                      alias: gross_salary
-                    - Binary:
-                        left:
-                          Ident:
-                            - gross_salary
-                        op: Add
-                        right:
-                          Ident:
-                            - benefits_cost
-                      alias: gross_cost
-          - FuncCall:
-              name:
-                Ident:
-                  - filter
-              args:
-                - Binary:
-                    left:
-                      Ident:
-                        - gross_cost
-                    op: Gt
-                    right:
-                      Literal:
-                        Integer: 0
-          - FuncCall:
-              name:
-                Ident:
-                  - group
-              args:
-                - Tuple:
-                    - Ident:
-                        - title
-                    - Ident:
-                        - country
-                - FuncCall:
-                    name:
-                      Ident:
-                        - aggregate
-                    args:
-                      - Tuple:
-                          - FuncCall:
-                              name:
-                                Ident:
-                                  - average
-                              args:
-                                - Ident:
-                                    - salary
-                          - FuncCall:
-                              name:
-                                Ident:
-                                  - average
-                              args:
-                                - Ident:
-                                    - gross_salary
-                          - FuncCall:
-                              name:
-                                Ident:
-                                  - sum
-                              args:
-                                - Ident:
-                                    - salary
-                          - FuncCall:
-                              name:
-                                Ident:
-                                  - sum
-                              args:
-                                - Ident:
-                                    - gross_salary
-                          - FuncCall:
-                              name:
-                                Ident:
-                                  - average
-                              args:
-                                - Ident:
-                                    - gross_cost
-                          - FuncCall:
-                              name:
-                                Ident:
-                                  - sum
-                              args:
-                                - Ident:
-                                    - gross_cost
-                            alias: sum_gross_cost
-                          - FuncCall:
-                              name:
-                                Ident:
-                                  - count
-                              args:
-                                - Ident:
-                                    - salary
-                            alias: ct
-          - FuncCall:
-              name:
-                Ident:
-                  - sort
-              args:
-                - Ident:
-                    - sum_gross_cost
-          - FuncCall:
-              name:
-                Ident:
-                  - filter
-              args:
-                - Binary:
-                    left:
-                      Ident:
-                        - ct
-                    op: Gt
-                    right:
-                      Literal:
-                        Integer: 200
-          - FuncCall:
-              name:
-                Ident:
-                  - take
-              args:
-                - Literal:
-                    Integer: 20
-    ty_expr: ~
-    kind: Main
+- Main:
+    Pipeline:
+      exprs:
+        - FuncCall:
+            name:
+              Ident:
+                - from
+            args:
+              - Ident:
+                  - employees
+        - FuncCall:
+            name:
+              Ident:
+                - filter
+            args:
+              - Binary:
+                  left:
+                    Ident:
+                      - country
+                  op: Eq
+                  right:
+                    Literal:
+                      String: USA
+        - FuncCall:
+            name:
+              Ident:
+                - derive
+            args:
+              - Tuple:
+                  - Binary:
+                      left:
+                        Ident:
+                          - salary
+                      op: Add
+                      right:
+                        Ident:
+                          - payroll_tax
+                    alias: gross_salary
+                  - Binary:
+                      left:
+                        Ident:
+                          - gross_salary
+                      op: Add
+                      right:
+                        Ident:
+                          - benefits_cost
+                    alias: gross_cost
+        - FuncCall:
+            name:
+              Ident:
+                - filter
+            args:
+              - Binary:
+                  left:
+                    Ident:
+                      - gross_cost
+                  op: Gt
+                  right:
+                    Literal:
+                      Integer: 0
+        - FuncCall:
+            name:
+              Ident:
+                - group
+            args:
+              - Tuple:
+                  - Ident:
+                      - title
+                  - Ident:
+                      - country
+              - FuncCall:
+                  name:
+                    Ident:
+                      - aggregate
+                  args:
+                    - Tuple:
+                        - FuncCall:
+                            name:
+                              Ident:
+                                - average
+                            args:
+                              - Ident:
+                                  - salary
+                        - FuncCall:
+                            name:
+                              Ident:
+                                - average
+                            args:
+                              - Ident:
+                                  - gross_salary
+                        - FuncCall:
+                            name:
+                              Ident:
+                                - sum
+                            args:
+                              - Ident:
+                                  - salary
+                        - FuncCall:
+                            name:
+                              Ident:
+                                - sum
+                            args:
+                              - Ident:
+                                  - gross_salary
+                        - FuncCall:
+                            name:
+                              Ident:
+                                - average
+                            args:
+                              - Ident:
+                                  - gross_cost
+                        - FuncCall:
+                            name:
+                              Ident:
+                                - sum
+                            args:
+                              - Ident:
+                                  - gross_cost
+                          alias: sum_gross_cost
+                        - FuncCall:
+                            name:
+                              Ident:
+                                - count
+                            args:
+                              - Ident:
+                                  - salary
+                          alias: ct
+        - FuncCall:
+            name:
+              Ident:
+                - sort
+            args:
+              - Ident:
+                  - sum_gross_cost
+        - FuncCall:
+            name:
+              Ident:
+                - filter
+            args:
+              - Binary:
+                  left:
+                    Ident:
+                      - ct
+                  op: Gt
+                  right:
+                    Literal:
+                      Integer: 200
+        - FuncCall:
+            name:
+              Ident:
+                - take
+            args:
+              - Literal:
+                  Integer: 20
   annotations: []
 

--- a/crates/prql_parser/src/stmt.rs
+++ b/crates/prql_parser/src/stmt.rs
@@ -108,7 +108,7 @@ fn var_def() -> impl Parser<Token, (Vec<Annotation>, StmtKind), Error = PError> 
         .then(expr_call().map(Box::new))
         .map(|((name, ty_expr), value)| {
             StmtKind::VarDef(VarDef {
-                name: Some(name),
+                name,
                 value,
                 ty_expr,
                 kind: VarDefKind::Let,
@@ -119,17 +119,14 @@ fn var_def() -> impl Parser<Token, (Vec<Annotation>, StmtKind), Error = PError> 
     let main_or_into = pipeline(expr_call())
         .map(Box::new)
         .then(keyword("into").ignore_then(ident_part()).or_not())
-        .map(|(value, name)| {
-            let kind = match &name {
-                None => VarDefKind::Main,
-                Some(_) => VarDefKind::Into,
-            };
-            StmtKind::VarDef(VarDef {
+        .map(|(value, name)| match name {
+            None => StmtKind::Main(value),
+            Some(name) => StmtKind::VarDef(VarDef {
                 name,
                 value,
                 ty_expr: None,
-                kind,
-            })
+                kind: VarDefKind::Into,
+            }),
         })
         .labelled("variable definition");
 

--- a/crates/tests_misc/tests/ast_code_matches.rs
+++ b/crates/tests_misc/tests/ast_code_matches.rs
@@ -31,7 +31,13 @@ fn test_stmt_ast_code_matches() {
         diff_code_after_start(
             &read_to_string("../../crates/prql_ast/src/stmt.rs").unwrap(),
             &read_to_string("../../crates/prql_compiler/src/ast/pl/stmt.rs").unwrap(),
-        ), @""
+        ), @r###"
+    @@ .. @@
+    -    Main(Box<Expr>),
+    @@ .. @@
+    -    pub name: String,
+    +    pub name: Option<String>,
+    "###
     )
 }
 


### PR DESCRIPTION
The types in prql_ast should model the language as closely as possible. You can never specify a name or a type for a main statement, so it should not use the VarDef struct in prql_ast. Moving the Main variant from VarDefKind to StmtKind also lets us make name in VarDef required.