### PR TITLE
doc: Fix warnings on `cargo doc`

### DIFF
--- a/crates/prql_compiler/src/ast/pl/mod.rs
+++ b/crates/prql_compiler/src/ast/pl/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! The central struct here is [Expr] and its [ExprKind].
 //!
-//! Top-level construct is a list of statements [Vec<Stmt>].
+//! Top-level construct is a list of statements [`Vec<Stmt>`].
 
 pub mod expr;
 pub mod extra;

--- a/crates/prql_compiler/src/sql/srq/mod.rs
+++ b/crates/prql_compiler/src/sql/srq/mod.rs
@@ -3,8 +3,8 @@
 //! This in an internal intermediate representation between RQ and SQL AST.
 //!
 //! For example, RQ does not have a separate node for DISTINCT, but uses [crate::ast::rq::Take] 1 with
-//! `partition`. In [super::preprocess] module, [crate::ast::rq::Transform] take is wrapped into
-//! [SqlTransform], which does have [SqlTransform::Distinct].
+//! `partition`. In [super::srq::preprocess] module, [crate::ast::rq::Transform] take is wrapped into
+//! [ast::SqlTransform], which does have [`ast::SqlTransform::Distinct`].
 //!
 //! This module also contains the compiler from RQ to SRQ.
 


### PR DESCRIPTION
Should we have a test for these? We've put less focus into our rust docs relative to our PRQL docs, given PRQL isn't really a library, but having refined docs would still be welcome.
