### PR TITLE
revert: #3003

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,16 +13,6 @@ updates:
     commit-message:
       prefix: "chore: "
 
-  # Every month, bump all patch versions of rust dependencies too
-  - package-ecosystem: cargo
-    directory: "/"
-    schedule:
-      interval: monthly
-    groups:
-      all:
-        patterns:
-          - "*"
-
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Reverts PRQL/prql#3003 — we actually can't have a separate grouped job for patch versions. 

So I guess we keep the status quo 

Otherwise everything gets grouped, and that makes working through a specific dependency change difficult.