### PR TITLE
refactor: privatize Resolver struct 

### DIFF
--- a/crates/prql_compiler/src/semantic/context.rs
+++ b/crates/prql_compiler/src/semantic/context.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, fmt::Debug};
 use super::*;
 use crate::ast::pl::*;
 use crate::error::Span;
+use crate::utils::IdGenerator;
 
 /// Context of the pipeline.
 #[derive(Default, Clone)]
@@ -14,6 +15,8 @@ pub struct Context {
     pub(crate) root_mod: Module,
 
     pub(crate) span_map: HashMap<usize, Span>,
+
+    pub(crate) id: IdGenerator<usize>,
 }
 
 /// A struct containing information about a single declaration.

--- a/crates/prql_compiler/src/semantic/context.rs
+++ b/crates/prql_compiler/src/semantic/context.rs
@@ -8,7 +8,7 @@ use crate::ast::pl::*;
 use crate::error::Span;
 
 /// Context of the pipeline.
-#[derive(Default, Serialize, Deserialize, Clone)]
+#[derive(Default, Clone)]
 pub struct Context {
     /// Map of all accessible names (for each namespace)
     pub(crate) root_mod: Module,

--- a/crates/prql_compiler/src/semantic/mod.rs
+++ b/crates/prql_compiler/src/semantic/mod.rs
@@ -51,7 +51,7 @@ pub fn resolve(mut file_tree: SourceTree<Vec<Stmt>>, options: ResolverOptions) -
         root_mod: Module::new_root(),
         ..Context::default()
     };
-    let mut resolver = Resolver::new(&mut context, options);
+    let mut resolver = Resolver::new(&mut context, &options);
 
     // resolve sources one by one
     // TODO: recursive references

--- a/crates/prql_compiler/src/semantic/mod.rs
+++ b/crates/prql_compiler/src/semantic/mod.rs
@@ -14,7 +14,6 @@ use std::path::PathBuf;
 
 pub use self::context::Context;
 pub use self::module::Module;
-use self::resolver::Resolver;
 pub use self::resolver::ResolverOptions;
 pub use eval::eval;
 pub use lowering::lower_to_ir;
@@ -51,13 +50,11 @@ pub fn resolve(mut file_tree: SourceTree<Vec<Stmt>>, options: ResolverOptions) -
         root_mod: Module::new_root(),
         ..Context::default()
     };
-    let mut resolver = Resolver::new(&mut context, &options);
 
     // resolve sources one by one
     // TODO: recursive references
     for (path, stmts) in normalize(file_tree)? {
-        resolver.current_module_path = path;
-        resolver.fold_statements(stmts)?;
+        resolver::resolve(&mut context, path, stmts, &options)?;
     }
 
     Ok(context)

--- a/crates/prql_compiler/src/semantic/mod.rs
+++ b/crates/prql_compiler/src/semantic/mod.rs
@@ -47,11 +47,11 @@ pub fn resolve(mut file_tree: SourceTree<Vec<Stmt>>, options: ResolverOptions) -
     }
 
     // init empty context
-    let context = Context {
+    let mut context = Context {
         root_mod: Module::new_root(),
         ..Context::default()
     };
-    let mut resolver = Resolver::new(context, options);
+    let mut resolver = Resolver::new(&mut context, options);
 
     // resolve sources one by one
     // TODO: recursive references
@@ -60,7 +60,7 @@ pub fn resolve(mut file_tree: SourceTree<Vec<Stmt>>, options: ResolverOptions) -
         resolver.fold_statements(stmts)?;
     }
 
-    Ok(resolver.context)
+    Ok(context)
 }
 
 /// Preferred way of injecting std module.

--- a/crates/prql_compiler/src/semantic/resolver/mod.rs
+++ b/crates/prql_compiler/src/semantic/resolver/mod.rs
@@ -9,7 +9,6 @@ use crate::ast::pl::{fold::*, *};
 use crate::error::{Error, Reason, Span, WithErrorInfo};
 use crate::semantic::context::TableDecl;
 use crate::semantic::{static_analysis, NS_PARAM};
-use crate::utils::IdGenerator;
 
 use super::context::{Context, Decl, DeclKind, TableExpr};
 use super::module::Module;
@@ -35,8 +34,6 @@ pub struct Resolver<'a> {
 
     disable_type_checking: bool,
 
-    pub id: IdGenerator<usize>,
-
     pub options: &'a ResolverOptions,
 }
 
@@ -54,14 +51,13 @@ impl<'a> Resolver<'a> {
             default_namespace: None,
             in_func_call_name: false,
             disable_type_checking: false,
-            id: IdGenerator::new(),
         }
     }
 
     // entry point
     pub fn fold_statements(&mut self, stmts: Vec<Stmt>) -> Result<()> {
         for mut stmt in stmts {
-            stmt.id = Some(self.id.gen());
+            stmt.id = Some(self.context.id.gen());
             if let Some(span) = stmt.span {
                 self.context.span_map.insert(stmt.id.unwrap(), span);
             }
@@ -275,7 +271,7 @@ impl AstFold for Resolver<'_> {
             return Ok(node);
         }
 
-        let id = self.id.gen();
+        let id = self.context.id.gen();
         let alias = node.alias.clone();
         let span = node.span;
 

--- a/crates/prql_compiler/src/semantic/resolver/mod.rs
+++ b/crates/prql_compiler/src/semantic/resolver/mod.rs
@@ -37,7 +37,7 @@ pub struct Resolver<'a> {
 
     pub id: IdGenerator<usize>,
 
-    pub options: ResolverOptions,
+    pub options: &'a ResolverOptions,
 }
 
 #[derive(Default, Clone)]
@@ -45,8 +45,8 @@ pub struct ResolverOptions {
     pub allow_module_decls: bool,
 }
 
-impl Resolver<'_> {
-    pub fn new(context: &mut Context, options: ResolverOptions) -> Resolver {
+impl<'a> Resolver<'a> {
+    pub fn new(context: &'a mut Context, options: &'a ResolverOptions) -> Resolver<'a> {
         Resolver {
             context,
             options,

--- a/crates/prql_compiler/src/semantic/resolver/mod.rs
+++ b/crates/prql_compiler/src/semantic/resolver/mod.rs
@@ -21,8 +21,18 @@ mod context_impl;
 mod transforms;
 mod type_resolver;
 
+pub fn resolve(
+    context: &mut Context,
+    module_path: Vec<String>,
+    stmts: Vec<Stmt>,
+    options: &ResolverOptions,
+) -> Result<()> {
+    let mut resolver = Resolver::new(context, module_path, options);
+    resolver.fold_statements(stmts)
+}
+
 /// Can fold (walk) over AST and for each function call or variable find what they are referencing.
-pub struct Resolver<'a> {
+struct Resolver<'a> {
     context: &'a mut Context,
 
     pub current_module_path: Vec<String>,
@@ -43,11 +53,15 @@ pub struct ResolverOptions {
 }
 
 impl<'a> Resolver<'a> {
-    pub fn new(context: &'a mut Context, options: &'a ResolverOptions) -> Resolver<'a> {
+    pub fn new(
+        context: &'a mut Context,
+        module_path: Vec<String>,
+        options: &'a ResolverOptions,
+    ) -> Resolver<'a> {
         Resolver {
             context,
             options,
-            current_module_path: Vec::new(),
+            current_module_path: module_path,
             default_namespace: None,
             in_func_call_name: false,
             disable_type_checking: false,

--- a/crates/prql_compiler/src/semantic/resolver/transforms.rs
+++ b/crates/prql_compiler/src/semantic/resolver/transforms.rs
@@ -460,7 +460,7 @@ fn fold_by_simulating_eval(
     log::debug!("fold by simulating evaluation");
 
     let param_name = "_tbl";
-    let param_id = resolver.id.gen();
+    let param_id = resolver.context.id.gen();
 
     // resolver will not resolve a function call if any arguments are missing
     // but would instead return a closure to be resolved later.

--- a/crates/prql_compiler/src/semantic/resolver/transforms.rs
+++ b/crates/prql_compiler/src/semantic/resolver/transforms.rs
@@ -18,7 +18,7 @@ use super::{Context, Lineage};
 use super::{NS_PARAM, NS_THIS};
 
 /// try to convert function call with enough args into transform
-pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
+pub(super) fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
     let internal_name = closure.body.kind.as_internal().unwrap();
 
     let (kind, input) = match internal_name.as_str() {

--- a/crates/prql_compiler/src/semantic/resolver/type_resolver.rs
+++ b/crates/prql_compiler/src/semantic/resolver/type_resolver.rs
@@ -187,7 +187,7 @@ pub fn infer_type(node: &Expr) -> Result<Option<Ty>> {
     Ok(Some(Ty { kind, name: None }))
 }
 
-impl Resolver {
+impl Resolver<'_> {
     /// Validates that found node has expected type. Returns assumed type of the node.
     pub fn validate_type<F>(
         &mut self,

--- a/crates/prql_compiler/src/semantic/resolver/type_resolver.rs
+++ b/crates/prql_compiler/src/semantic/resolver/type_resolver.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Reason, WithErrorInfo};
 use super::Resolver;
 
 /// Takes a resolved [Expr] and evaluates it a type expression that can be used to construct a type.
-pub fn coerce_to_type(resolver: &mut Resolver, expr: Expr) -> Result<Ty> {
+pub(super) fn coerce_to_type(resolver: &mut Resolver, expr: Expr) -> Result<Ty> {
     coerce_kind_to_set(resolver, expr.kind)
 }
 


### PR DESCRIPTION
Previously you had to use the Resolver as follows:

    let mut resolver = Resolver::new(context, options);
    resolver.current_module_path = path;
    resolver.fold_statements(stmts)?;
    let new_context = resolver.context;

This API is problematic since you could forget to set the current module
path and it's not at all obvious that you're supposed to access .context
after calling fold_statements. In this and the following four commits
we will simplify the API to:

    resolve(&mut context, path, stmts &options)?;