### PR TITLE
ci: pin the megalinter patch version in GitHub Actions

### DIFF
--- a/.github/workflows/lint-megalinter.yaml
+++ b/.github/workflows/lint-megalinter.yaml
@@ -33,7 +33,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter@v7
+        uses: oxsecurity/megalinter@v7.2.0
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/


### PR DESCRIPTION
Related to #3055

megalinter sometimes adds new linters and the new linters may through error.
By pinning the patch version, the timing of new linter additions can be limited to PR by dependabot.