### PR TITLE
feat: partial application

### DIFF
--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
@@ -10,12 +10,12 @@ columns:
       input_name: customers
       except: []
 inputs:
-  - id: 182
+  - id: 193
     name: table_1
     table:
       - default_db
       - table_1
-  - id: 194
+  - id: 186
     name: customers
     table:
       - default_db

--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
@@ -7,26 +7,26 @@ columns:
       name:
         - e
         - emp_no
-      target_id: 221
+      target_id: 220
       target_name: ~
   - Single:
       name:
         - e
         - gender
-      target_id: 222
+      target_id: 221
       target_name: ~
   - Single:
       name:
         - emp_salary
-      target_id: 247
+      target_id: 246
       target_name: ~
 inputs:
-  - id: 182
+  - id: 215
     name: e
     table:
       - default_db
       - employees
-  - id: 216
+  - id: 208
     name: salaries
     table:
       - default_db

--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
@@ -7,26 +7,26 @@ columns:
       name:
         - orders
         - customer_no
-      target_id: 212
+      target_id: 211
       target_name: ~
   - Single:
       name:
         - orders
         - gross
-      target_id: 213
+      target_id: 212
       target_name: ~
   - Single:
       name:
         - orders
         - tax
-      target_id: 214
+      target_id: 213
       target_name: ~
   - Single:
       name: ~
-      target_id: 216
+      target_id: 215
       target_name: ~
 inputs:
-  - id: 182
+  - id: 210
     name: orders
     table:
       - default_db

--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
@@ -21,7 +21,7 @@ TransformCall:
             input_name: c_invoice
             except: []
       inputs:
-        - id: 182
+        - id: 203
           name: c_invoice
           table:
             - default_db
@@ -185,14 +185,14 @@ lineage:
         name:
           - c_invoice
           - issued_at
-        target_id: 205
+        target_id: 204
         target_name: ~
     - Single:
         name: ~
-        target_id: 229
+        target_id: 228
         target_name: ~
   inputs:
-    - id: 182
+    - id: 203
       name: c_invoice
       table:
         - default_db

--- a/crates/prql-compiler/src/semantic/std.prql
+++ b/crates/prql-compiler/src/semantic/std.prql
@@ -120,17 +120,15 @@ let window = func
   tbl <relation>
   -> <relation> internal window
 
-let noop = x -> x
-
 let append = `default_db.bottom`<relation> top<relation> -> <relation> internal append
 let intersect = `default_db.bottom`<relation> top<relation> -> <relation> (
-  noop t = top
-  join (noop b = bottom) (tuple_every (tuple_map _eq (tuple_zip t.* b.*)))
+  t = top
+  join (b = bottom) (tuple_every (tuple_map _eq (tuple_zip t.* b.*)))
   select t.*
 )
 let remove = `default_db.bottom`<relation> top<relation> -> <relation> (
-  noop t = top
-  join side:left (noop b = bottom) (tuple_every (tuple_map _eq (tuple_zip t.* b.*)))
+  t = top
+  join side:left (b = bottom) (tuple_every (tuple_map _eq (tuple_zip t.* b.*)))
   filter (tuple_every (tuple_map _is_null b.*))
   select t.*
 )

--- a/crates/prql-compiler/src/tests/test_bad_error_messages.rs
+++ b/crates/prql-compiler/src/tests/test_bad_error_messages.rs
@@ -59,16 +59,11 @@ fn test_bad_error_messages() {
     from artists
     "###).unwrap_err(), @r###"
     Error:
-       ╭─[:2:5]
+       ╭─[:3:5]
        │
-     2 │ ╭─▶     select tracks
-     3 │ ├─▶     from artists
-       │ │
-       │ ╰────────────────────── main expected type `relation`, but found type `infer -> infer`
-       │
-       │     Help: Have you forgotten an argument to function main?
-       │
-       │     Note: Type `relation` expands to `[tuple_of_scalars]`
+     3 │     from artists
+       │     ──────┬─────
+       │           ╰─────── expected a function, but found `default_db.artists`
     ───╯
     "###);
 
@@ -77,13 +72,8 @@ fn test_bad_error_messages() {
     from artists
     sort -name
     "###).unwrap_err(), @r###"
-    Error:
-       ╭─[:3:11]
-       │
-     3 │     sort -name
-       │           ──┬─
-       │             ╰─── Unknown name
-    ───╯
+    Error: expected a pipeline that resolves to a table, but found `internal std.sub`
+    ↳ Hint: are you missing `from` statement?
     "###);
 }
 


### PR DESCRIPTION
When a function call argument is a function, wrap the call into a new function
which expects the missing argument of the argument function.

This is equivalent to changing this:

```
let a = (sort x | take 1)
```
... into this:
```
let a = rel -> (rel | sort x | take 1)
```

We already supported this, but only for pipelines.
This PR generalizes this behavior to plain function calls.

The downside is that when your function *does expect* a function as an
argument, this behavior will get in the way. In this case, the user can
annotate the parameter to be a function, with the convenient recent addition
of `<func>` type annotation.

PS: this behavior may not be called partial application, I'm not sure and too
lazy to look it up.
