### PR TITLE
web: Try removing slash for playground data

### DIFF
--- a/web/playground/src/workbench/duckdb.js
+++ b/web/playground/src/workbench/duckdb.js
@@ -39,7 +39,7 @@ export const CHINOOK_TABLES = [
 ];
 
 async function registerChinook(db) {
-  const baseUrl = `${window.location.href}/data/chinook`;
+  const baseUrl = `${window.location.href}data/chinook`;
   const http = duckdb.DuckDBDataProtocol.HTTP;
 
   await Promise.all(


### PR DESCRIPTION
As discussed on Discord -- could this be causing the playground failing?
