### PR TITLE
devops: Remove prettier overlap with .gitignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,13 @@ repos:
         # https://github.com/crate-ci/typos/issues/347
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-prettier
-    # Upgrading to the bare `v3.0.0` seems to break the plugin; contributions welcome to fix.
     rev: v3.0.0
     hooks:
       - id: prettier
         additional_dependencies:
           - prettier
+          # TODO: This doesn't seem to work, would be great to fix.
+          # https://github.com/PRQL/prql/issues/3078
           - prettier-plugin-go-template
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.280

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,20 +1,8 @@
-*.min.*
+**/*.min.*
 /web/book/theme/highlight.js
 
 # TODO: move these into content out of layouts
-/web/website/themes/prql-theme/layouts/partials/codes/
 /web/website/themes/prql-theme/layouts/_default/_markup/render-link.html
-
-# Ideally prettier would allow blanket gitignores, https://github.com/prettier/prettier/issues/8048
-
-**/node_modules
-**/.git
-target/
-.mypy_cache
-**/build
-**/dist
-/web/book/book
-/web/website/public
 
 # TODO: fix the go-template issue in `.prettierrc.yaml`
 **/*.html


### PR DESCRIPTION
This is now done by default
