### PR TITLE
ci: update iFaxity/wait-on-action to use node.js 16

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -86,7 +86,7 @@ jobs:
         working-directory: ./crates/prql-compiler/tests/integration
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
       - name: Wait for database
-        uses: ifaxity/wait-on-action@v1
+        uses: ifaxity/wait-on-action@v1.1.0
         with:
           resource: "tcp:1433 tcp:3306 tcp:5432 tcp:9004"
           timeout: 60000


### PR DESCRIPTION
v1 tag seems outdated (iFaxity/wait-on-action#10)