### PR TITLE
fix: playground csv loading, take 2

### DIFF
--- a/web/playground/src/workbench/duckdb.js
+++ b/web/playground/src/workbench/duckdb.js
@@ -39,19 +39,20 @@ export const CHINOOK_TABLES = [
 ];
 
 async function registerChinook(db) {
-  const baseUrl = `${window.location.href}data/chinook`;
+  const baseUrl = `${window.location.href}/data/chinook`;
 
   await Promise.all(
     CHINOOK_TABLES.map(async (table) => {
       const res = await fetch(`${baseUrl}/${table}.csv`);
+      const text = await res.text();
 
-      db.registerFileText(`${table}.csv`, res);
+      db.registerFileText(`${table}.csv`, text);
     }),
   );
 
   const c = await db.connect();
   for (const table of CHINOOK_TABLES) {
-    await c.insertCSVFromPath(`${table}.csv`, { name: table, detect: true });
+    await c.insertCSVFromPath(`${table}.csv`, { name: table, detect: true, header: true });
   }
   c.close();
 }

--- a/web/playground/src/workbench/duckdb.js
+++ b/web/playground/src/workbench/duckdb.js
@@ -52,7 +52,11 @@ async function registerChinook(db) {
 
   const c = await db.connect();
   for (const table of CHINOOK_TABLES) {
-    await c.insertCSVFromPath(`${table}.csv`, { name: table, detect: true, header: true });
+    await c.insertCSVFromPath(`${table}.csv`, {
+      name: table,
+      detect: true,
+      header: true,
+    });
   }
   c.close();
 }


### PR DESCRIPTION
Followup for #3076 

I'm surprised that yesterdays fix even worked in any way - I wasn't able to test if fully because prql-js was having some wasm problems.

This one is tested.