### PR TITLE
docs: Fix typo and use semantic kbd element

### DIFF
--- a/web/book/src/project/integrations/vscode.md
+++ b/web/book/src/project/integrations/vscode.md
@@ -6,8 +6,8 @@ very handy for editing, saving, and reusing PRQL queries in VS Code.
 
 To install the VS Code extension, open VS Code and type
 <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>P</kbd>
-(<kbd>Cmd</kbd>-<kbd>Shift</kbd>-<kbd>P</kbd> on a Mac) and type `PRQL`.
-Install the extension as usual.
+(<kbd>Cmd</kbd>-<kbd>Shift</kbd>-<kbd>P</kbd> on a Mac) and type `PRQL`. Install
+the extension as usual.
 
 [Repo for the PRQL VS Code extension](https://github.com/PRQL/prql-vscode)
 

--- a/web/book/src/project/integrations/vscode.md
+++ b/web/book/src/project/integrations/vscode.md
@@ -4,8 +4,10 @@ PRQL has a Visual Studio Code extension that compiles a PRQL query in a VS Code
 editor and displays the resulting SQL code in a second pane on the side. This is
 very handy for editing, saving, and reusing PRQL queries in VS Code.
 
-To install the VS Code extension, open VS Code and type Ctl-Shift-P (Cmd-Shift-P
-on a Mac) and type `PRQL`. Install the extension as usual.
+To install the VS Code extension, open VS Code and type
+<kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>P</kbd>
+(<kbd>Cmd</kbd>-<kbd>Shift</kbd>-<kbd>P</kbd> on a Mac) and type `PRQL`.
+Install the extension as usual.
 
 [Repo for the PRQL VS Code extension](https://github.com/PRQL/prql-vscode)
 


### PR DESCRIPTION
Fix typo; "Ctl" to "Ctrl" and Use semantic `<kbd>` markup.