### PR TITLE
build: Compile `prql-js` for wasm only

### DIFF
--- a/bindings/prql-js/Cargo.toml
+++ b/bindings/prql-js/Cargo.toml
@@ -21,7 +21,7 @@ test = false
 [features]
 default = ["console_error_panic_hook"]
 
-[dependencies]
+[target.'cfg(target_family="wasm")'.dependencies]
 prql-compiler = {path = "../../crates/prql-compiler", default-features = false}
 wasm-bindgen = "0.2.87"
 
@@ -31,7 +31,7 @@ wasm-bindgen = "0.2.87"
 # code size when deploying.
 console_error_panic_hook = {version = "0.1.7", optional = true}
 
-[dev-dependencies]
+[target.'cfg(target_family="wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3.30"
 
 [package.metadata.cargo-udeps.ignore]

--- a/bindings/prql-js/src/lib.rs
+++ b/bindings/prql-js/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(target_family = "wasm")]
+
 mod utils;
 
 use std::str::FromStr;

--- a/crates/prql-compiler/Cargo.toml
+++ b/crates/prql-compiler/Cargo.toml
@@ -18,8 +18,8 @@ test-dbs = ["duckdb", "rusqlite", "tokio"]
 test-dbs-external = ["chrono", "duckdb", "mysql", "pg_bigdecimal", "postgres", "rusqlite", "tiberius", "tokio", "tokio-util"]
 
 [dependencies]
-prql-ast = {path = "../prql-ast", version = "0.9.2" }
-prql-parser = {path = "../prql-parser", version = "0.9.2" }
+prql-ast = {path = "../prql-ast", version = "0.9.2"}
+prql-parser = {path = "../prql-parser", version = "0.9.2"}
 
 anstream = {version = "0.3.2", features = ["auto"]}
 anyhow = {version = "1.0.57", features = ["backtrace"]}


### PR DESCRIPTION
While attempting to look at https://github.com/PRQL/prql/issues/3098, I tried to look at what was causing the builds the second time around.

Here's a `fish` script (easy to adjust for `bash`):

```fish
begin;
    echo 'Running: cargo +nightly clean'; cargo +nightly clean ;
    echo 'Running first build'; cargo +nightly build --verbose --all-targets;
    echo 'Running second build'; cargo +nightly build --verbose --all-targets -p prqlc;
end &| tee build.log
```

Then there's two lines in `build.log` for the same dependency, one from the first; one from the second:

```
    Running `/Users/maximilian/.rustup/toolchains/nightly-aarch64-apple-darwin/bin/rustc --crate-name serde /Users/maximilian/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.163/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="serde_derive"' --cfg 'feature="std"' -C metadata=5e334edc106c7255 -C extra-filename=-5e334edc106c7255 --out-dir /Users/maximilian/workspace/prql/target/debug/deps -L dependency=/Users/maximilian/workspace/prql/target/debug/deps --extern serde_derive=/Users/maximilian/workspace/prql/target/debug/deps/libserde_derive-6e3b03dd545079c5.dylib --cap-lints allow`
    Running `/Users/maximilian/.rustup/toolchains/nightly-aarch64-apple-darwin/bin/rustc --crate-name serde /Users/maximilian/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.163/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="serde_derive"' --cfg 'feature="std"' -C metadata=7fbd537ea76b6b2f -C extra-filename=-7fbd537ea76b6b2f --out-dir /Users/maximilian/workspace/prql/target/debug/deps -L dependency=/Users/maximilian/workspace/prql/target/debug/deps --extern serde_derive=/Users/maximilian/workspace/prql/target/debug/deps/libserde_derive-6e3b03dd545079c5.dylib --cap-lints allow`
```

These have different features — only one has `alloc`. And then running:

```
cargo tree -e features --target=(default-target) -i serde
```

...helps find the thing that's generating the request for the `alloc` feature — in this case `wasm-bindgen`.

This seems like a very labor-intensive way of trying to unify dependencies between each crate & the workspace. But I'm including the first fix, which is to not compile `wasm-bindgen` for non-wasm targets.

So:
- This class of problem seem like at least one reason for #3098
- I'm not sure how to generalize it, or whether it's even viable to attempt to do that (I'm guessing it's not — new conflicts could come about at any time...)
