### PR TITLE
ci: Build workspace in `prqlc` build

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -25,7 +25,9 @@ runs:
     - uses: Swatinem/rust-cache@v2
       with:
         # Share cache with `test-rust`, except for `musl` targets.
-        save-if: ${{ (github.ref == 'refs/heads/main') && contains(inputs.target, 'musl') }}
+        save-if:
+          ${{ (github.ref == 'refs/heads/main') && contains(inputs.target,
+          'musl') }}
         shared-key: rust-${{ inputs.target }}
         prefix-key: ${{ env.version }}
 
@@ -59,9 +61,7 @@ runs:
         # workspace. (This is overly complicated and would be great to simplify,
         # even at the cost of slighly less efficiency.)
         args:
-          --profile=${{ inputs.profile }} 
-          --locked 
-          --target=${{ inputs.target }} 
+          --profile=${{ inputs.profile }} --locked --target=${{ inputs.target }}
           ${{ contains(inputs.target, 'musl') && '--package=prqlc' || '' }}
 
     - name: Create artifact for Linux and macOS

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -24,8 +24,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        # Share cache with `test-rust`
-        save-if: false
+        # Share cache with `test-rust`, except for `musl` targets.
+        save-if: ${{ (github.ref == 'refs/heads/main') && contains(inputs.target, 'musl') }}
         shared-key: rust-${{ inputs.target }}
         prefix-key: ${{ env.version }}
 
@@ -52,10 +52,17 @@ runs:
       uses: richb-hanover/cargo@v1.1.0
       with:
         command: build
-        # We previously had `--package=prqlc`, but this caches much worse than just building the whole workspace.
-        # https://github.com/PRQL/prql/issues/3098
+        # We previously had `--package=prqlc` for all, but this caches much
+        # worse than just building the whole workspace.
+        # https://github.com/PRQL/prql/issues/3098, so we just build the whole
+        # workspace — except for the `musl` target, which can't build the whole
+        # workspace. (This is overly complicated and would be great to simplify,
+        # even at the cost of slighly less efficiency.)
         args:
-          --profile=${{ inputs.profile }} --locked --target=${{ inputs.target }}
+          --profile=${{ inputs.profile }} 
+          --locked 
+          --target=${{ inputs.target }} 
+          ${{ contains(inputs.target, 'musl') && '--package=prqlc' || '' }}
 
     - name: Create artifact for Linux and macOS
       shell: bash

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -52,9 +52,10 @@ runs:
       uses: richb-hanover/cargo@v1.1.0
       with:
         command: build
+        # We previously had `--package=prqlc`, but this caches much worse than just building the whole workspace.
+        # https://github.com/PRQL/prql/issues/3098
         args:
-          --package=prqlc --profile=${{ inputs.profile }} --locked --target=${{
-          inputs.target }}
+          --profile=${{ inputs.profile }} --locked --target=${{ inputs.target }}
 
     - name: Create artifact for Linux and macOS
       shell: bash


### PR DESCRIPTION
As noted inline, I think this will be much faster, ironically
