### PR TITLE
build: Remove duplicate `similar` compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,7 +3596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 dependencies = [
  "bstr 0.2.17",
- "serde",
  "unicode-segmentation",
 ]
 

--- a/crates/tests_misc/Cargo.toml
+++ b/crates/tests_misc/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 [dev-dependencies]
 insta = {version = "1.31", features = ["colors", "glob", "yaml"]}
 regex = "1.9.1"
-similar = { version = "2.2.1", features = ["serde"] }
+similar = {version = "2.2.1"}


### PR DESCRIPTION
I don't think this needs a different feature.

(found with `cargo tree --duplicates`)
