### PR TITLE
build: Disable empty crate tests

### DIFF
--- a/crates/prql-ast/Cargo.toml
+++ b/crates/prql-ast/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 enum-as-inner = "0.6.0"
 semver = {version = "1.0.14", features = ["serde"]}

--- a/crates/prql-compiler/examples/compile-files/Cargo.toml
+++ b/crates/prql-compiler/examples/compile-files/Cargo.toml
@@ -8,5 +8,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+test = false
+
 [build-dependencies]
 prql-compiler = {path = '../../'}

--- a/crates/prql-compiler/examples/compile-files/Cargo.toml
+++ b/crates/prql-compiler/examples/compile-files/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
-[lib]
-doctest = false
+[[bin]]
+name = "compile-files"
 test = false
 
 [build-dependencies]

--- a/crates/prql-parser/Cargo.toml
+++ b/crates/prql-parser/Cargo.toml
@@ -8,9 +8,12 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 itertools = "0.11.0"
-prql-ast = {path = "../prql-ast", version = "0.9.2" }
+prql-ast = {path = "../prql-ast", version = "0.9.2"}
 semver = {version = "1.0.14"}
 
 # Chumsky's default features have issues when running in wasm (though we only


### PR DESCRIPTION
THese add a few seconds onto each `cargo test` call
