### PR TITLE
ci: make version extraction more reliable

### DIFF
--- a/.github/set_version.sh
+++ b/.github/set_version.sh
@@ -2,4 +2,4 @@
 # since the caches seem to accumulate cruft over time;
 # ref https://github.com/PRQL/prql/pull/2407
 
-grep '^version =' Cargo.toml | tr -d ' "' >> $GITHUB_ENV
+echo "version=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[0].version')" >>"$GITHUB_ENV"

--- a/.github/set_version.sh
+++ b/.github/set_version.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # We set prefix-key to the version from Cargo.toml for Swatinem/rust-cache@v2
 # since the caches seem to accumulate cruft over time;
 # ref https://github.com/PRQL/prql/pull/2407

--- a/.github/set_version.sh
+++ b/.github/set_version.sh
@@ -4,4 +4,5 @@
 # since the caches seem to accumulate cruft over time;
 # ref https://github.com/PRQL/prql/pull/2407
 
-echo "version=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[0].version')" >>"$GITHUB_ENV"
+version=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[] | select(.name == "prql-compiler") | .version')
+echo "version=${version}" >>"$GITHUB_ENV"


### PR DESCRIPTION
https://github.com/PRQL/prql/pull/3122#issuecomment-1653053214

There is no need to remove spaces or quotation marks because `cargo metadata` correctly parses the TOML and extracts the version number.