### PR TITLE
refactor: clean up code in `semantic::resolve` function

### DIFF
--- a/crates/prql-compiler/src/semantic/mod.rs
+++ b/crates/prql-compiler/src/semantic/mod.rs
@@ -55,8 +55,8 @@ pub fn resolve(
     }
 
     // init empty context
-    let root_module = RootModule::new();
-    let mut resolver = Resolver::new(root_module, options);
+    let mut root_module = RootModule::new();
+    let mut resolver = Resolver::new(&mut root_module, options);
 
     // resolve sources one by one
     // TODO: recursive references
@@ -67,7 +67,7 @@ pub fn resolve(
         resolver.fold_statements(stmts)?;
     }
 
-    Ok(resolver.context)
+    Ok(root_module)
 }
 
 /// Preferred way of injecting std module.

--- a/crates/prql-compiler/src/semantic/mod.rs
+++ b/crates/prql-compiler/src/semantic/mod.rs
@@ -57,7 +57,7 @@ pub fn resolve(
     // init empty context
     let root_module = RootModule {
         root_mod: Module::new_root(),
-        ..RootModule::default()
+        span_map: Default::default(),
     };
     let mut resolver = Resolver::new(root_module, options);
 

--- a/crates/prql-compiler/src/semantic/mod.rs
+++ b/crates/prql-compiler/src/semantic/mod.rs
@@ -55,10 +55,7 @@ pub fn resolve(
     }
 
     // init empty context
-    let root_module = RootModule {
-        root_mod: Module::new_root(),
-        span_map: Default::default(),
-    };
+    let root_module = RootModule::new();
     let mut resolver = Resolver::new(root_module, options);
 
     // resolve sources one by one

--- a/crates/prql-compiler/src/semantic/mod.rs
+++ b/crates/prql-compiler/src/semantic/mod.rs
@@ -55,11 +55,11 @@ pub fn resolve(
     }
 
     // init empty context
-    let context = RootModule {
+    let root_module = RootModule {
         root_mod: Module::new_root(),
         ..RootModule::default()
     };
-    let mut resolver = Resolver::new(context, options);
+    let mut resolver = Resolver::new(root_module, options);
 
     // resolve sources one by one
     // TODO: recursive references

--- a/crates/prql-compiler/src/semantic/mod.rs
+++ b/crates/prql-compiler/src/semantic/mod.rs
@@ -63,8 +63,7 @@ pub fn resolve(
     for (path, stmts) in normalize(file_tree)? {
         let stmts = ast_expand::expand_stmts(stmts)?;
 
-        resolver.current_module_path = path;
-        resolver.fold_statements(stmts)?;
+        resolver.resolve(path, stmts)?;
     }
 
     Ok(root_module)

--- a/crates/prql-compiler/src/semantic/module.rs
+++ b/crates/prql-compiler/src/semantic/module.rs
@@ -8,8 +8,8 @@ use crate::ir::pl::{Expr, Ident, TupleField, Ty};
 use crate::Error;
 
 use super::decl::{Decl, DeclKind, TableDecl, TableExpr};
-use super::{Lineage, LineageColumn, NS_PARAM, NS_STD};
-use super::{NS_INFER, NS_INFER_MODULE, NS_SELF, NS_THAT, NS_THIS};
+use super::{Lineage, LineageColumn};
+use super::{NS_INFER, NS_INFER_MODULE, NS_SELF};
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Module {
@@ -37,27 +37,6 @@ impl Module {
         Module {
             names: HashMap::from([(name.to_string(), entry)]),
             ..Default::default()
-        }
-    }
-
-    pub fn new_root() -> Module {
-        // Each module starts with a default namespace that contains a wildcard
-        // and the standard library.
-        Module {
-            names: HashMap::from([
-                (
-                    "default_db".to_string(),
-                    Decl::from(DeclKind::Module(Self::new_database())),
-                ),
-                (NS_STD.to_string(), Decl::from(DeclKind::default())),
-            ]),
-            shadowed: None,
-            redirects: vec![
-                Ident::from_name(NS_THIS),
-                Ident::from_name(NS_THAT),
-                Ident::from_name(NS_PARAM),
-                Ident::from_name(NS_STD),
-            ],
         }
     }
 

--- a/crates/prql-compiler/src/semantic/resolver/mod.rs
+++ b/crates/prql-compiler/src/semantic/resolver/mod.rs
@@ -26,7 +26,7 @@ mod type_resolver;
 pub struct Resolver<'a> {
     context: &'a mut RootModule,
 
-    pub current_module_path: Vec<String>,
+    current_module_path: Vec<String>,
 
     default_namespace: Option<String>,
 
@@ -58,8 +58,12 @@ impl Resolver<'_> {
         }
     }
 
-    // entry point
-    pub fn fold_statements(&mut self, stmts: Vec<Stmt>) -> Result<()> {
+    pub fn resolve(&mut self, path: Vec<String>, stmts: Vec<Stmt>) -> Result<()> {
+        self.current_module_path = path;
+        self.fold_statements(stmts)
+    }
+
+    fn fold_statements(&mut self, stmts: Vec<Stmt>) -> Result<()> {
         for mut stmt in stmts {
             stmt.id = Some(self.id.gen());
             if let Some(span) = stmt.span {

--- a/crates/prql-compiler/src/semantic/resolver/type_resolver.rs
+++ b/crates/prql-compiler/src/semantic/resolver/type_resolver.rs
@@ -190,7 +190,7 @@ pub fn infer_type(node: &Expr) -> Result<Option<Ty>> {
     Ok(Some(Ty { kind, name: None }))
 }
 
-impl Resolver {
+impl Resolver<'_> {
     /// Validates that found node has expected type. Returns assumed type of the node.
     pub fn validate_type<F>(
         &mut self,

--- a/crates/prql-compiler/src/semantic/root_module.rs
+++ b/crates/prql-compiler/src/semantic/root_module.rs
@@ -11,7 +11,7 @@ use super::{
 };
 
 /// Context of the pipeline.
-#[derive(Default, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RootModule {
     /// Map of all accessible names (for each namespace)
     pub(crate) root_mod: Module,

--- a/crates/prql-compiler/src/semantic/root_module.rs
+++ b/crates/prql-compiler/src/semantic/root_module.rs
@@ -5,10 +5,12 @@ use anyhow::Result;
 use prql_ast::{expr::Ident, stmt::QueryDef, Span};
 use serde::{Deserialize, Serialize};
 
+use super::decl::DeclKind;
 use super::{
     decl::{Decl, TableExpr},
     Module, NS_MAIN, NS_QUERY_DEF,
 };
+use super::{NS_PARAM, NS_STD, NS_THAT, NS_THIS};
 
 /// Context of the pipeline.
 #[derive(Serialize, Deserialize, Clone)]
@@ -22,6 +24,31 @@ pub struct RootModule {
 // TODO: impl Deref<Target=Module> for RootModule and DerefMut
 
 impl RootModule {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        // Each module starts with a default namespace that contains a wildcard
+        // and the standard library.
+        RootModule {
+            root_mod: Module {
+                names: HashMap::from([
+                    (
+                        "default_db".to_string(),
+                        Decl::from(DeclKind::Module(Module::new_database())),
+                    ),
+                    (NS_STD.to_string(), Decl::from(DeclKind::default())),
+                ]),
+                shadowed: None,
+                redirects: vec![
+                    Ident::from_name(NS_THIS),
+                    Ident::from_name(NS_THAT),
+                    Ident::from_name(NS_PARAM),
+                    Ident::from_name(NS_STD),
+                ],
+            },
+            span_map: HashMap::new(),
+        }
+    }
+
     /// Finds that main pipeline given a path to either main itself or its parent module.
     /// Returns main expr and fq ident of the decl.
     pub fn find_main_rel(&self, path: &[String]) -> Result<(&TableExpr, Ident), Option<String>> {


### PR DESCRIPTION
This is the promised 2nd attempt at #3023.