### PR TITLE
docs: Add some suggested issues to project update

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ ready to be rolled out to non-technical teams for fairly simple queries.
 We recently release [0.9.0](https://github.com/PRQL/prql/releases/tag/0.9.0),
 our biggest release ever. Here's our current
 [Roadmap](https://prql-lang.org/roadmap/).
-<!-- TODO: add back when we get them 
+
+<!-- TODO: add back when we get them
 and our
 [Milestones](https://github.com/PRQL/prql/milestones). -->
 
@@ -119,13 +120,13 @@ To stay in touch with PRQL:
 - For those who might be interested in contributing to the code now, here are a
   few bugs (as of 2023-07-29) that we'd be keen to fix and someone with
   basic-ish rust knowledge could make good progress. As discussed in our
-  [contributing
-  docs](https://prql-lang.org/book/project/contributing/development.html).
+  [contributing docs](https://prql-lang.org/book/project/contributing/development.html).
   always feel free to ask questions or open a draft PR.
-  - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
+  - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at
+    least not panic
   - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
-  - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
-
+  - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward
+    defined in the issue
 
 ## Explore
 

--- a/README.md
+++ b/README.md
@@ -81,17 +81,6 @@ Our immediate focus for the code is on:
 
 - Ensuring our supported features feel extremely robust; resolving any
   [priority bugs](https://github.com/PRQL/prql/issues?q=is%3Aissue+is%3Aopen+label%3Abug+label%3Apriority).
-  - For those who might be interested in contributing, here are a few bugs that
-    we'd be keen to fix and are at the level where someone who knows some amount
-    of rust could fix, either independently or with a small amount of guidance.
-    As discussed in our
-    [contributing docs](https://prql-lang.org/book/project/contributing/development.html).
-    always feel free to ask questions or open a draft PR!
-    - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at
-      least not panic
-    - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
-    - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward
-      defined in the issue
 - Filling remaining feature gaps, so that PRQL is possible to use for almost all
   standard SQL queries; for example
   [date to string functions](https://github.com/PRQL/prql/issues/366).
@@ -111,6 +100,19 @@ We're also spending time thinking about:
   contributors to the project, but contributions to the compiler itself are
   quite concentrated. We're keen to expand this;
   [#1840](https://github.com/PRQL/prql/issues/1840) for feedback.
+
+Contributing
+
+For those who might be interested in contributing, here are a few bugs (as of
+2023-07-29) that we'd be keen to fix and are at the level where someone who
+knows some amount of rust could fix, either independently or with a small amount
+of guidance. As discussed in our [contributing
+docs](https://prql-lang.org/book/project/contributing/development.html). always
+feel free to ask questions or open a draft PR!
+
+- [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
+- [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
+- [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
 
 ## Get involved
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Our immediate focus for the code is on:
   - For those who might be interested in contributing, here are a few bugs that
     we'd be keen to fix and are at the level where someone who knows some amount
     of rust could fix, either independently or with a small amount of guidance.
-    As discussed in our [contributing
-    docs](https://prql-lang.org/book/project/contributing/development.html).
+    As discussed in our
+    [contributing docs](https://prql-lang.org/book/project/contributing/development.html).
     always feel free to ask questions or open a draft PR!
     - #3151 — confined to parser
     - #3111 — maybe not fix, but at least not panic

--- a/README.md
+++ b/README.md
@@ -104,16 +104,15 @@ We're also spending time thinking about:
 
 If you're up for contributing today:
 
-For those who might be interested in contributing, here are a few bugs (as of
-2023-07-29) that we'd be keen to fix and are at the level of someone with
-basic-ish rust knowledge could make good progress. As discussed in our
-[contributing
-docs](https://prql-lang.org/book/project/contributing/development.html). always
-feel free to ask questions or open a draft PR.
-
-- [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
-- [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
-- [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
+- For those who might be interested in contributing, here are a few bugs (as of
+  2023-07-29) that we'd be keen to fix and are at the level of someone with
+  basic-ish rust knowledge could make good progress. As discussed in our
+  [contributing
+  docs](https://prql-lang.org/book/project/contributing/development.html). always
+  feel free to ask questions or open a draft PR.
+  - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
+  - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
+  - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
 
 ## Get involved
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ To stay in touch with PRQL:
   started — the project can be built in a couple of commands, and we're a really
   friendly community!
 - For those who might be interested in contributing to the code now, here are a
-  few bugs (as of 2023-07-29) that we'd be keen to fix and are at the level of
-  someone with basic-ish rust knowledge could make good progress. As discussed
-  in our [contributing
+  few bugs (as of 2023-07-29) that we'd be keen to fix and someone with
+  basic-ish rust knowledge could make good progress. As discussed in our
+  [contributing
   docs](https://prql-lang.org/book/project/contributing/development.html).
   always feel free to ask questions or open a draft PR.
   - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ Our immediate focus for the code is on:
     As discussed in our
     [contributing docs](https://prql-lang.org/book/project/contributing/development.html).
     always feel free to ask questions or open a draft PR!
-    - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
+    - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at
+      least not panic
     - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
-    - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
+    - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward
+      defined in the issue
 - Filling remaining feature gaps, so that PRQL is possible to use for almost all
   standard SQL queries; for example
   [date to string functions](https://github.com/PRQL/prql/issues/366).

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ PRQL still has some minor bugs and some missing features, and is probably only
 ready to be rolled out to non-technical teams for fairly simple queries.
 
 We recently release [0.9.0](https://github.com/PRQL/prql/releases/tag/0.9.0),
-our biggest release ever.
-
-Here's our current [Roadmap](https://prql-lang.org/roadmap/) and our
-[Milestones](https://github.com/PRQL/prql/milestones).
+our biggest release ever. Here's our current
+[Roadmap](https://prql-lang.org/roadmap/).
+<!-- TODO: add back when we get them 
+and our
+[Milestones](https://github.com/PRQL/prql/milestones). -->
 
 Our immediate focus for the code is on:
 

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ We're also spending time thinking about:
   quite concentrated. We're keen to expand this;
   [#1840](https://github.com/PRQL/prql/issues/1840) for feedback.
 
-Contributing
+If you're up for contributing today:
 
 For those who might be interested in contributing, here are a few bugs (as of
-2023-07-29) that we'd be keen to fix and are at the level where someone who
-knows some amount of rust could fix, either independently or with a small amount
-of guidance. As discussed in our [contributing
+2023-07-29) that we'd be keen to fix and are at the level of someone with
+basic-ish rust knowledge could make good progress. As discussed in our
+[contributing
 docs](https://prql-lang.org/book/project/contributing/development.html). always
-feel free to ask questions or open a draft PR!
+feel free to ask questions or open a draft PR.
 
 - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
 - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser

--- a/README.md
+++ b/README.md
@@ -100,19 +100,8 @@ We're also spending time thinking about:
 - Making it easier to contribute to the compiler. We have a wide group of
   contributors to the project, but contributions to the compiler itself are
   quite concentrated. We're keen to expand this;
-  [#1840](https://github.com/PRQL/prql/issues/1840) for feedback.
-
-If you're up for contributing today:
-
-- For those who might be interested in contributing, here are a few bugs (as of
-  2023-07-29) that we'd be keen to fix and are at the level of someone with
-  basic-ish rust knowledge could make good progress. As discussed in our
-  [contributing
-  docs](https://prql-lang.org/book/project/contributing/development.html). always
-  feel free to ask questions or open a draft PR.
-  - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
-  - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
-  - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
+  [#1840](https://github.com/PRQL/prql/issues/1840) for feedback, some
+  suggestions on starter issues are below.
 
 ## Get involved
 
@@ -127,6 +116,16 @@ To stay in touch with PRQL:
 - See the [development][development] documentation for PRQL. It's easy to get
   started — the project can be built in a couple of commands, and we're a really
   friendly community!
+- For those who might be interested in contributing to the code now, here are a
+  few bugs (as of 2023-07-29) that we'd be keen to fix and are at the level of
+  someone with basic-ish rust knowledge could make good progress. As discussed
+  in our [contributing
+  docs](https://prql-lang.org/book/project/contributing/development.html).
+  always feel free to ask questions or open a draft PR.
+  - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
+  - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
+  - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
+
 
 ## Explore
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Our immediate focus for the code is on:
 
 - Ensuring our supported features feel extremely robust; resolving any
   [priority bugs](https://github.com/PRQL/prql/issues?q=is%3Aissue+is%3Aopen+label%3Abug+label%3Apriority).
+  - For those who might be interested in contributing, here are a few bugs that
+    we'd be keen to fix and are at the level where someone who knows some amount
+    of rust could fix, either independently or with a small amount of guidance.
+    As discussed in our [contributing
+    docs](https://prql-lang.org/book/project/contributing/development.html).
+    always feel free to ask questions or open a draft PR!
+    - #3151 — confined to parser
+    - #3111 — maybe not fix, but at least not panic
+    - #3077 — some path forward defined in the issue
 - Filling remaining feature gaps, so that PRQL is possible to use for almost all
   standard SQL queries; for example
   [date to string functions](https://github.com/PRQL/prql/issues/366).

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Our immediate focus for the code is on:
     As discussed in our
     [contributing docs](https://prql-lang.org/book/project/contributing/development.html).
     always feel free to ask questions or open a draft PR!
-    - #3151 — confined to parser
-    - #3111 — maybe not fix, but at least not panic
-    - #3077 — some path forward defined in the issue
+    - [#3111](https://github.com/PRQL/prql/issues/3111) — maybe not fix, but at least not panic
+    - [#3151](https://github.com/PRQL/prql/issues/3151) — confined to parser
+    - [#3077](https://github.com/PRQL/prql/issues/3077) — some path forward defined in the issue
 - Filling remaining feature gaps, so that PRQL is possible to use for almost all
   standard SQL queries; for example
   [date to string functions](https://github.com/PRQL/prql/issues/366).


### PR DESCRIPTION
This will require more oversight from me on keeping these up to date, but I think is worthwhile. Or does it muddy the update?

For context, these are pulled from a message on Discord:

---

We got some great bug reports recently!

I would love to be in a place where we could fix those in a days-weeks cadence, rather than requiring a big lift to restructure code. Personally, I'm doing a bad job there — my track record with these is to start, get a bit stuck, and then @aljazerzen often generously finishes my PR.

To the extent anyone else would like to give any of them a go (anyone apart from @aljazerzen , who obv can always do them, but everything falls on him), that would be really great.

Here are a few that I think could be good places to start:
- https://github.com/PRQL/prql/issues/3111 — maybe not fix, but at least not panic
- https://github.com/PRQL/prql/issues/3151 — confined to parser
- https://github.com/PRQL/prql/issues/3077 — some path forward defined in the issue
