### PR TITLE
fix: Fix links to docs.rs

### DIFF
--- a/bindings/prql-dotnet/PrqlCompiler/PrqlCompiler.cs
+++ b/bindings/prql-dotnet/PrqlCompiler/PrqlCompiler.cs
@@ -62,7 +62,7 @@ namespace Prql.Compiler
         /// <returns>JSON.</returns>
         /// <exception cref="ArgumentException"><paramref name="prqlQuery"/> is null or empty.</exception>
         /// <exception cref="FormatException"><paramref name="prqlQuery"/> cannot be compiled.</exception>
-        /// <remarks>https://docs.rs/prql-compiler/latest/prql_compiler/ast/pl</remarks>
+        /// <remarks>https://docs.rs/prql-compiler/latest/prql_compiler/ir/pl</remarks>
         public static Result PrqlToPl(string prqlQuery)
         {
             if (string.IsNullOrEmpty(prqlQuery))
@@ -106,7 +106,7 @@ namespace Prql.Compiler
         /// <exception cref="ArgumentException"><paramref name="prqlQuery"/> is null or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
         /// <exception cref="FormatException"><paramref name="prqlQuery"/> cannot be compiled.</exception>
-        /// <remarks>https://docs.rs/prql-compiler/latest/prql_compiler/ast/rq</remarks>
+        /// <remarks>https://docs.rs/prql-compiler/latest/prql_compiler/ir/rq</remarks>
         public static Result RqToSql(string rqJson, PrqlCompilerOptions options)
         {
             if (string.IsNullOrEmpty(rqJson))

--- a/bindings/prql-lib/libprql_lib.h
+++ b/bindings/prql-lib/libprql_lib.h
@@ -131,7 +131,7 @@ struct CompileResult compile(const char *prql_query, const struct Options *optio
 
 /**
  * Build PL AST from a PRQL string. PL in documented in the
- * [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ast/pl).
+ * [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ir/pl).
  *
  * Takes PRQL source buffer and writes PL serialized as JSON to `out` buffer.
  *
@@ -164,7 +164,7 @@ struct CompileResult pl_to_rq(const char *pl_json);
 
 /**
  * Convert RQ AST into an SQL string. RQ is documented in the
- * [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ast/rq).
+ * [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ir/rq).
  *
  * Takes RQ serialized as JSON buffer and writes SQL source to `out` buffer.
  *

--- a/bindings/prql-lib/libprql_lib.hpp
+++ b/bindings/prql-lib/libprql_lib.hpp
@@ -99,7 +99,7 @@ extern "C" {
 CompileResult compile(const char *prql_query, const Options *options);
 
 /// Build PL AST from a PRQL string. PL in documented in the
-/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ast/pl).
+/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ir/pl).
 ///
 /// Takes PRQL source buffer and writes PL serialized as JSON to `out` buffer.
 ///
@@ -128,7 +128,7 @@ CompileResult prql_to_pl(const char *prql_query);
 CompileResult pl_to_rq(const char *pl_json);
 
 /// Convert RQ AST into an SQL string. RQ is documented in the
-/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ast/rq).
+/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ir/rq).
 ///
 /// Takes RQ serialized as JSON buffer and writes SQL source to `out` buffer.
 ///

--- a/bindings/prql-lib/src/lib.rs
+++ b/bindings/prql-lib/src/lib.rs
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn compile(
 }
 
 /// Build PL AST from a PRQL string. PL in documented in the
-/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ast/pl).
+/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ir/pl).
 ///
 /// Takes PRQL source buffer and writes PL serialized as JSON to `out` buffer.
 ///
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn pl_to_rq(pl_json: *const c_char) -> CompileResult {
 }
 
 /// Convert RQ AST into an SQL string. RQ is documented in the
-/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ast/rq).
+/// [prql-compiler Rust crate](https://docs.rs/prql-compiler/latest/prql_compiler/ir/rq).
 ///
 /// Takes RQ serialized as JSON buffer and writes SQL source to `out` buffer.
 ///


### PR DESCRIPTION
Closes https://github.com/PRQL/prql/issues/3186.

I guess the link checker doesn't scan rust files?
