### PR TITLE
ci: Remove cache from `test-taskfile`

### DIFF
--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -27,7 +27,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: ${{ env.version }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # The mac rust cache key. It's not _that_ useful since this will build
+          # much more, but it's better than nothing. We can't have our own
+          # cache, since we're out of cache space and this workflow takes 1.5GB.
+          shared-key: rust-x86_64-apple-darwin-test-dbs
+          save-if: false
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"


### PR DESCRIPTION
Not run that often, take a huge amount of cache space
