### PR TITLE
ci: Skip rust tests on non-rust-changes

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -19,6 +19,8 @@ outputs:
 runs:
   using: composite
   steps:
+    - run: echo ${{ inputs.target }}
+      shell: bash
     - run: echo ${{ inputs.features }}
       shell: bash
     - run: rustup target add ${{ inputs.target }}

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -19,6 +19,8 @@ outputs:
 runs:
   using: composite
   steps:
+    - run: echo ${{ inputs.features }}
+      shell: bash
     - run: rustup target add ${{ inputs.target }}
       shell: bash
 

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -10,10 +10,7 @@ inputs:
     required: true
   features:
     description: Features to enable
-    required: true
-  features2:
-    description: Features to enable
-    required: true
+    default: ""
 outputs:
   artifact-name:
     description: The name of the artifact
@@ -22,12 +19,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - run: echo ${{ inputs.target }}
-      shell: bash
-    - run: echo ${{ inputs.features2 }}
-      shell: bash
-    - run: echo ${{ inputs.features }}
-      shell: bash
     - run: rustup target add ${{ inputs.target }}
       shell: bash
 

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -11,6 +11,9 @@ inputs:
   features:
     description: Features to enable
     required: true
+  features2:
+    description: Features to enable
+    required: true
 outputs:
   artifact-name:
     description: The name of the artifact
@@ -20,6 +23,8 @@ runs:
   using: composite
   steps:
     - run: echo ${{ inputs.target }}
+      shell: bash
+    - run: echo ${{ inputs.features2 }}
       shell: bash
     - run: echo ${{ inputs.features }}
       shell: bash

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -10,8 +10,7 @@ inputs:
     required: true
   features:
     description: Features to enable
-    required: false
-    default: ""
+    required: true
 outputs:
   artifact-name:
     description: The name of the artifact

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   # This assesses whether we need to run jobs. It's currently only implemented
-  # for `check-links-book`, but we could expand it to other jobs, bringing the
+  # for a couple jobs, but we could expand it to other jobs, bringing the
   # jobs into this workflow.
   changes:
     runs-on: ubuntu-latest
@@ -35,6 +35,7 @@ jobs:
       pull-requests: read
     outputs:
       book: ${{ steps.filter.outputs.book }}
+      rust: ${{ steps.filter.outputs.rust }}
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -44,14 +44,20 @@ jobs:
             book:
               - '.github/workflows/check-links-book.yaml'
               - 'web/book/**'
+            rust:
+              - '**/*.rs'
+              - 'crates/**'
+              - 'web/book/**'
 
   test-rust:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    uses: ./.github/workflows/test-rust.yaml
     strategy:
       matrix:
         # We use a matrix here to mirror `test-all`, so they share a cache.
         os: [ubuntu-latest]
         target: ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-    uses: ./.github/workflows/test-rust.yaml
     with:
       os: ${{ matrix.os }}
       target: ${{ matrix.target }}
@@ -74,9 +80,8 @@ jobs:
 
   # Run Mac & Windows & bindings' other tests on a `pr-test-all` label or a `!`
   # (meaning a breaking change) in the PR title. (We also run on other
-  # conditions defined in `test-all.yaml`; the conditions defined here aren't
-  # possible to use as conditions for running a workflow, only a job, so we use
-  # this approach.)
+  # conditions defined in `test-all.yaml`; we could move those in here now that
+  # we have the `changes` job.)
   test-all:
     uses: ./.github/workflows/test-all.yaml
     if:
@@ -178,11 +183,14 @@ jobs:
           # something which temporarily fails that, such as if we're changing the
           # location of a file in this repo which is linked to.
           allowed-failures: check-links-markdown
-          allowed-skips: test-all, publish-web, nightly, check-links-book
+          allowed-skips:
+            test-all, publish-web, nightly, check-links-book, test-rust
           jobs: ${{ toJSON(needs) }}
 
   build-prqlc:
     runs-on: ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -199,7 +207,7 @@ jobs:
           #   target: aarch64-apple-darwin
           - os: macos-latest
             target: x86_64-apple-darwin
-            # Match these with the available caches from tests
+            # Match these features with the available caches from tests
             features: test-dbs
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -187,10 +187,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Match the features with the available caches from tests
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             features: ""
-            features2: ""
           # TODO: Until we have tests for these, we don't have a cache for them.
           # If we can add tests, then re-enable them. They run on `release.yaml`
           # regardless.
@@ -201,13 +201,10 @@ jobs:
           #   target: aarch64-apple-darwin
           - os: macos-latest
             target: x86_64-apple-darwin
-            # Match these with the available caches from tests
             features: test-dbs
-            features2: test-dbs
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             features: ""
-            features2: test-dbs
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
@@ -215,6 +212,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           profile: dev
+          features: ${{ matrix.features }}
     # These are the same env variables as in `test-rust.yaml`. Custom actions
     # don't allow setting env variables for the whole job, so we do it here. (We
     # could change the `build-prqlc` action to a workflow...).

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -189,6 +189,8 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
+            features: ""
+            features2: ""
           # TODO: Until we have tests for these, we don't have a cache for them.
           # If we can add tests, then re-enable them. They run on `release.yaml`
           # regardless.
@@ -201,9 +203,11 @@ jobs:
             target: x86_64-apple-darwin
             # Match these with the available caches from tests
             features: test-dbs
+            features2: test-dbs
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             features: ""
+            features2: test-dbs
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Since we have the `changes` job, this is now possible
