### PR TITLE
ci: Use same envs throughout

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -9,6 +9,8 @@ on:
   workflow_call:
 
 env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
   RUSTFLAGS: "-C debuginfo=0"
 
 concurrency:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -227,13 +227,15 @@ jobs:
           target: ${{ matrix.target }}
           profile: dev
           features: ${{ matrix.features }}
-    # # These are the same env variables as in `test-rust.yaml`. Custom actions
-    # # don't allow setting env variables for the whole job, so we do it here. (We
-    # # could change the `build-prqlc` action to a workflow...).
-    # env:
-    #   CARGO_TERM_COLOR: always
-    #   CLICOLOR_FORCE: 1
-    #   RUSTFLAGS: "-C debuginfo=0"
+    # TODO: can we remove this now we have them at the job level?
+    #
+    # These are the same env variables as in `test-rust.yaml`. Custom actions
+    # don't allow setting env variables for the whole job, so we do it here. (We
+    # could change the `build-prqlc` action to a workflow...).
+    env:
+      CARGO_TERM_COLOR: always
+      CLICOLOR_FORCE: 1
+      RUSTFLAGS: "-C debuginfo=0"
 
   automerge-dependabot:
     # This would arguably fit more naturally in `pull-request-target`, but it's

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -25,6 +25,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-pull-request
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+
 jobs:
   # This assesses whether we need to run jobs. It's currently only implemented
   # for a couple jobs, but we could expand it to other jobs, bringing the
@@ -222,13 +227,13 @@ jobs:
           target: ${{ matrix.target }}
           profile: dev
           features: ${{ matrix.features }}
-    # These are the same env variables as in `test-rust.yaml`. Custom actions
-    # don't allow setting env variables for the whole job, so we do it here. (We
-    # could change the `build-prqlc` action to a workflow...).
-    env:
-      CARGO_TERM_COLOR: always
-      CLICOLOR_FORCE: 1
-      RUSTFLAGS: "-C debuginfo=0"
+    # # These are the same env variables as in `test-rust.yaml`. Custom actions
+    # # don't allow setting env variables for the whole job, so we do it here. (We
+    # # could change the `build-prqlc` action to a workflow...).
+    # env:
+    #   CARGO_TERM_COLOR: always
+    #   CLICOLOR_FORCE: 1
+    #   RUSTFLAGS: "-C debuginfo=0"
 
   automerge-dependabot:
     # This would arguably fit more naturally in `pull-request-target`, but it's

--- a/.github/workflows/test-taskfile.yaml
+++ b/.github/workflows/test-taskfile.yaml
@@ -10,6 +10,8 @@ on:
   workflow_dispatch:
 
 env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
   RUSTFLAGS: "-C debuginfo=0"
 
 concurrency:


### PR DESCRIPTION
Found another case where caches weren't being shared; this should fix
