### PR TITLE
test: Add `description` field to integration test

### DIFF
--- a/crates/prql-compiler/tests/integration/main.rs
+++ b/crates/prql-compiler/tests/integration/main.rs
@@ -320,7 +320,8 @@ fn test_rdbms() {
 
         let prql = fs::read_to_string(path).unwrap();
 
-        let mut results = BTreeMap::new();
+        // for each of the dialects
+        insta::allow_duplicates! {
         for con in &mut connections {
             if !con.dialect.should_run_query(&prql) {
                 continue;
@@ -332,7 +333,7 @@ fn test_rdbms() {
                 .context(format!("Executing {test_name} for {dialect}"))
                 .unwrap();
 
-            // TODO: I think these could possibility be delegated to the DBConnection impls
+            // TODO: I think these could possibly be moved to the DbConnection impls
             replace_booleans(&mut rows);
             remove_trailing_zeros(&mut rows);
 
@@ -342,23 +343,14 @@ fn test_rdbms() {
                 .map(|r| r.iter().join(","))
                 .join("\n");
 
-            results.insert(dialect.to_string(), result);
+            // Add message so we know which dialect fails.
+            insta::with_settings!({
+                description=>format!("# Running on dialect `{}`\n\n# Query:\n---\n{}", &con.dialect, &prql)
+            }, {
+                assert_snapshot!("results", &result);
+            })
         }
-
-        let (first_dialect, first_result) =
-            results.pop_first().expect("No results for {test_name}");
-
-        // Check the first result against the snapshot
-        assert_snapshot!("results", first_result, &prql);
-
-        // Then check every other result against the first result
-        results.iter().for_each(|(dialect, result)| {
-            assert_eq!(
-                *first_result, *result,
-                "{} == {}: {test_name}",
-                first_dialect, dialect
-            );
-        })
+        }
     })
 }
 

--- a/crates/prql-compiler/tests/integration/snapshots/integration__results@aggregation.prql.snap
+++ b/crates/prql-compiler/tests/integration/snapshots/integration__results@aggregation.prql.snap
@@ -1,6 +1,7 @@
 ---
-source: prql-compiler/tests/integration/main.rs
-expression: "# mssql:test\nfrom tracks\nfilter genre_id == 100\nderive empty_name = name == ''\naggregate {sum track_id, concat name, every empty_name, any empty_name}"
-input_file: prql-compiler/tests/integration/queries/aggregation.prql
+source: crates/prql-compiler/tests/integration/main.rs
+description: "# Running on dialect `sqlite`\n\n# Query:\n---\n# mssql:skip\n# mysql:skip\n# clickhouse:skip\nfrom tracks\nfilter genre_id == 100\nderive empty_name = name == ''\naggregate {sum track_id, concat_array name, every empty_name, any empty_name}\n"
+expression: "&result"
+input_file: crates/prql-compiler/tests/integration/queries/aggregation.prql
 ---
 0,,1,0


### PR DESCRIPTION
This restores the slightly more elegant `with_duplicates` approach, and uses insta's `description` field to note the currently running dialect