### PR TITLE
refactor: chinook to tables

### DIFF
--- a/web/playground/src/app/App.js
+++ b/web/playground/src/app/App.js
@@ -26,7 +26,7 @@ class App extends React.Component {
   state = {
     library: {
       examples,
-      chinook,
+      tables: chinook,
       book,
       "local storage": loadLocalStorage(),
     },


### PR DESCRIPTION
Fixes: #3201 

I saw that internally "chinook" word is used multiple times. So, rather than changing it entirely, I used an alias.