### PR TITLE
build: Add C++ minimal example

### DIFF
--- a/.github/workflows/test-lib.yaml
+++ b/.github/workflows/test-lib.yaml
@@ -35,3 +35,6 @@ jobs:
       - name: Run basic C example
         working-directory: bindings/prql-lib/examples/minimal-c
         run: make run
+      - name: Run basic C++ example
+        working-directory: bindings/prql-lib/examples/minimal-cpp
+        run: make run

--- a/bindings/prql-lib/examples/minimal-cpp/Makefile
+++ b/bindings/prql-lib/examples/minimal-cpp/Makefile
@@ -1,0 +1,17 @@
+PRQL_PROJECT=../../../..
+
+build-prql:
+	cargo build -p prql-lib --release
+
+# TODO: would be helpful to allow running with a debug build too.
+build: main.cpp build-prql
+	g++ main.cpp -o main.out \
+		-I${PRQL_PROJECT}/bindings/prql-lib \
+		-L${PRQL_PROJECT}/target/release \
+		${PRQL_PROJECT}/target/release/libprql_lib.a
+
+run: build
+	./main.out
+
+valgrind: build
+	valgrind ./main.out

--- a/bindings/prql-lib/examples/minimal-cpp/README.md
+++ b/bindings/prql-lib/examples/minimal-cpp/README.md
@@ -1,0 +1,7 @@
+# Basic C example
+
+A minimal example for using prql-lib with `gcc` and `make`.
+
+## How to run
+
+      make run

--- a/bindings/prql-lib/examples/minimal-cpp/README.md
+++ b/bindings/prql-lib/examples/minimal-cpp/README.md
@@ -1,7 +1,7 @@
-# Basic C example
+# Basic C++ example
 
 A minimal example for using prql-lib with `gcc` and `make`.
 
 ## How to run
 
-      make run
+    make run

--- a/bindings/prql-lib/examples/minimal-cpp/main.cpp
+++ b/bindings/prql-lib/examples/minimal-cpp/main.cpp
@@ -18,9 +18,6 @@ int main() {
 
     CompileResult res = compile(prql_query, nullptr);
     print_result(res);
-    if (sizeof(res.messages) != 0) {
-        return 1;
-    }
     result_destroy(res);
 
     return 0;

--- a/bindings/prql-lib/examples/minimal-cpp/main.cpp
+++ b/bindings/prql-lib/examples/minimal-cpp/main.cpp
@@ -1,0 +1,27 @@
+#include <cstring>
+#include <iostream>
+
+#include "libprql_lib.hpp"
+
+using namespace prql;
+
+void print_result(CompileResult res) {
+    if (strcmp(res.output, "") == 0) {
+        std::cout << "Output: <empty>\n\n";
+    } else {
+        std::cout << "Output:\n\n" << res.output;
+    }
+}
+
+int main() {
+    const auto prql_query = "from albums | select {album_id, title} | take 3";
+
+    CompileResult res = compile(prql_query, nullptr);
+    print_result(res);
+    if (sizeof(res.messages) != 0) {
+        return 1;
+    }
+    result_destroy(res);
+
+    return 0;
+}


### PR DESCRIPTION
A minimal C++ based upon the C example.

Includes the `libprql_lib.hpp` C++ header file, has a `using namespace` statement for the prql namespace and calls the `compile` function.

@aljazerzen can you peek at this?

I don't know if it possible to spruce it up with `std::string`, `std::vector`, for-each loop for messages, or something.