### PR TITLE
ci: Fix `check-published` job

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -176,7 +176,7 @@ jobs:
           else
             export published=false
           fi
-          echo "published=${published}" >>"$GITHUB_ENV"
+          echo "published=${published}" >>"$GITHUB_OUTPUT"
           echo "${published}"
 
   test-release-dry-run:


### PR DESCRIPTION
This wasn't working in https://github.com/PRQL/prql/actions/runs/5743166103/job/15570503983?pr=3222#step:9:19

(Though https://github.com/PRQL/prql/issues/3223 might supersede this...)
