### PR TITLE
tweak: Fix automerge

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -263,9 +263,10 @@ jobs:
           # - It's an backport to the web branch
           # - It's a pre-commit-ci update and there's only 1 commit — so it hasn't
           #   made any changes to files
-          github.actor == 'dependabot[bot]' || (github.base_ref ==
-          'refs/heads/web' && github.actor == 'prql-bot') || (github.actor ==
-          'pre-commit-ci' && steps.commit-count.outputs.commit-count == '1')
-        run: gh pr merge --auto --merge ${{github.event.pull_request.html_url}}
+          github.actor == 'dependabot[bot]' || (github.base_ref == 'web' &&
+          github.actor == 'prql-bot') || (github.actor == 'pre-commit-ci' &&
+          steps.commit-count.outputs.commit-count == '1')
+        run:
+          gh pr merge --auto --merge ${{ github.event.pull_request.html_url }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Weirdly `ref` and `base_ref` have different formats!
