### PR TITLE
docs: Refine Homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1182,7 +1182,7 @@ I especially want to give [Aljaž Mur Eržen](https://github.com/aljazerzen)
 (@aljazerzen) the credit he deserves, who has contributed the majority of the
 difficult work of building out the compiler. Much credit also goes to
 [Charlie Sanders](https://github.com/charlie-sanders) (@charlie-sanders), one of
-PRQL's earliest supporters and the author of PyPrql, and
+PRQL's earliest supporters and the author of pyprql, and
 [Ryan Patterson-Cross](https://github.com/rbpatt2019) (@rbpatt2019), who built
 the Jupyter integration among other Python contributions.
 

--- a/bindings/prql-python/README.md
+++ b/bindings/prql-python/README.md
@@ -3,7 +3,7 @@
 `prql-python` offers Rust bindings to the `prql-compiler` Rust library. It
 exposes a Python method `compile(query: str) -> str`.
 
-This is consumed by [PyPrql](https://github.com/prql/PyPrql) &
+This is consumed by [pyprql](https://github.com/prql/pyprql) &
 [dbt-prql](https://github.com/prql/dbt-prql).
 
 The crate is not published to crates.io; only to PyPI at

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -176,7 +176,7 @@ integrations_section:
     - label: "ClickHouse"
       link: https://clickhouse.com/docs/en/guides/developer/alternative-query-languages
       text: |
-        ClickHouse natively supports PRQL with 
+        ClickHouse natively supports PRQL with
 
         `SET dialect = 'prql'`
 

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -147,7 +147,7 @@ tools_section:
         "Online in-browser playground that compiles PRQL to SQL as you type."
 
     - link: https://pyprql.readthedocs.io/
-      label: "PyPrql"
+      label: "pyprql"
       text: |
         Provides Jupyter/IPython cell magic and Pandas accessor.
 
@@ -169,17 +169,20 @@ integrations_section:
     - label: "Jupyter/IPython"
       link: https://pyprql.readthedocs.io/en/latest/magic_readme.html
       text:
-        "PyPrql contains a Jupyter extension, which executes a PRQL cell against
+        "pyprql contains a Jupyter extension, which executes a PRQL cell against
         a database. It can also set up an in-memory DuckDB instance, populated
         with a pandas DataFrame."
 
     - label: "ClickHouse"
       link: https://clickhouse.com/docs/en/guides/developer/alternative-query-languages
-      text: ClickHouse natively supports PRQL with `SET dialect = 'prql'`
+      text: |
+        ClickHouse natively supports PRQL with 
+
+        `SET dialect = 'prql'`
 
     - label: Visual Studio Code
       link: https://marketplace.visualstudio.com/items?itemName=prql-lang.prql-vscode
-      text: Extension with syntax highlighting and an upcoming language server.
+      text: Extension with syntax highlighting and live SQL compilation.
 
     - label: "Prefect"
       link: https://prql-lang.org/book/project/integrations/prefect.html
@@ -209,7 +212,12 @@ bindings_section:
     - link: "https://crates.io/crates/prql-compiler"
       label: "prql-compiler"
       text: |
-        Reference compiler implementation, written in Rust. Transpile, format and annotate PRQL queries.
+        Compiler implementation, written in Rust. Compile, format & annotate PRQL queries.
+
+    - link: https://prql-lang.org/book/project/bindings/index.html
+      label: Others
+      text: |
+        Java, C, C++, Elixir, .NET, and PHP have unsupported or nascent bindings.
 
 testimonials_section:
   enable: true


### PR DESCRIPTION
Add a section for "other bindings", align capitalization of `pyprql`, refine wording
