### PR TITLE
feat: Limit quotes to an odd number of quotes

### DIFF
--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -293,16 +293,14 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
 }
 
 fn quoted_string(escaped: bool) -> impl Parser<char, String, Error = Cheap<char>> {
-    // I don't know how this could be simplified and implemented for n>3 in general
+    // I don't know how this could be simplified and implemented for n*2 in general
     choice((
-        quoted_string_inner(r#""""""""#, escaped),
+        quoted_string_inner(r#"""""""""#, escaped),
         quoted_string_inner(r#"""""""#, escaped),
-        quoted_string_inner(r#""""""#, escaped),
         quoted_string_inner(r#"""""#, escaped),
         quoted_string_inner(r#"""#, escaped),
-        quoted_string_inner(r#"''''''"#, escaped),
+        quoted_string_inner(r#"'''''''"#, escaped),
         quoted_string_inner(r#"'''''"#, escaped),
-        quoted_string_inner(r#"''''"#, escaped),
         quoted_string_inner(r#"'''"#, escaped),
         quoted_string_inner(r#"'"#, escaped),
     ))

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -293,7 +293,7 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
 }
 
 fn quoted_string(escaped: bool) -> impl Parser<char, String, Error = Cheap<char>> {
-    // I don't know how this could be simplified and implemented for n*2 in general
+    // I don't know how this could be simplified and implemented for (n*2)+1 in general
     choice((
         quoted_string_inner(r#"""""""""#, escaped),
         quoted_string_inner(r#"""""""#, escaped),

--- a/web/book/src/reference/syntax/literals.md
+++ b/web/book/src/reference/syntax/literals.md
@@ -41,8 +41,9 @@ from my_table
 select x = 'hello world'
 ```
 
-To quote a string containing quotes, either use the "other" type of quote, or
-use 3, 4, 5 or 6 quotes, and close with the same number.
+To quote a string containing quotes, either use the "other" type of quote, or an
+odd number{{footnote: currently up to 7}} of quotes, and close with the same
+number.
 
 ```prql
 from my_table


### PR DESCRIPTION
With an even number of quotes, it's ambiguous whether it represents an empty string or the start of a new string — i.e. `""""` could be:
- `""` followed by `""` 
- or an opening `""""`.
