### PR TITLE
fix: Fix Clippy lint

### DIFF
--- a/crates/prql-compiler/tests/integration/main.rs
+++ b/crates/prql-compiler/tests/integration/main.rs
@@ -1,7 +1,6 @@
 #![cfg(not(target_family = "wasm"))]
 #![cfg(any(feature = "test-dbs", feature = "test-dbs-external"))]
 
-use std::collections::BTreeMap;
 use std::{env, fs};
 
 use anyhow::Context;
@@ -9,7 +8,6 @@ use insta::{assert_snapshot, glob};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use similar_asserts::assert_eq;
 use strum::IntoEnumIterator;
 use tokio::runtime::Runtime;
 


### PR DESCRIPTION
This happened in the integration tests, which we don't check for in PRs any longer, because of the duckdb caching issues. Not ideal, but shouldn't happen often and shoudn't last for too long
