### PR TITLE
docs: prqlc is now installable via winget

### DIFF
--- a/crates/prqlc/README.md
+++ b/crates/prqlc/README.md
@@ -74,6 +74,12 @@ take 3
 brew install prqlc
 ```
 
+### via winget (Windows)
+
+```sh
+winget install prqlc
+```
+
 ### From GitHub release page
 
 Precompiled binaries are available for Linux, macOS, and Windows on the

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -162,6 +162,8 @@ tools_section:
 
         `brew install prqlc`
 
+        `winget install prqlc`
+
 integrations_section:
   enable: true
   title: "Integrations"


### PR DESCRIPTION
Related to #2599

```sh
❯ winget install prqlc
見つかりました PRQL compiler CLI - prqlc [PRQL.prqlc] バージョン 0.9.3
このアプリケーションは所有者からライセンス供与されます。
Microsoft はサードパーティのパッケージに対して責任を負わず、ライセンスも付与しません。
ダウンロード中 https://github.com/PRQL/prql/releases/download/0.9.3/prqlc-v0.9.3-x86_64-pc-windows-msvc.zip
  █████████▊                      1024 KB / 3.04 MB
```