### PR TITLE
feat: Allow s & f strings to contain expressions

### DIFF
--- a/crates/prql-parser/src/lib.rs
+++ b/crates/prql-parser/src/lib.rs
@@ -121,6 +121,20 @@ mod common {
     }
 }
 
+use prql_ast::expr::Expr;
+
+fn parse_expr(source: &str) -> Result<Expr, Vec<Error>> {
+    let tokens = Parser::parse(&lexer::lexer(), source).map_err(|errs| {
+        errs.into_iter()
+            .map(|err| convert_lexer_error(source, err, 0))
+            .collect::<Vec<_>>()
+    })?;
+
+    let stream = prepare_stream(tokens, source, 0);
+    Parser::parse(&expr::expr_call().then_ignore(end()), stream)
+        .map_err(|errs| errs.into_iter().map(convert_parser_error).collect())
+}
+
 #[cfg(test)]
 mod test {
 


### PR DESCRIPTION
This doesn't work at all, but using it to ask a question of the best way of doing #3279 — how can we parse an expression from within another parser?

Here's the relevant line: https://github.com/PRQL/prql/compare/main...max-sixty:prql:try-s-string-expr?expand=1#diff-f3825716552312a9ef9f74ba3196b570761c8907b541923cdd5f6f4dcebb677fR162-R164

