### PR TITLE
docs: Re-write string docs

### DIFF
--- a/web/book/src/reference/syntax/literals.md
+++ b/web/book/src/reference/syntax/literals.md
@@ -76,22 +76,11 @@ the same number.
 
 ```prql
 from artists
-select x = "\"hello world\""
-```
-
-```prql
-from artists
-select x = '"hello world"'
-```
-
-```prql
-from artists
-select x = """I said "hello world"!"""
-```
-
-```prql
-from artists
-select x = """""I said """hello world"""!"""""
+select {
+  escaped = "\"hello world\"",
+  other   = '"hello world"',
+  triple  = """I said "hello world"!""",
+}
 ```
 
 See also:

--- a/web/book/src/reference/syntax/literals.md
+++ b/web/book/src/reference/syntax/literals.md
@@ -29,43 +29,69 @@ select {
 
 ## Strings
 
-String literals can use either single or double quotes:
+String literals can use any matching odd number of either single or double
+quotes:
 
 ```prql
-from my_table
-select x = "hello world"
+from artists
+derive {
+  single        =   'hello world',
+  double        =   "hello world",
+  double_triple = """hello world""",
+}
+```
+
+Strings can contain any escapes defined by
+[JSON standard](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
+
+```prql
+from artists
+derive escapes = "\t\tline ends here\n \\ "
+derive world = "\u0048\u0065\u006C\u006C\u006F"
+```
+
+### R-strings
+
+To handle escapes as raw characters, use an r-string:
+
+```prql
+from artists
+derive normal_string =  "\\\t"
+derive raw_string    = r"\\\t"
+```
+
+```admonish note
+These escape rules specify how PRQL interprets escape characters when compiling
+strings to SQL, not necessarily how the database will interpret the string.
+Dialects interpret escape characters differently, and PRQL doesn't yet account for
+these differences. Please open issues with any difficulties in the current
+implementation.
+```
+
+### Quoting quotations
+
+To quote a string containing quotes, escape the quotes, use the "other" type of
+quote, or an odd number{{footnote: currently up to 7}} of quotes, and close with
+the same number.
+
+```prql
+from artists
+select x = "\"hello world\""
 ```
 
 ```prql
-from my_table
-select x = 'hello world'
-```
-
-To quote a string containing quotes, either use the "other" type of quote, or an
-odd number{{footnote: currently up to 7}} of quotes, and close with the same
-number.
-
-```prql
-from my_table
+from artists
 select x = '"hello world"'
 ```
 
 ```prql
-from my_table
+from artists
 select x = """I said "hello world"!"""
 ```
 
 ```prql
-from my_table
+from artists
 select x = """""I said """hello world"""!"""""
-```
-
-Strings can also contain any escape defined by
-[JSON standard](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
-
-```prql
-from my_table
-select x = "\t\tline ends here\n \\ "
 ```
 
 See also:

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__0.snap
@@ -1,0 +1,9 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "from artists\nselect x = \"\\\"hello world\\\"\"\n"
+---
+SELECT
+  '"hello world"' AS x
+FROM
+  artists
+

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__0.snap
@@ -1,9 +1,11 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from artists\nselect x = \"\\\"hello world\\\"\"\n"
+expression: "from artists\nselect {\n  escaped = \"\\\"hello world\\\"\",\n  other   = '\"hello world\"',\n  triple  = \"\"\"I said \"hello world\"!\"\"\",\n}\n"
 ---
 SELECT
-  '"hello world"' AS x
+  '"hello world"' AS escaped,
+  '"hello world"' AS other,
+  'I said "hello world"!' AS triple
 FROM
   artists
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__1.snap
@@ -1,0 +1,9 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "from artists\nselect x = '\"hello world\"'\n"
+---
+SELECT
+  '"hello world"' AS x
+FROM
+  artists
+

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__2.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__2.snap
@@ -1,0 +1,9 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "from artists\nselect x = \"\"\"I said \"hello world\"!\"\"\"\n"
+---
+SELECT
+  'I said "hello world"!' AS x
+FROM
+  artists
+

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__3.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__quoting-quotations__3.snap
@@ -1,0 +1,9 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "from artists\nselect x = \"\"\"\"\"I said \"\"\"hello world\"\"\"!\"\"\"\"\"\n"
+---
+SELECT
+  'I said """hello world"""!' AS x
+FROM
+  artists
+

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__r-strings__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__r-strings__0.snap
@@ -1,0 +1,11 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "from artists\nderive normal_string =  \"\\\\\\t\"\nderive raw_string    = r\"\\\\\\t\"\n"
+---
+SELECT
+  *,
+  '\	' AS normal_string,
+  '\\\t' AS raw_string
+FROM
+  artists
+

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__strings__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__strings__0.snap
@@ -1,9 +1,12 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from my_table\nselect x = \"hello world\"\n"
+expression: "from artists\nderive {\n  single        =   'hello world',\n  double        =   \"hello world\",\n  double_triple = \"\"\"hello world\"\"\",\n}\n"
 ---
 SELECT
-  'hello world' AS x
+  *,
+  'hello world' AS single,
+  'hello world' AS double,
+  'hello world' AS double_triple
 FROM
-  my_table
+  artists
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__strings__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__strings__1.snap
@@ -1,9 +1,12 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from my_table\nselect x = 'hello world'\n"
+expression: "from artists\nderive escapes = \"\\t\\tline ends here\\n \\\\ \"\nderive world = \"\\u0048\\u0065\\u006C\\u006C\\u006F\"\n"
 ---
 SELECT
-  'hello world' AS x
+  *,
+  '		line ends here
+ \ ' AS escapes,
+  'Hello' AS world
 FROM
-  my_table
+  artists
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__strings__2.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__strings__2.snap
@@ -1,9 +1,10 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from my_table\nselect x = '\"hello world\"'\n"
+expression: "from artists\nselect x = \"\\t\\tline ends here\\n \\\\ \"\n"
 ---
 SELECT
-  '"hello world"' AS x
+  '		line ends here
+ \ ' AS x
 FROM
-  my_table
+  artists
 


### PR DESCRIPTION
I'm not sure we actually should have done the `r` strings — we're compiling for another language, not the final result, so `\t\t` would have been pretty reasonable to keep as `\t\t` rather than two tab characters.

I'm not in a rush to revert though — folks can always just use the r-strings to get the same thing.
