### PR TITLE
ci: Rename `prql-bot` token

### DIFF
--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -60,7 +60,7 @@ jobs:
       - uses: tibdex/backport@v2
         with:
           # This is a personal access token from the @prql-bot
-          github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
           # Docs are at https://github.com/tibdex/backport/blob/main/action.yml
           # We only use `web` atm
           label_pattern: "^pr-backport-(?<base>([^ ]+))$"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -270,4 +270,4 @@ jobs:
           gh pr merge --auto --squash --delete-branch ${{
           github.event.pull_request.html_url }}
         env:
-          GITHUB_TOKEN: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.HOMEBREW_PRQL_TOKEN }}
+          github-token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'prql',


### PR DESCRIPTION
We're using it for more than backporting now.

I haven't deleted the old one, I'll try and remember to do that in a couple months when I see it unused.
