### PR TITLE
ci: Don't run `unreferenced-snapshots` on `main`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -134,6 +134,7 @@ jobs:
       # https://github.com/duckdb/duckdb-rs/issues/178 is fixed given compile
       # times
       features: ""
+      nightly: ${{ needs.rules.outputs.nightly == 'true' }}
 
   test-python:
     needs: rules

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -13,6 +13,10 @@ on:
       features:
         type: string
         required: true
+      nightly:
+        description: "Whether to run extra tests (this is not nightly rust)"
+        type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -71,13 +75,17 @@ jobs:
         uses: richb-hanover/cargo@v1.1.0
         with:
           command: insta
-          # Here, we also add:
-          # - Unreferenced snapshots - `--unreferenced=auto` when testing on
-          #   linux & with `test-dbs` feature.
+          # Now replaced with whether `nightly` is true, because we only run
+          # these on merges, which was making post-merge failures more frequent.
+          #
+          # # Here, we also add:
+          # # - Unreferenced snapshots - `--unreferenced=auto` when testing on
+          # #   linux & with `test-dbs` feature.
+          # ${{ contains(inputs.features, 'test-dbs') && inputs.target ==
+          # 'x86_64-unknown-linux-gnu' && '--unreferenced=auto' || '' }}
           args: >
             test --target=${{ inputs.target }} --features=${{ inputs.features }}
-            ${{ contains(inputs.features, 'test-dbs') && inputs.target ==
-            'x86_64-unknown-linux-gnu' && '--unreferenced=auto' || '' }}
+            ${{ inputs.nightly == 'true' && '--unreferenced=auto' || '' }}
       - name: 📎 Clippy
         uses: richb-hanover/cargo@v1.1.0
         with:


### PR DESCRIPTION
We don't test this in PRs, so we've already had a couple of post-merge failures, and it's not that important — the main thing we want to prevent is someone running `task test-rust` and randomly getting a huge diff (or snapshots accumulating). So now we run only on nightly.