### PR TITLE
ci: Move `measure-code-coverage` from `test-all`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -73,6 +73,7 @@ jobs:
       rust: ${{ steps.changes.outputs.rust }}
       # Run most test (`all` is a misnomer!)
       test-all: ${{ steps.all.outputs.run }}
+      web: ${{ steps.changes.outputs.web }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -228,7 +228,7 @@ jobs:
     with:
       # Currently we never run Mac, see prql-elixir docs for details
       oss:
-        ${{ (needs.rules.outputs.java == 'true' || needs.rules.outputs.nightly
+        ${{ (needs.rules.outputs.elixir == 'true' || needs.rules.outputs.nightly
         == 'true') && '["ubuntu-latest", "windows-latest"]' ||
         '["ubuntu-latest"]' }}
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -62,18 +62,18 @@ jobs:
     outputs:
       book: ${{ steps.changes.outputs.book }}
       dotnet: ${{ steps.changes.outputs.dotnet }}
+      elixir: ${{ steps.changes.outputs.elixir }}
+      java: ${{ steps.changes.outputs.java }}
       js: ${{ steps.changes.outputs.js }}
+      lib: ${{ steps.changes.outputs.lib }}
       # Really run all tests
       nightly: ${{ steps.nightly.outputs.run }}
-      python: ${{ steps.changes.outputs.python }}
-      lib: ${{ steps.changes.outputs.lib }}
-      java: ${{ steps.changes.outputs.java }}
-      elixir: ${{ steps.changes.outputs.elixir }}
       php: ${{ steps.changes.outputs.php }}
+      python: ${{ steps.changes.outputs.python }}
       rust: ${{ steps.changes.outputs.rust }}
       # Run most test (`all` is a misnomer!)
       test-all: ${{ steps.all.outputs.run }}
-      web: ${{ steps.changes.outputs.web }}
+
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
@@ -88,28 +88,30 @@ jobs:
             book:
               - .github/workflows/check-links-book.yaml
               - web/book/**
-            lib:
-              - bindings/prql-lib/**
-              - .github/workflows/test-lib.yaml
-            php:
-              - bindings/prql-php/**
-              - bindings/prql-lib/**
-              - .github/workflows/test-php.yaml
-            java:
-              - bindings/prql-java/**
-              - bindings/prql-lib/**
-              - .github/workflows/test-java.yaml
-            elixir:
-              - bindings/prql-elixir/**
-              - bindings/prql-lib/**
-              - .github/workflows/test-elixir.yaml
             dotnet:
               - bindings/prql-dotnet/**
               - bindings/prql-lib/**
               - .github/workflows/test-dotnet.yaml
+            elixir:
+              - bindings/prql-elixir/**
+              - bindings/prql-lib/**
+              - .github/workflows/test-elixir.yaml
+            java:
+              - bindings/prql-java/**
+              - bindings/prql-lib/**
+              - .github/workflows/test-java.yaml
             js:
               - bindings/prql-js/**
               - .github/workflows/test-js.yaml
+            lib:
+              - bindings/prql-lib/**
+              - .github/workflows/test-lib.yaml
+            nightly:
+              - .github/workflows/nightly.yaml
+            php:
+              - bindings/prql-php/**
+              - bindings/prql-lib/**
+              - .github/workflows/test-php.yaml
             python:
               - bindings/prql-python/**
               - .github/workflows/test-python.yaml
@@ -117,12 +119,11 @@ jobs:
               - "**/*.rs"
               - crates/**
               - web/book/**
-            nightly:
-              - .github/workflows/nightly.yaml
             web:
               - "web/**"
               - ".github/workflows/build-web.yaml"
               - "**.md"
+
       - id: nightly
         run:
           echo "run=${{ steps.changes.outputs.nightly == 'true' ||
@@ -280,7 +281,9 @@ jobs:
     # mistakes such as forgetting to list an .md file in SUMMARY.md.
     # Running a link checker on the generated HTML is more reliable.
     needs: rules
-    if: needs.rules.outputs.book == 'true'
+    if:
+      needs.rules.outputs.book == 'true' || needs.rules.outputs.nightly ==
+      'true'
 
     runs-on: ubuntu-latest
 
@@ -302,10 +305,42 @@ jobs:
           shared-key: web
           # Created by `build-web`
           save-if: false
+      # Only build the book — rather than `build-web` which also builds the playground
       - name: Build the mdbook
         run: mdbook build web/book/
       - name: Check links
         run: hyperlink web/book/book/
+
+  measure-code-cov:
+    runs-on: ubuntu-latest
+    needs: rules
+    # TODO: Would be great to have this running on every PR, but
+    # waiting on https://github.com/PRQL/prql/issues/2870. We could enable it
+    # but not wait for it?
+    if: needs.rules.outputs.test-all == 'true'
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-tarpaulin
+      - run: ./.github/set_version.sh
+        shell: bash
+      - name: 💰 Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          prefix-key: ${{ env.version }}
+      - run:
+          cargo tarpaulin --skip-clean --all-targets --features=test-dbs
+          --out=Xml
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+      - name: Upload code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: cobertura.xml
 
   check-ok-to-merge:
     # This doesn't run anything, but offers a task for us to tell GitHub

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -69,34 +69,6 @@ jobs:
       target: ${{ matrix.target }}
       features: ${{ matrix.features }}
 
-  measure-code-cov:
-    runs-on: ubuntu-latest
-    # TODO: see whether we can add this job to the pull-request workflow,
-    # possibly waiting for https://github.com/PRQL/prql/issues/2870
-    steps:
-      - name: 📂 Checkout code
-        uses: actions/checkout@v3
-      - uses: baptiste0928/cargo-install@v2
-        with:
-          crate: cargo-tarpaulin
-      - run: ./.github/set_version.sh
-        shell: bash
-      - name: 💰 Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          prefix-key: ${{ env.version }}
-      - run:
-          cargo tarpaulin --skip-clean --all-targets --features=test-dbs
-          --out=Xml
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
-      - name: Upload code coverage results
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
-
   time-compilation:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-elixir.yaml
+++ b/.github/workflows/test-elixir.yaml
@@ -27,8 +27,7 @@ jobs:
   test:
     strategy:
       matrix:
-        # Currently disabling mac tests, see prql-elixir/readme.md for more details.
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(inputs.oss) }}
         otp: ["25.1.2"]
         elixir: ["1.14.2"]
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
We're fairly close to finishing this. The previous PR was all the things that will cut the CI time down, by reducing the number of jobs for the standard `test-all` case. This is a small refinement, and we can finish these off & update the comments at leisure.
