### PR TITLE
ci: Use npm cache in `build-web`

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -50,6 +50,8 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
 
       - run: ./.github/set_version.sh
 


### PR DESCRIPTION
Not sure how space-efficient this will be, we're kinda at a limit now...
