### PR TITLE
ci: Also build prqlc on merges

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -429,7 +429,7 @@ jobs:
   build-prqlc:
     runs-on: ${{ matrix.os }}
     needs: rules
-    if: needs.rules.outputs.rust == 'true'
+    if: needs.rules.outputs.rust == 'true' || needs.rules.outputs.main == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Forgot to add that condition, was _only_ building on PRs
