### PR TITLE
docs(book): remove outdated R example

### DIFF
--- a/web/book/src/project/bindings/r.md
+++ b/web/book/src/project/bindings/r.md
@@ -17,20 +17,3 @@ Check out <https://eitsupi.github.io/prqlr/> for more context.
 ```r
 install.packages("prqlr")
 ```
-
-## Usage
-
-```r
-library(prqlr)
-
-"
-from employees
-join salaries [emp_id]
-group [dept_id, gender] (
-  aggregate {
-    avg_salary = average salary
-  }
-)
-" |>
-  prql_compile()
-```


### PR DESCRIPTION
The latest prqlr supports PRQL 0.9.

Perhaps it would be better to just link to the prqlr documentation instead of writing an untested code block here.