### PR TITLE
ci: Remove label spec for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: "/"
-    labels:
-      - pr-test-all
     schedule:
       interval: daily
     ignore:


### PR DESCRIPTION
CI now handles this itself now, because of the files which get changes
