### PR TITLE
ci: change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
           files: ${{ steps.build-artifact.outputs.artifact-name }}
 
   winget-release:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: build-prqlc
     if: github.ref_type == 'tag' && !inputs.dry-run
     steps:


### PR DESCRIPTION
Winget Releaser supports non-Windows runners, and `ubuntu-latest` is generally faster.