### PR TITLE
docs: Restrict readme GH badge to push events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <!-- [![Twitter](https://img.shields.io/twitter/follow/prql_lang?color=%231DA1F2&style=for-the-badge)](https://twitter.com/prql_lang) -->
 <!-- Dev badges on second line -->
 
-[![GitHub CI Status](https://img.shields.io/github/actions/workflow/status/PRQL/prql/pull-request.yaml?branch=main&logo=github&style=for-the-badge)](https://github.com/PRQL/prql/actions?query=branch%3Amain+workflow%3Apull-request)
+[![GitHub CI Status](https://img.shields.io/github/actions/workflow/status/prql/prql/pull-request.yaml?event=push&branch=main&logo=github&style=for-the-badge)](https://github.com/PRQL/prql/actions?query=branch%3Amain+workflow%3Apull-request)
 [![GitHub contributors](https://img.shields.io/github/contributors/PRQL/prql?style=for-the-badge)](https://github.com/PRQL/prql/graphs/contributors)
 [![Stars](https://img.shields.io/github/stars/PRQL/prql?style=for-the-badge)](https://github.com/PRQL/prql/stargazers)
 


### PR DESCRIPTION
This prevents a PR that's on a fork's `main` branch for causing this to show a failure. This is rare, but happening atm.
