### PR TITLE
ci: Dependabot does patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,20 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: daily
+      # Running daily means the GHA cache will be cycling much faster, and we're
+      # not in a great rush. So trying weekly, and we can iterate.
+      interval: weekly
     ignore:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
     commit-message:
       prefix: "chore: "
+    # Bump all patch versions of rust dependencies as a single PR
+    groups:
+      patch:
+        update-types:
+          - patch
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Now grouped into a single PR per week.

Also reduced the frequency to prevent GHA cache cycling
