### PR TITLE
build: Update Snap from core20 to core22

### DIFF
--- a/packages/snap/snapcraft.yaml
+++ b/packages/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
-name: prqlc # you probably want to 'snapcraft register <name>'
+name: prqlc
 title: PRQL Compiler
-base: core20 # the base snap is the execution environment for this snap
+base: core22
 version: git
 summary: CLI for PRQL, a modern language for transforming data
 description: |


### PR DESCRIPTION
Update to core22 which is the new recommended base.