### PR TITLE
ci(winget-release): fix version ref

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,7 @@ jobs:
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: PRQL.prqlc
-          version: ${{ github.ref }}
+          version: ${{ github.ref_name }}
           installers-regex: '^prqlc-.*-windows-.*\.zip$'
           token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
           fork-user: prql-bot


### PR DESCRIPTION
The latest workflow run was failed due to the invalid version (`refs/tags/0.9.4`).

```log
Executing command: java -jar komac.jar update --id 'PRQL.prqlc' --version refs/tags/0.9.4 --urls 'https://github.com/PRQL/prql/releases/download/0.9.4/prqlc-v0.9.4-x86_64-pc-windows-msvc.zip' --submit
```

<https://github.com/PRQL/prql/actions/runs/5957270684/job/16160037100#step:2:75>

The version should be `0.9.4`, which can be referenced via `github.ref_name`.