### PR TITLE
ci: Disable snap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,7 +145,9 @@ jobs:
 
   build-and-publish-snap:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.dry-run }}
+    # This is failing at the moment https://github.com/PRQL/prql/issues/3386
+    # if: ${{ !inputs.dry-run }}
+    if: ${{ false }}
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Let's try and enable it with a PR. But even after https://github.com/snapcore/action-build/issues/62, this is failing — I think possible it's on us not the action...

(and it's causing builds to break, so our convention is to remove and then revert rather than keep it failing on main)

CC @vanillajonathan FYI
