### PR TITLE
ci: Re-enable inline docker cache

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -49,8 +49,9 @@ jobs:
             'workflow_dispatch' }}
           cache-from: |
             ${{ steps.meta.outputs.tags }}
+            type=gha
+          cache-to: |
+            type=inline
           # Disabling GHA cache due to Https://github.com/docker/build-push-action/issues/939
-          # type=gha
-          # cache-to: |
           # ${{ github.ref_name == 'main' && 'type=gha,mode=max' || '' }}
           # type=inline


### PR DESCRIPTION
While keeping GHA docker cache disabled.

Ref #3394
