### PR TITLE
fix: Potentially fix logic error

### DIFF
--- a/crates/prql-compiler/src/utils/mod.rs
+++ b/crates/prql-compiler/src/utils/mod.rs
@@ -101,7 +101,7 @@ where
 
     fn any_true(self) -> Option<bool> {
         self.cloned()
-            .fold(Some(true), |a, x| a.zip(x).map(|(a, b)| a && b))
+            .fold(Some(true), |a, x| a.zip(x).map(|(a, b)| a || b))
     }
 }
 


### PR DESCRIPTION
Am I missing something or are `all` & `any` the same at the moment? Is this change correct?
