### PR TITLE
ci: Never run full link check outside of schedule

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -322,9 +322,10 @@ jobs:
         uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          # Run on all files in nightly, but only our own changed files in PRs
+          # Run on all files in nightly schedule, but only on local files
+          # otherwise (and only changed files in PRs)
           config-file:
-            ${{ needs.rules.outputs.nightly == 'true' &&
+            ${{ needs.rules.outputs.nightly-schedule == 'true' &&
             '.config/.markdown-link-check-all.json' ||
             '.config/.markdown-link-check-local.json' }}
           base-branch: main


### PR DESCRIPTION
(probably the term "nightly" has been overused and is now confusing things like this, but it would be too much of a reckoning with my past to change it to `all`...)
