### PR TITLE
ci: Use `github.event_name` for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
   brew-dispatcher:
     name: Release on homebrew-prql
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag'
+    if: github.event_name == 'release'
     steps:
       - uses: actions/github-script@v6
         with:
@@ -58,7 +58,7 @@ jobs:
           target: ${{ matrix.target }}
           profile: release
       - name: Upload release artifact
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           append_body: true
@@ -67,7 +67,7 @@ jobs:
   winget-release:
     runs-on: ubuntu-latest
     needs: build-prqlc
-    if: github.ref_type == 'tag'
+    if: github.event_name == 'release'
     steps:
       - name: publish
         uses: vedantmgoyal2009/winget-releaser@v2
@@ -98,7 +98,7 @@ jobs:
           package: prqlc
           package_root: .debpkg
           maintainer: The PRQL Project
-          version: ${{ github.ref_type == 'tag' && github.ref_name || 0 }}
+          version: ${{ github.event_name == 'release' && github.ref_name || 0 }}
           desc: >
             prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and
             offers various diagnostics.
@@ -127,7 +127,7 @@ jobs:
           package_root: .rpmpkg
           maintainer: The PRQL Project
           vendor: The PRQL Project
-          version: ${{ github.ref_type == 'tag' && github.ref_name || 0 }}
+          version: ${{ github.event_name == 'release' && github.ref_name || 0 }}
           desc: >
             prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and
             offers various diagnostics.
@@ -138,7 +138,7 @@ jobs:
 
   build-and-publish-snap:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_type == 'tag' }}
+    if: ${{ github.event_name == 'release' }}
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
@@ -148,7 +148,7 @@ jobs:
         id: build
         uses: snapcore/action-build@v1
       - name: 🆙 Publish Snap
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'release'
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS:
@@ -180,7 +180,7 @@ jobs:
   publish-prql-python:
     runs-on: ubuntu-latest
     needs: [build-python-wheels]
-    if: github.ref_type == 'tag'
+    if: github.event_name == 'release'
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -208,7 +208,9 @@ jobs:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm publish ${{ (github.ref_type != 'tag') && '--dry-run' || '' }}
+      - run:
+          npm publish ${{ (github.event_name != 'release') && '--dry-run' || ''
+          }}
         working-directory: bindings/prql-js/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -225,8 +227,8 @@ jobs:
       # https://github.com/crate-ci/cargo-release/issues/691
       # --no-verify is required to prevent build.
       - run:
-          cargo release publish --no-confirm ${{ github.ref_type == 'tag' &&
-          '--execute' || '--no-verify --package prql-ast'}}
+          cargo release publish --no-confirm ${{ github.event_name == 'release'
+          && '--execute' || '--no-verify --package prql-ast'}}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -251,14 +253,14 @@ jobs:
 
   push-web-branch:
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag'
+    if: github.event_name == 'release'
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
       - run: git push origin HEAD:web --force
 
   push-devcontainer:
-    if: github.ref_type == 'tag'
+    if: github.event_name == 'release'
     uses: ./.github/workflows/build-devcontainer.yaml
     with:
       push: true


### PR DESCRIPTION
Conceptually closer to our goal.

Inspired by, and possibly fixes https://github.com/PRQL/prql/issues/3382
