### PR TITLE
ci: Add back integration tests into PR builds

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -77,17 +77,13 @@ jobs:
         uses: richb-hanover/cargo@v1.1.0
         with:
           command: insta
-          # Now replaced with whether `nightly` is true, because we only run
-          # these on merges, which was making post-merge failures more frequent.
-          #
-          # # Here, we also add:
-          # # - Unreferenced snapshots - `--unreferenced=auto` when testing on
-          # #   linux & with `test-dbs` feature.
-          # ${{ contains(inputs.features, 'test-dbs') && inputs.target ==
-          # 'x86_64-unknown-linux-gnu' && '--unreferenced=auto' || '' }}
+          # Here, we also add:
+          # - Unreferenced snapshots - `--unreferenced=auto` when testing on
+          #   linux & with `test-dbs` feature.
           args: >
             test --target=${{ inputs.target }} --features=${{ inputs.features }}
-            ${{ inputs.nightly == 'true' && '--unreferenced=auto' || '' }}
+            ${{ contains(inputs.features, 'test-dbs') && inputs.target ==
+            'x86_64-unknown-linux-gnu' && '--unreferenced=auto' || '' }}
       - name: 📎 Clippy
         uses: richb-hanover/cargo@v1.1.0
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -155,12 +155,15 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            features: test-dbs-external
           # Only run wasm on ubuntu, given it's the same rust target. (There is a
           # possibility of having a failure on just one platform, but it's quite
           # unlikely. If we do observe this, we can expand, or introduce a
           # `test-actually-all.yaml` which accounts for these corner cases without
           # using runners & cache space)
           - target: wasm32-unknown-unknown
+            os: ubuntu-latest
     with:
       os: ubuntu-latest
       target: ${{ matrix.target }}
@@ -280,9 +283,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            features: test-dbs-external
           - os: macos-latest
             target: x86_64-apple-darwin
             features: test-dbs


### PR DESCRIPTION
The upstream issue re caching seems to have been fixed! Possibly this is something that's coincident and it reoccurs — revert this if that turns out to be the case.
