### PR TITLE
fix: Do not panic for invalid lineage in transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Fix stack overflow on very long queries in Windows debug builds (@max-sixty,
   #2908)
 
+- Fix panic when unresolved lineage appears in group or window (@davidot, #3266)
+
 **Documentation**:
 
 **Web**:

--- a/crates/prql-compiler/src/semantic/resolver/transforms.rs
+++ b/crates/prql-compiler/src/semantic/resolver/transforms.rs
@@ -1071,27 +1071,4 @@ mod tests {
             - Wildcard
         "###);
     }
-
-    // #[test]
-    // fn test_invalid_lineage_in_transform() {
-    //     let result = parse_resolve_and_lower(
-    //         "
-    //     from tbl
-    //     group id (
-    //         sort -val
-    //     )
-    //     ",
-    //     );
-    //     assert!(result.is_err());
-
-    //     let result = parse_resolve_and_lower(
-    //         "
-    //     from tbl
-    //     window rows:-3..3 (
-    //         sort -val
-    //     )
-    //     ",
-    //     );
-    //     assert!(result.is_err());
-    // }
 }

--- a/crates/prql-compiler/src/tests/test_bad_error_messages.rs
+++ b/crates/prql-compiler/src/tests/test_bad_error_messages.rs
@@ -151,3 +151,15 @@ fn misplaced_type_error() {
     ───╯
     "###);
 }
+
+#[test]
+fn invalid_lineage_in_transform() {
+    assert_display_snapshot!(compile(r###"
+  from tbl
+  group id (
+    sort -val
+  )
+  "###).unwrap_err(), @r###"
+  Error: "Invalid lineage in group, verify the contents of the group call"
+  "###);
+}


### PR DESCRIPTION
Makes the case in #3266 not panic.
But it gives a horrible error code dumping the ast? node or something like that.

Also this is essentially my first rust usage, so feel free to point out any rust things I'm doing wrong

Fixes #3266

The error with the input from the issue:

```
Error: "expected Expr { kind: Func(Func { name_hint: None, return_ty: None, body: Expr { kind: Func(Func { name_hint: None, return_ty: None, body: Expr { kind: Func(Func { name_hint: Some(Ident { path: [\"std\"], name: \"sub\" }), return_ty: Some(Ty(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") })]), name: None })), body: Expr { kind: Internal(\"std.sub\"), span: Some(1:1145-1161), alias: None, id: None, target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false }, params: [FuncParam { name: \"left\", ty: Some(Ty(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") })]), name: None })), default_value: None }, FuncParam { name: \"right\", ty: Some(Ty(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") })]), name: None })), default_value: None }], named_params: [], args: [Expr { kind: Func(Func { name_hint: Some(Ident { path: [\"std\"], name: \"sort\" }), return_ty: Some(Ty(Ty { kind: Array(Ty { kind: Tuple([Wildcard(Some(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"bool\"), Ty { kind: Primitive(Bool), name: Some(\"bool\") }), (Some(\"text\"), Ty { kind: Primitive(Text), name: Some(\"text\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") }), (Some(\"time\"), Ty { kind: Primitive(Time), name: Some(\"time\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (None, Ty { kind: Singleton(Null), name: None })]), name: Some(\"scalar\") }))]), name: Some(\"tuple_of_scalars\") }), name: Some(\"relation\") })), body: Expr { kind: Internal(\"sort\"), span: Some(1:2861-2874), alias: None, id: None, target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false }, params: [FuncParam { name: \"by\", ty: Some(Ty(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"bool\"), Ty { kind: Primitive(Bool), name: Some(\"bool\") }), (Some(\"text\"), Ty { kind: Primitive(Text), name: Some(\"text\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") }), (Some(\"time\"), Ty { kind: Primitive(Time), name: Some(\"time\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (None, Ty { kind: Singleton(Null), name: None }), (Some(\"tuple_of_scalars\"), Ty { kind: Tuple([Wildcard(Some(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"bool\"), Ty { kind: Primitive(Bool), name: Some(\"bool\") }), (Some(\"text\"), Ty { kind: Primitive(Text), name: Some(\"text\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") }), (Some(\"time\"), Ty { kind: Primitive(Time), name: Some(\"time\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (None, Ty { kind: Singleton(Null), name: None })]), name: Some(\"scalar\") }))]), name: Some(\"tuple_of_scalars\") })]), name: None })), default_value: None }, FuncParam { name: \"tbl\", ty: Some(Ty(Ty { kind: Array(Ty { kind: Tuple([Wildcard(Some(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"bool\"), Ty { kind: Primitive(Bool), name: Some(\"bool\") }), (Some(\"text\"), Ty { kind: Primitive(Text), name: Some(\"text\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") }), (Some(\"time\"), Ty { kind: Primitive(Time), name: Some(\"time\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (None, Ty { kind: Singleton(Null), name: None })]), name: Some(\"scalar\") }))]), name: Some(\"tuple_of_scalars\") }), name: Some(\"relation\") })), default_value: None }], named_params: [], args: [Expr { kind: Ident(Ident { path: [\"_param\"], name: \"_partial_311\" }), span: None, alias: None, id: None, target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false }, Expr { kind: Ident(Ident { path: [\"_param\"], name: \"_partial_317\" }), span: None, alias: None, id: None, target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false }], env: {} }), span: Some(0:24-28), alias: None, id: Some(317), target_id: None, target_ids: [], ty: Some(Ty { kind: Function(Some(TyFunc { args: [Some(Ty { kind: Array(Ty { kind: Tuple([Wildcard(Some(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"bool\"), Ty { kind: Primitive(Bool), name: Some(\"bool\") }), (Some(\"text\"), Ty { kind: Primitive(Text), name: Some(\"text\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") }), (Some(\"time\"), Ty { kind: Primitive(Time), name: Some(\"time\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (None, Ty { kind: Singleton(Null), name: None })]), name: Some(\"scalar\") }))]), name: Some(\"tuple_of_scalars\") }), name: Some(\"relation\") })], return_ty: Some(Ty { kind: Array(Ty { kind: Tuple([Wildcard(Some(Ty { kind: Union([(Some(\"int\"), Ty { kind: Primitive(Int), name: Some(\"int\") }), (Some(\"float\"), Ty { kind: Primitive(Float), name: Some(\"float\") }), (Some(\"bool\"), Ty { kind: Primitive(Bool), name: Some(\"bool\") }), (Some(\"text\"), Ty { kind: Primitive(Text), name: Some(\"text\") }), (Some(\"date\"), Ty { kind: Primitive(Date), name: Some(\"date\") }), (Some(\"time\"), Ty { kind: Primitive(Time), name: Some(\"time\") }), (Some(\"timestamp\"), Ty { kind: Primitive(Timestamp), name: Some(\"timestamp\") }), (None, Ty { kind: Singleton(Null), name: None })]), name: Some(\"scalar\") }))]), name: Some(\"tuple_of_scalars\") }), name: Some(\"relation\") }) })), name: None }), lineage: None, needs_window: false, flatten: false }, Expr { kind: Ident(Ident { path: [], name: \"val\" }), span: Some(0:30-33), alias: None, id: None, target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false }], env: {} }), span: None, alias: None, id: None, target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false }, params: [], named_params: [], args: [], env: {} }), span: None, alias: None, id: None, target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false }, params: [FuncParam { name: \"_partial_317\", ty: None, default_value: None }], named_params: [], args: [], env: {} }), span: None, alias: None, id: Some(313), target_id: None, target_ids: [], ty: None, lineage: None, needs_window: false, flatten: false } to have table type"
```