### PR TITLE
build: Remove `--install-links` from playground build

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -162,7 +162,8 @@ tasks:
         {{ range $dep := (.brew_dependencies | trim | splitLines) -}}
           [ -n "$(which {{ $dep }})" ]
         {{ end -}}
-      - "[ $(npm -v | cut -d. -f1) -ge 9 ]"
+      - |
+        [ "$(npm -v | awk -F. '{print ($1 > 9 || ($1 == 9 && $2 > 4)) ? 0 : 1}')" -eq 0 ]
     silent: true
     cmds:
       - cmd: |
@@ -172,7 +173,9 @@ tasks:
 
           {{ .brew_dependencies }}
 
-          These aren't required for initial PRQL development, but they are required for some of the tests.
+          ...or alternatively that npm < 9.4
+
+          These aren't required for initial PRQL development, but they are required for some of the extras.
 
           Install them with:
 
@@ -292,7 +295,7 @@ tasks:
       # Must set `install-links=false` in the playground's `npm install` to
       # install prql-js as the regular dependency, instead of creating a
       # symlink. Refer to https://github.com/PRQL/prql/pull/1296.
-      - cd playground && npm install --install-links=false
+      - cd playground && npm install
       - cd playground && npm run build
       # We place the playground app in a nested path, because we want to use
       # prql-lang.org/playground with an iframe containing the playground.
@@ -347,7 +350,7 @@ tasks:
     desc: Build & serve the playground.
     dir: web/playground
     cmds:
-      - npm install --install-links=false
+      - npm install
       - npm start
 
   run-playground-cached:
@@ -362,13 +365,10 @@ tasks:
     # Use task's sources/generates to see if checksums of
     # node_modules directory have changed since package.json was updated
 
-    # Use `npm install --install-links=false` to install prql-js
-    # as the regular dependency, instead of creating a
-    # symlink. Refer to https://github.com/PRQL/prql/pull/1296.
     desc: Check to see if package.json has changed since we ran npm install
     dir: web/playground
     cmds:
-      - npm install --install-links=false
+      - npm install
     sources:
       - package.json
     generates:

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -4214,11 +4214,11 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
+      "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
       "dependencies": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -4382,9 +4382,9 @@
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "node_modules/@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+      "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -22203,11 +22203,11 @@
       }
     },
     "@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
+      "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
       "requires": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "@types/html-minifier-terser": {
@@ -22371,9 +22371,9 @@
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+      "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
     },
     "@types/ws": {
       "version": "8.5.3",


### PR DESCRIPTION
This is no longer needed; the npm change was reverted in `9.4.0`: https://github.com/npm/cli/pull/6142
