### PR TITLE
ci: Remove concurrency from child workflows

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -12,10 +12,6 @@ on:
         type: boolean
         default: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -10,11 +10,6 @@ env:
   RUSTFLAGS: "-C debuginfo=0"
   RUSTDOCFLAGS: "-Dwarnings"
 
-concurrency:
-  # See notes in `tests.yaml`
-  group: ${{ github.workflow }}-${{ github.ref }}-web
-  cancel-in-progress: true
-
 jobs:
   build-web:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-dotnet.yaml
+++ b/.github/workflows/test-dotnet.yaml
@@ -4,11 +4,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-concurrency:
-  # See notes in `tests.yaml`
-  group: ${{ github.workflow }}-${{ github.ref }}-dotnet
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-elixir.yaml
+++ b/.github/workflows/test-elixir.yaml
@@ -12,10 +12,6 @@ on:
         type: string
         default: '["ubuntu-latest"]'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-elixir
-  cancel-in-progress: true
-
 defaults:
   run:
     working-directory: bindings/prql-elixir

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -12,10 +12,6 @@ on:
         type: string
         default: '["ubuntu-latest"]'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-java
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -18,10 +18,6 @@ env:
   RUSTFLAGS: "-C debuginfo=0"
   RUSTDOCFLAGS: "-Dwarnings"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-js
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-lib.yaml
+++ b/.github/workflows/test-lib.yaml
@@ -4,11 +4,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-concurrency:
-  # See notes in `tests.yaml`
-  group: ${{ github.workflow }}-${{ github.ref }}-lib
-  cancel-in-progress: true
-
 jobs:
   test-lib:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -4,11 +4,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-concurrency:
-  # See notes in `tests.yaml`
-  group: ${{ github.workflow }}-${{ github.ref }}-php
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -12,11 +12,6 @@ on:
         type: string
         default: '["ubuntu-latest"]'
 
-concurrency:
-  # See notes in `tests.yaml`
-  group: ${{ github.workflow }}-${{ github.ref }}-python
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Now we've moved everything into `tests.yaml`, we don't need these concurrency blocks. And one caused a workflow to be cancelled when the scheduled nightly workflow ran
