### PR TITLE
fix: Rewrite precedence, fix corner-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 - Fix panic when unresolved lineage appears in group or window (@davidot, #3266)
 
+- Fix a corner-case in handling precedence, and remove unneeded parentheses in
+  some outputs (@max-sixty, #3472)
+
 **Documentation**:
 
 **Web**:

--- a/crates/prql-compiler/src/sql/gen_expr.rs
+++ b/crates/prql-compiler/src/sql/gen_expr.rs
@@ -722,30 +722,31 @@ pub(super) fn translate_operand(
 /// For an operation represented as `a child b` with a surrounding parent
 /// operation (e.g., `(a child b) parent c` or `a parent (b child c)`):
 ///
-/// 1. **When the child operator has higher precedence than the parent**:
+/// 1. When the child operator has higher precedence than the parent:
 ///    - Parentheses are not required.
 ///
-/// 2. **When the child operator has lower precedence than the parent**:
+/// 2. When the child operator has lower precedence than the parent:
 ///    - Parentheses are required.
 ///
-/// 3. **When the child and parent operators have the same precedence**,
-///    parentheses are not required if:
+/// 3. When the child and parent operators have the same precedence, parentheses
+///    are not required if:
 ///
-///    a. The parent is Both associative — e.g. `a + (b - c)`, but not `a - (b + c)`
+///    a. The parent is "Both" associative — e.g. `a + (b - c)`, but not `a - (b
+///    - c)`,
 ///
 ///    b. or the child is on the (left,right) and the child is (left,right)
 ///    associative — e.g. `(a - b) - c` — but not `a - (b - c)`
-///
+//
 // This function has a lot of inputs, and maybe there is a better way of doing
 // this. But it does require a lot of information to make the correct decision,
 // so I don't think there's an easy way of stripping the number of inputs (For
 // example, even if we passed a reference to the parent, that still wouldn't
 // tell us whether the child were on the left or the right...)
 //
-// Note that this is super-verbose, and could instead be a neat little single
-// expression. But it was quite difficult to work through, so please do not make
-// the code terser without being quite confident that it's easier to understand
-// for people reading it.
+// Note that the code is deliberately verbose. While it could instead be a neat
+// little single expression, it was quite difficult to work through, so please
+// do not make the code terser without being quite confident that it's easier to
+// understand for people reading it.
 fn needs_parentheses(
     expr: &ExprOrSource,
     is_left: bool,

--- a/crates/prql-compiler/src/sql/gen_expr.rs
+++ b/crates/prql-compiler/src/sql/gen_expr.rs
@@ -724,7 +724,7 @@ pub(super) fn translate_ident_part(ident: String, ctx: &Context) -> sql_ast::Ide
 ///    - Parentheses are required.
 ///
 /// 3. **When the child and parent operators have the same precedence**,
-///    parenthese are not required if
+///    parentheses are not required if
 ///    a. Both are ${left}-associative,
 ///    b. and either:
 ///      i.  The expression is on the ${left} — e.g. `(a - b) - c` — but not `a - (b - c)`

--- a/crates/prql-compiler/src/sql/gen_expr.rs
+++ b/crates/prql-compiler/src/sql/gen_expr.rs
@@ -729,7 +729,11 @@ pub(super) fn translate_ident_part(ident: String, ctx: &Context) -> sql_ast::Ide
 ///    b. and either:
 ///      i.  The expression is on the ${left} — e.g. `(a - b) - c` — but not `a - (b - c)`
 ///      ii. or parent is commutative — e.g. `a + (b + c)` — but not `a - (b + c)`
-
+// This function has a lot of inputs, and maybe there is a better way of doing
+// this. But it does require a lot of information to make the correct decision,
+// so I don't think there's an easy way of stripping the number of inputs (For example,
+// even if we passed a reference to the parent, that still wouldn't tell us
+// whether the child were on the left or the right...)
 pub(super) fn translate_operand(
     expr: Expr,
     parent_strength: i32,
@@ -746,7 +750,7 @@ pub(super) fn translate_operand(
     let rule_2 = strength < parent_strength;
     let rule_3 = strength == parent_strength;
     let rule_3a_left = parent_left_associative && expr.left_associative();
-    let rule_3a_right = !parent_left_associative && !expr.left_associative();
+    let rule_3a_right = !parent_left_associative && expr.right_associative();
     let rule_3b_left = is_left || parent_is_commutative;
     let rule_3b_right = !is_left || parent_is_commutative;
 

--- a/crates/prql-compiler/src/sql/operators.rs
+++ b/crates/prql-compiler/src/sql/operators.rs
@@ -89,7 +89,7 @@ pub(super) fn translate_operator(
                     .unwrap_or(parent_binding_strength);
 
                 // translate args
-                let arg = translate_operand(arg, required_strength, false, ctx)?;
+                let arg = translate_operand(arg, required_strength, false, false, false, ctx)?;
 
                 text += &arg.into_source();
             }

--- a/crates/prql-compiler/src/sql/operators.rs
+++ b/crates/prql-compiler/src/sql/operators.rs
@@ -89,7 +89,13 @@ pub(super) fn translate_operator(
                     .unwrap_or(parent_binding_strength);
 
                 // translate args
-                let arg = translate_operand(arg, required_strength, false, false, false, ctx)?;
+                let arg = translate_operand(
+                    arg,
+                    false,
+                    required_strength,
+                    super::gen_expr::Associativity::Both,
+                    ctx,
+                )?;
 
                 text += &arg.into_source();
             }

--- a/crates/prql-compiler/src/sql/std.sql.prql
+++ b/crates/prql-compiler/src/sql/std.sql.prql
@@ -80,7 +80,7 @@ let div_i = l r -> s"FLOOR(ABS({l:11} / {r:11})) * SIGN({l:0}) * SIGN({r:0})"
 
 # We have a simple float division by default, but it can be overridden by dialects.
 @{binding_strength=11}
-let div_f = l r -> s"({l} / {r})"
+let div_f = l r -> s"{l} / {r}"
 
 @{binding_strength=11}
 let mod = l r -> s"{l} % {r}"

--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -53,10 +53,17 @@ fn json_of_test() {
 fn test_precedence() {
     assert_display_snapshot!((compile(r###"
     from x
-    select temp_c = (temp - 32) / 1.8
+    derive {
+      temp_c = (temp_f - 32) / 1.8,
+      temp_f = temp_c * 9/5,
+      temp_z = temp_x + 9 - 5,
+    }
     "###).unwrap()), @r###"
     SELECT
-      ("temp" - 32) / 1.8 AS temp_c
+      *,
+      (temp_f - 32) / 1.8 AS temp_c,
+      (temp_f - 32) / 1.8 * 9 / 5 AS temp_f,
+      temp_x + 9 - 5 AS temp_z
     FROM
       x
     "###);
@@ -121,6 +128,7 @@ fn test_precedence() {
       (c + a) - b,
       ((c - d) - (a - b)),
       ((c + d) + (a - b)),
+      a / (b * c),
       +x,
       -x,
     }
@@ -134,42 +142,11 @@ fn test_precedence() {
       c + a - b,
       c - d - a - b,
       c + d + a - b,
+      a / b * c,
       y - z AS x,
       -(y - z)
     FROM
       numbers
-    "###
-    );
-
-    assert_display_snapshot!(compile(
-    r###"
-    from foo
-    select a / (b * 0.7)
-    "###
-    ).unwrap(), @r###"
-    SELECT
-      a / b * 0.7
-    FROM
-      foo
-    "###
-    );
-}
-
-#[test]
-fn test_precedence2() {
-    assert_display_snapshot!(compile(
-    r###"
-    from weather
-    derive temp_f = temp_c * 9/5 
-    derive temp_g = temp_c + 9-5 
-    "###
-    ).unwrap(), @r###"
-    SELECT
-      *,
-      temp_c * 9 / 5 AS temp_f,
-      temp_c + 9 - 5 AS temp_g
-    FROM
-      weather
     "###
     );
 }

--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -98,7 +98,7 @@ fn test_precedence() {
       a > 0 AS gtz,
       NOT a > 0 AS ltz,
       NOT a > 0
-      AND NOT (NOT a > 0) AS zero,
+      AND NOT NOT a > 0 AS zero,
       NOT a = b AS is_not_equal,
       NOT a > b AS is_not_gt,
       (NOT a) IS NULL AS negated_is_null_1,
@@ -148,7 +148,7 @@ fn test_precedence() {
     "###
     ).unwrap(), @r###"
     SELECT
-      a / (b * 0.7)
+      a / b * 0.7
     FROM
       foo
     "###
@@ -159,14 +159,17 @@ fn test_precedence() {
 fn test_precedence2() {
     assert_display_snapshot!(compile(
     r###"
-    from tracks
-    select listening_time_years = (pandora_plays)  / 60 / 61
+    from weather
+    derive temp_f = temp_c * 9/5 
+    derive temp_g = temp_c + 9-5 
     "###
     ).unwrap(), @r###"
     SELECT
-      (pandora_plays / 60) / 61 AS listening_time_years
+      *,
+      temp_c * 9 / 5 AS temp_f,
+      temp_c + 9 - 5 AS temp_g
     FROM
-      tracks
+      weather
     "###
     );
 }

--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -127,12 +127,12 @@ fn test_precedence() {
     "###
     ).unwrap(), @r###"
     SELECT
-      c - (a + b),
+      c - a + b,
       c + a - b,
       c + a - b,
       c + a + b,
       c + a - b,
-      c - d - (a - b),
+      c - d - a - b,
       c + d + a - b,
       y - z AS x,
       -(y - z)

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__0.snap
@@ -4,7 +4,7 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\n\nfrom citie
 ---
 SELECT
   *,
-  ((temp_f - 32) / 1.8) AS temp_c
+  (temp_f - 32) / 1.8 AS temp_c
 FROM
   cities
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__1.snap
@@ -4,8 +4,8 @@ expression: "let interp = low:0 high x -> (x - low) / (high - low)\n\nfrom stude
 ---
 SELECT
   *,
-  ((sat_score - 0) / (1600 - 0)) AS sat_proportion_1,
-  ((sat_score - 0) / (1600 - 0)) AS sat_proportion_2
+  (sat_score - 0) / (1600 - 0) AS sat_proportion_1,
+  (sat_score - 0) / (1600 - 0) AS sat_proportion_2
 FROM
   students
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__late-binding__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__late-binding__0.snap
@@ -7,9 +7,9 @@ SELECT
   labor,
   overhead,
   cost_total,
-  (materials / cost_total) AS materials_share,
-  (labor / cost_total) AS labor_share,
-  (overhead / cost_total) AS overhead_share
+  materials / cost_total AS materials_share,
+  labor / cost_total AS labor_share,
+  overhead / cost_total AS overhead_share
 FROM
   costs
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__piping-values-into-functions__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__piping-values-into-functions__0.snap
@@ -4,8 +4,8 @@ expression: "let interp = low:0 high x -> (x - low) / (high - low)\n\nfrom stude
 ---
 SELECT
   *,
-  ((sat_score - 0) / (1600 - 0)) AS sat_proportion_1,
-  ((sat_score - 0) / (1600 - 0)) AS sat_proportion_2
+  (sat_score - 0) / (1600 - 0) AS sat_proportion_1,
+  (sat_score - 0) / (1600 - 0) AS sat_proportion_2
 FROM
   students
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__piping-values-into-functions__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__piping-values-into-functions__1.snap
@@ -4,7 +4,7 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\n\nfrom citie
 ---
 SELECT
   *,
-  ((temp_f - 32) / 1.8) AS temp_c
+  (temp_f - 32) / 1.8 AS temp_c
 FROM
   cities
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__piping-values-into-functions__2.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__piping-values-into-functions__2.snap
@@ -4,7 +4,7 @@ expression: "let fahrenheit_to_celsius = temp -> (temp - 32) / 1.8\nlet interp =
 ---
 SELECT
   *,
-  ((((temp_c - 32) / 1.8) - 0) / (100 - 0)) AS boiling_proportion
+  ((temp_c - 32) / 1.8 - 0) / (100 - 0) AS boiling_proportion
 FROM
   kettles
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__parentheses__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__parentheses__0.snap
@@ -7,7 +7,7 @@ SELECT
   distance BETWEEN 0 AND 20 AS is_proximate,
   SUM(distance) OVER () AS total_distance,
   MIN(COALESCE(distance, 5)) OVER () AS min_capped_distance,
-  (distance / 40) AS travel_time,
+  distance / 40 AS travel_time,
   ROUND(distance, 1 + 1) AS distance_rounded_2_dp,
   distance >= 100 AS is_far,
   distance BETWEEN -100 AND 0,

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__wrapping-lines__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__wrapping-lines__1.snap
@@ -4,16 +4,8 @@ expression: "from tracks\n# This would be a really long line without being able 
 ---
 SELECT
   (
-    (
-      (
-        (
-          (
-            spotify_plays + apple_music_plays + pandora_plays
-          ) * length_s
-        ) / 60
-      ) / 60
-    ) / 24
-  ) / 365 AS listening_time_years
+    spotify_plays + apple_music_plays + pandora_plays
+  ) * length_s / 60 / 60 / 24 / 365 AS listening_time_years
 FROM
   tracks
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__wrapping-lines__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__wrapping-lines__1.snap
@@ -9,11 +9,11 @@ SELECT
         (
           (
             spotify_plays + apple_music_plays + pandora_plays
-          ) * length_s / 60
+          ) * length_s
         ) / 60
-      ) / 24
-    ) / 365
-  ) AS listening_time_years
+      ) / 60
+    ) / 24
+  ) / 365 AS listening_time_years
 FROM
   tracks
 

--- a/web/website/data/examples/expressions.yaml
+++ b/web/website/data/examples/expressions.yaml
@@ -13,7 +13,7 @@ sql: |
     started + unfinished AS finished,
     ((started + unfinished) / started) AS fin_share,
     (
-      ((started + unfinished) / started) / (1 - ((started + unfinished) / started))
+      (((started + unfinished) / started)) / (1 - ((started + unfinished) / started))
     ) AS fin_ratio
   FROM
     track_plays

--- a/web/website/data/examples/expressions.yaml
+++ b/web/website/data/examples/expressions.yaml
@@ -11,9 +11,8 @@ sql: |
   SELECT
     *,
     started + unfinished AS finished,
-    ((started + unfinished) / started) AS fin_share,
-    (
-      (((started + unfinished) / started)) / (1 - ((started + unfinished) / started))
-    ) AS fin_ratio
+    (started + unfinished) / started AS fin_share,
+    (started + unfinished) / started / (1 - (started + unfinished) / started)
+     AS fin_ratio
   FROM
     track_plays

--- a/web/website/data/examples/functions.yaml
+++ b/web/website/data/examples/functions.yaml
@@ -6,6 +6,6 @@ prql: |
   select temp_f = (fahrenheit_from_celsius temp_c)
 sql: |
   SELECT
-    (temp_c * 9 / 5) + 32 AS temp_f
+    temp_c * 9 / 5 + 32 AS temp_f
   FROM
     weather


### PR DESCRIPTION
This fixes #3469, by re-writing how we do precedence. I think these are pretty robust rules now. It was surprisingly difficult — I definitely didn't expect to be thinking so much about precedence!

(weirdly I couldn't find a source so mostly came up with these myself, though surely every language should have some implementation of this??)