### PR TITLE
build: More deps

### DIFF
--- a/.github/set_version.sh
+++ b/.github/set_version.sh
@@ -6,4 +6,4 @@
 
 version=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[] | select(.name == "prql-compiler") | .version')
 # Setting `2` on 2023-09-07 because of bloated cache can revert on next version
-echo "version=${version}2" >>"$GITHUB_ENV"
+echo "version=${version}.2" >>"$GITHUB_ENV"

--- a/.github/set_version.sh
+++ b/.github/set_version.sh
@@ -5,4 +5,5 @@
 # ref https://github.com/PRQL/prql/pull/2407
 
 version=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[] | select(.name == "prql-compiler") | .version')
-echo "version=${version}" >>"$GITHUB_ENV"
+# Setting `2` on 2023-09-07 because of bloated cache can revert on next version
+echo "version=${version}2" >>"$GITHUB_ENV"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,23 +90,37 @@ dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
- "anstyle-wincon",
+ "anstyle-wincon 1.0.1",
  "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle"
-version = "1.0.0"
+name = "anstream"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon 2.1.0",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -125,10 +145,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
+name = "anstyle-wincon"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 dependencies = [
  "backtrace",
 ]
@@ -274,7 +304,7 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b71d8d68d0bc2e648e4e395896dc518be8b90c5f0f763c59083187c3d46184b"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
 ]
 
 [[package]]
@@ -419,9 +449,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -502,12 +532,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.8",
  "serde",
 ]
 
@@ -565,11 +595,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -595,17 +626,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -669,37 +699,34 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
- "anstream",
+ "anstream 0.5.0",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
- "once_cell",
  "strsim",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.3.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04ddfaacc3bc9e6ea67d024575fafc2a813027cf374b8f24f7bc233c6b6be12"
+checksum = "4110a1e6af615a9e6d0a36f805d5c99099f8bab9b8042f5bc1fa220a4a89e36f"
 dependencies = [
- "clap 4.3.0",
+ "clap 4.4.2",
 ]
 
 [[package]]
@@ -708,7 +735,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d"
 dependencies = [
- "clap 4.3.0",
+ "clap 4.4.2",
  "clap_complete",
  "clap_complete_fig",
  "clap_complete_nushell",
@@ -720,7 +747,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c73f19beec3b698ecc59d023cf373943f0ff405237ed0d7c6df118fb554334b"
 dependencies = [
- "clap 4.3.0",
+ "clap 4.4.2",
  "clap_complete",
 ]
 
@@ -730,15 +757,15 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e"
 dependencies = [
- "clap 4.3.0",
+ "clap 4.4.2",
  "clap_complete",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -748,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clio"
@@ -759,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "746ce4269bee03af43b3349f37f420cf5957f8431c531c08dea0441b298b10e0"
 dependencies = [
  "cfg-if",
- "clap 4.3.0",
+ "clap 4.4.2",
  "is-terminal",
  "libc",
  "tempfile",
@@ -811,11 +838,11 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colorchoice-clap"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412e88a3a3a3f52e436909b49beb467a05649e8b0dda0e6202bd05c1b63dbc49"
+checksum = "6afb91776a1ed84bebf6f3d13948c262e5d2694d4a689cd48808ccf84f25b251"
 dependencies = [
- "clap 4.3.0",
+ "clap 4.4.2",
  "colorchoice",
 ]
 
@@ -915,9 +942,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -940,7 +967,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.3.0",
+ "clap 4.4.2",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -1027,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -1052,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
  "csv-core",
  "itoa",
@@ -1276,9 +1303,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1325,12 +1352,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "filetime"
@@ -1586,7 +1610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
 dependencies = [
  "aho-corasick",
- "bstr 1.6.0",
+ "bstr 1.6.2",
  "fnv",
  "log",
  "regex",
@@ -1681,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hmac"
@@ -1702,9 +1726,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1819,15 +1843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-enum"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,7 +1858,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1854,8 +1869,8 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "rustix 0.38.6",
+ "hermit-abi 0.3.2",
+ "rustix 0.38.11",
  "windows-sys 0.48.0",
 ]
 
@@ -1879,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jni"
@@ -1916,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2148,13 +2163,13 @@ checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "mdbook"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d317294c6e3d7f9d2e60dfd20932bec627f86c76ec101a5da0110fc0fbe06266"
+checksum = "c55eb7c4dad20cc5bc15181c2aaf43d5689d5c3e0b80b50cc4cf0b7fe72a26d9"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.3.0",
+ "clap 4.4.2",
  "clap_complete",
  "env_logger",
  "handlebars",
@@ -2190,7 +2205,7 @@ name = "mdbook-prql"
 version = "0.9.5"
 dependencies = [
  "ansi-to-html",
- "anstream",
+ "anstream 0.3.2",
  "anyhow",
  "globset",
  "insta",
@@ -2206,15 +2221,15 @@ dependencies = [
  "serde_yaml",
  "similar-asserts",
  "strum 0.25.0",
- "strum_macros 0.25.0",
+ "strum_macros 0.25.2",
  "walkdir",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -2269,14 +2284,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2341,7 +2356,7 @@ dependencies = [
  "base64",
  "bigdecimal",
  "bindgen",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "bitvec",
  "byteorder",
  "bytes",
@@ -2366,7 +2381,7 @@ dependencies = [
  "smallvec",
  "subprocess",
  "thiserror",
- "time 0.3.21",
+ "time",
  "uuid",
 ]
 
@@ -2408,12 +2423,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify"
-version = "6.1.0"
+name = "normpath"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbf4f3b058c29e9642cf53217e0531cbfc78bc24e0a212a9837b7415b9d9007"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
 dependencies = [
- "bitflags 2.3.3",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2495,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
@@ -2536,11 +2560,12 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opener"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c15678e37254c15bd2f092314abb4e51d7fdde05c2021279c12631b54f005"
+checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
 dependencies = [
- "bstr 1.6.0",
+ "bstr 1.6.2",
+ "normpath",
  "winapi",
 ]
 
@@ -2641,9 +2666,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2651,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2661,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2674,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -2905,7 +2930,7 @@ dependencies = [
 name = "prql-compiler"
 version = "0.9.5"
 dependencies = [
- "anstream",
+ "anstream 0.3.2",
  "anyhow",
  "ariadne",
  "cfg-if",
@@ -2933,7 +2958,7 @@ dependencies = [
  "sqlformat",
  "sqlparser",
  "strum 0.25.0",
- "strum_macros 0.25.0",
+ "strum_macros 0.25.2",
  "tiberius",
  "tokio",
  "tokio-util",
@@ -2999,11 +3024,11 @@ dependencies = [
 name = "prqlc"
 version = "0.9.5"
 dependencies = [
- "anstream",
+ "anstream 0.3.2",
  "anyhow",
  "ariadne",
  "atty",
- "clap 4.3.0",
+ "clap 4.4.2",
  "clap_complete_command",
  "clio",
  "color-eyre",
@@ -3135,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -3261,13 +3286,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.8",
  "regex-syntax",
 ]
 
@@ -3279,9 +3304,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3290,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rend"
@@ -3337,7 +3362,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "csv",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
@@ -3378,9 +3403,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -3392,11 +3417,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.6"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.5",
@@ -3405,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "rustler"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095fb0fb2864560480609c5b1427fe9f3872f6b3e400036f5531e8f06ff33026"
+checksum = "0884cb623b9f43d3e2c51f9071c5e96a5acf3e6e6007866812884ff0cb983f1e"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -3416,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "rustler_codegen"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8911f25973c1d68a3ffdea53d664026f6b0877c949bd3f9f5bc263385c33553"
+checksum = "50e277af754f2560cf4c4ebedb68c1a735292fb354505c6133e47ec406e699cf"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3438,15 +3463,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -3515,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
@@ -3579,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3740,7 +3765,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.0",
+ "strum_macros 0.25.2",
 ]
 
 [[package]]
@@ -3758,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3826,21 +3851,21 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.19",
- "windows-sys 0.45.0",
+ "rustix 0.38.11",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3858,7 +3883,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix 0.37.19",
+ "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
 
@@ -3873,18 +3898,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3922,23 +3947,12 @@ dependencies = [
  "pin-project-lite",
  "pretty-hex",
  "thiserror",
- "time 0.3.21",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",
  "uuid",
  "winauth",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -4117,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4176,9 +4190,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -4197,9 +4211,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -4245,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "url"
@@ -4298,9 +4312,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4311,12 +4325,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4351,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4392,9 +4400,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.33"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -4406,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.33"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,23 +90,9 @@ dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
- "anstyle-wincon 1.0.1",
+ "anstyle-wincon",
  "colorchoice",
  "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon 2.1.0",
- "colorchoice",
  "utf8parse",
 ]
 
@@ -139,16 +125,6 @@ name = "anstyle-wincon"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -699,34 +675,37 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
- "anstream 0.5.0",
+ "anstream",
  "anstyle",
+ "bitflags 1.3.2",
  "clap_lex",
+ "once_cell",
  "strsim",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.4.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4110a1e6af615a9e6d0a36f805d5c99099f8bab9b8042f5bc1fa220a4a89e36f"
+checksum = "a04ddfaacc3bc9e6ea67d024575fafc2a813027cf374b8f24f7bc233c6b6be12"
 dependencies = [
- "clap 4.4.2",
+ "clap 4.3.0",
 ]
 
 [[package]]
@@ -735,7 +714,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d"
 dependencies = [
- "clap 4.4.2",
+ "clap 4.3.0",
  "clap_complete",
  "clap_complete_fig",
  "clap_complete_nushell",
@@ -747,7 +726,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c73f19beec3b698ecc59d023cf373943f0ff405237ed0d7c6df118fb554334b"
 dependencies = [
- "clap 4.4.2",
+ "clap 4.3.0",
  "clap_complete",
 ]
 
@@ -757,15 +736,15 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e"
 dependencies = [
- "clap 4.4.2",
+ "clap 4.3.0",
  "clap_complete",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -775,19 +754,19 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clio"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746ce4269bee03af43b3349f37f420cf5957f8431c531c08dea0441b298b10e0"
+checksum = "20a7c15685caad17ac973fde985e95c8a0b7a4206de22f6b5fb58a70f430b2cc"
 dependencies = [
+ "atty",
  "cfg-if",
- "clap 4.4.2",
- "is-terminal",
+ "clap 4.3.0",
  "libc",
  "tempfile",
  "walkdir",
@@ -838,11 +817,11 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colorchoice-clap"
-version = "1.0.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afb91776a1ed84bebf6f3d13948c262e5d2694d4a689cd48808ccf84f25b251"
+checksum = "412e88a3a3a3f52e436909b49beb467a05649e8b0dda0e6202bd05c1b63dbc49"
 dependencies = [
- "clap 4.4.2",
+ "clap 4.3.0",
  "colorchoice",
 ]
 
@@ -967,7 +946,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.2",
+ "clap 4.3.0",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -2163,13 +2142,13 @@ checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "mdbook"
-version = "0.4.34"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55eb7c4dad20cc5bc15181c2aaf43d5689d5c3e0b80b50cc4cf0b7fe72a26d9"
+checksum = "7b67ee4a744f36e6280792016c17e69921b51df357181d1eb17d620fcc3609f3"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.4.2",
+ "clap 4.3.0",
  "clap_complete",
  "env_logger",
  "handlebars",
@@ -2205,7 +2184,7 @@ name = "mdbook-prql"
 version = "0.9.5"
 dependencies = [
  "ansi-to-html",
- "anstream 0.3.2",
+ "anstream",
  "anyhow",
  "globset",
  "insta",
@@ -2423,15 +2402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normpath"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,12 +2530,11 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opener"
-version = "0.6.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
+checksum = "293c15678e37254c15bd2f092314abb4e51d7fdde05c2021279c12631b54f005"
 dependencies = [
  "bstr 1.6.2",
- "normpath",
  "winapi",
 ]
 
@@ -2930,7 +2899,7 @@ dependencies = [
 name = "prql-compiler"
 version = "0.9.5"
 dependencies = [
- "anstream 0.3.2",
+ "anstream",
  "anyhow",
  "ariadne",
  "cfg-if",
@@ -3024,11 +2993,11 @@ dependencies = [
 name = "prqlc"
 version = "0.9.5"
 dependencies = [
- "anstream 0.3.2",
+ "anstream",
  "anyhow",
  "ariadne",
  "atty",
- "clap 4.4.2",
+ "clap 4.3.0",
  "clap_complete_command",
  "clio",
  "color-eyre",

--- a/bindings/prql-elixir/native/prql/Cargo.toml
+++ b/bindings/prql-elixir/native/prql/Cargo.toml
@@ -20,4 +20,4 @@ test = false
 # See Readme for details on Mac
 [target.'cfg(not(any(target_family="wasm", target_os = "macos", tarpaulin)))'.dependencies]
 prql-compiler = {path = "../../../../crates/prql-compiler", default-features = false, version = "0.9.5" }
-rustler = "0.29.0"
+rustler = "0.29.1"

--- a/bindings/prql-js/Cargo.toml
+++ b/bindings/prql-js/Cargo.toml
@@ -34,7 +34,7 @@ wasm-bindgen = "0.2.87"
 console_error_panic_hook = {version = "0.1.7", optional = true}
 
 [target.'cfg(target_family="wasm")'.dev-dependencies]
-wasm-bindgen-test = "0.3.30"
+wasm-bindgen-test = "0.3.37"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["wasm-bindgen-test"]

--- a/bindings/prql-python/Cargo.toml
+++ b/bindings/prql-python/Cargo.toml
@@ -23,7 +23,7 @@ prql-compiler = {path = "../../crates/prql-compiler", default-features = false}
 insta = {version = "1.31", features = ["colors", "glob", "yaml"]}
 
 [build-dependencies]
-pyo3-build-config = "0.19.0"
+pyo3-build-config = "0.19.2"
 
 [package.metadata.release]
 tag-name = "{{version}}"

--- a/crates/prql-ast/Cargo.toml
+++ b/crates/prql-ast/Cargo.toml
@@ -13,6 +13,6 @@ doctest = false
 
 [dependencies]
 enum-as-inner = "0.6.0"
-semver = {version = "1.0.14", features = ["serde"]}
-serde = {version = "1.0.137", features = ["derive"]}
+semver = {version = "1.0.18", features = ["serde"]}
+serde = {version = "1.0.188", features = ["derive"]}
 strum = {version = "0.25.0", features = ["std", "derive"]}

--- a/crates/prql-compiler-macros/Cargo.toml
+++ b/crates/prql-compiler-macros/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 
 [dependencies]
 prql-compiler = {path = "../prql-compiler", default-features = false, version = "0.9.5" }
-syn = "2.0.2"
+syn = "2.0.31"
 
 [package.metadata.release]
 tag-name = "{{version}}"

--- a/crates/prql-compiler/Cargo.toml
+++ b/crates/prql-compiler/Cargo.toml
@@ -22,22 +22,22 @@ prql-ast = {path = "../prql-ast", version = "0.9.5"}
 prql-parser = {path = "../prql-parser", version = "0.9.5"}
 
 anstream = {version = "0.3.2", features = ["auto"]}
-anyhow = {version = "1.0.57", features = ["backtrace"]}
+anyhow = {version = "1.0.75", features = ["backtrace"]}
 ariadne = "0.3.0"
-csv = "1.2.0"
+csv = "1.2.2"
 enum-as-inner = "0.6.0"
 itertools = "0.11.0"
-log = "0.4.17"
+log = "0.4.20"
 once_cell = "1.18.0"
-regex = "1.9.0"
-semver = {version = "1.0.14", features = ["serde"]}
+regex = "1.9.5"
+semver = {version = "1.0.18", features = ["serde"]}
 # We could put `serde` behind a feature if we wanted to reduce the size of prql-compiler.
-serde = {version = "1.0.137", features = ["derive"]}
-serde_json = "1.0.81"
+serde = {version = "1.0.188", features = ["derive"]}
+serde_json = "1.0.105"
 sqlformat = "0.2.2"
 sqlparser = {version = "0.37.0", features = ["serde"]}
 strum = {version = "0.25.0", features = ["std", "derive"]}
-strum_macros = "0.25.0"
+strum_macros = "0.25.2"
 
 serde_yaml = {version = "0.9", optional = true}
 

--- a/crates/prql-parser/Cargo.toml
+++ b/crates/prql-parser/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 [dependencies]
 itertools = "0.11.0"
 prql-ast = {path = "../prql-ast", version = "0.9.5" }
-semver = {version = "1.0.14"}
+semver = {version = "1.0.18"}
 
 # Chumsky's default features have issues when running in wasm (though we only
 # see it when compiling on MacOS), so we only include features when running

--- a/crates/prqlc/Cargo.toml
+++ b/crates/prqlc/Cargo.toml
@@ -12,25 +12,25 @@ metadata.msrv = "1.65.0"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 anstream = {version = "0.3.2", features = ["auto"]}
-anyhow = {version = "1.0.57"}
+anyhow = {version = "1.0.75"}
 ariadne = "0.3.0"
 # Remove when https://github.com/PRQL/prql/issues/3228 is resolved.
 atty = "0.2.14"
-clap = {version = "4.3.0", features = ["derive", "env", "wrap_help"]}
+clap = {version = "4.3.24", features = ["derive", "env", "wrap_help"]}
 clap_complete_command = "0.5.1"
-clio = {version = "0.3.3", features = ['clap-parse']}
-color-eyre = "0.6.1"
-colorchoice-clap = "1.0.0"
+clio = {version = "0.3.4", features = ['clap-parse']}
+color-eyre = "0.6.2"
+colorchoice-clap = "1.0.2"
 env_logger = {version = "0.10.0", features = ["color"]}
 itertools = "0.11.0"
-notify = "^6.1.0"
+notify = "6.1.1"
 prql-ast = {path = '../prql-ast', version = "0.9.5"}
 prql-compiler = {path = '../prql-compiler', features = ["serde_yaml"], version = "0.9.5"}
-regex = {version = "1.9.0", features = ["std", "unicode"]}
-serde = "^1"
-serde_json = "1.0.81"
-serde_yaml = "0.9.1"
-walkdir = "^2.3.2"
+regex = {version = "1.9.5", features = ["std", "unicode"]}
+serde = "1"
+serde_json = "1.0.105"
+serde_yaml = "0.9.25"
+walkdir = "2.4.0"
 
 # We use minijinja just for the Jinja lexer, which is not part of the
 # public interface which is covered by semver guarantees.

--- a/crates/prqlc/Cargo.toml
+++ b/crates/prqlc/Cargo.toml
@@ -16,11 +16,11 @@ anyhow = {version = "1.0.75"}
 ariadne = "0.3.0"
 # Remove when https://github.com/PRQL/prql/issues/3228 is resolved.
 atty = "0.2.14"
-clap = {version = "4.3.24", features = ["derive", "env", "wrap_help"]}
+clap = {version = "4.3.0", features = ["derive", "env", "wrap_help"]}
 clap_complete_command = "0.5.1"
-clio = {version = "0.3.4", features = ['clap-parse']}
+clio = {version = "0.3.3", features = ['clap-parse']}
 color-eyre = "0.6.2"
-colorchoice-clap = "1.0.2"
+colorchoice-clap = "1.0.0"
 env_logger = {version = "0.10.0", features = ["color"]}
 itertools = "0.11.0"
 notify = "6.1.1"

--- a/crates/prqlc/tests/snapshots/test__shell_completion-2.snap
+++ b/crates/prqlc/tests/snapshots/test__shell_completion-2.snap
@@ -7,14 +7,14 @@ info:
     - shell-completion
     - fish
   env:
-    CLICOLOR_FORCE: ""
     RUST_LOG: ""
     RUST_BACKTRACE: ""
+    CLICOLOR_FORCE: ""
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-complete -c prqlc -n "__fish_use_subcommand" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_use_subcommand" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_use_subcommand" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_use_subcommand" -s V -l version -d 'Print version'
 complete -c prqlc -n "__fish_use_subcommand" -f -a "parse" -d 'Parse into PL AST'
@@ -28,51 +28,51 @@ complete -c prqlc -n "__fish_use_subcommand" -f -a "watch" -d 'Watch a directory
 complete -c prqlc -n "__fish_use_subcommand" -f -a "list-targets" -d 'Show available compile target names'
 complete -c prqlc -n "__fish_use_subcommand" -f -a "shell-completion" -d 'Print a shell completion for supported shells'
 complete -c prqlc -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from parse" -l format -r -f -a "{json	,yaml	}"
-complete -c prqlc -n "__fish_seen_subcommand_from parse" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from parse" -l format -r -f -a "{json	'',yaml	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from parse" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from parse" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from fmt" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from fmt" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from fmt" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "semantics" -d 'Parse & resolve, but don\'t lower into RQ'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "eval" -d 'Parse & evaluate expression down to a value'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "annotate" -d 'Parse, resolve & combine source with comments annotating relation type'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "ast" -d 'Print info about the AST data structure'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from semantics" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from semantics" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from semantics" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from eval" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from eval" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from eval" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from annotate" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from annotate" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from annotate" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from ast" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from ast" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from ast" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "semantics" -d 'Parse & resolve, but don\'t lower into RQ'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "eval" -d 'Parse & evaluate expression down to a value'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "annotate" -d 'Parse, resolve & combine source with comments annotating relation type'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "ast" -d 'Print info about the AST data structure'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l format -r -f -a "{json	,yaml	}"
-complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l format -r -f -a "{json	'',yaml	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from resolve" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from sql:preprocess" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from sql:preprocess" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from sql:preprocess" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l format -r -f -a "{json	,yaml	}"
-complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l format -r -f -a "{json	'',yaml	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -s t -l target -d 'Target to compile to' -r
-complete -c prqlc -n "__fish_seen_subcommand_from compile" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from compile" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -l hide-signature-comment -d 'Exclude the signature comment containing the PRQL version'
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -l no-format -d 'Emit unformatted, dense SQL'
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c prqlc -n "__fish_seen_subcommand_from watch" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from watch" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from watch" -l no-format
 complete -c prqlc -n "__fish_seen_subcommand_from watch" -l no-signature
 complete -c prqlc -n "__fish_seen_subcommand_from watch" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from list-targets" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from list-targets" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from list-targets" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from shell-completion" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
+complete -c prqlc -n "__fish_seen_subcommand_from shell-completion" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from shell-completion" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from parse; and not __fish_seen_subcommand_from fmt; and not __fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from resolve; and not __fish_seen_subcommand_from sql:preprocess; and not __fish_seen_subcommand_from sql:anchor; and not __fish_seen_subcommand_from compile; and not __fish_seen_subcommand_from watch; and not __fish_seen_subcommand_from list-targets; and not __fish_seen_subcommand_from shell-completion; and not __fish_seen_subcommand_from help" -f -a "parse" -d 'Parse into PL AST'
 complete -c prqlc -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from parse; and not __fish_seen_subcommand_from fmt; and not __fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from resolve; and not __fish_seen_subcommand_from sql:preprocess; and not __fish_seen_subcommand_from sql:anchor; and not __fish_seen_subcommand_from compile; and not __fish_seen_subcommand_from watch; and not __fish_seen_subcommand_from list-targets; and not __fish_seen_subcommand_from shell-completion; and not __fish_seen_subcommand_from help" -f -a "fmt" -d 'Parse & generate PRQL code back'

--- a/crates/prqlc/tests/snapshots/test__shell_completion-2.snap
+++ b/crates/prqlc/tests/snapshots/test__shell_completion-2.snap
@@ -8,13 +8,13 @@ info:
     - fish
   env:
     RUST_LOG: ""
-    RUST_BACKTRACE: ""
     CLICOLOR_FORCE: ""
+    RUST_BACKTRACE: ""
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-complete -c prqlc -n "__fish_use_subcommand" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_use_subcommand" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_use_subcommand" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_use_subcommand" -s V -l version -d 'Print version'
 complete -c prqlc -n "__fish_use_subcommand" -f -a "parse" -d 'Parse into PL AST'
@@ -28,51 +28,51 @@ complete -c prqlc -n "__fish_use_subcommand" -f -a "watch" -d 'Watch a directory
 complete -c prqlc -n "__fish_use_subcommand" -f -a "list-targets" -d 'Show available compile target names'
 complete -c prqlc -n "__fish_use_subcommand" -f -a "shell-completion" -d 'Print a shell completion for supported shells'
 complete -c prqlc -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from parse" -l format -r -f -a "{json	'',yaml	''}"
-complete -c prqlc -n "__fish_seen_subcommand_from parse" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from parse" -l format -r -f -a "{json	,yaml	}"
+complete -c prqlc -n "__fish_seen_subcommand_from parse" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from parse" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from fmt" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from fmt" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from fmt" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "semantics" -d 'Parse & resolve, but don\'t lower into RQ'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "eval" -d 'Parse & evaluate expression down to a value'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "annotate" -d 'Parse, resolve & combine source with comments annotating relation type'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "ast" -d 'Print info about the AST data structure'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from semantics" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from semantics" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from semantics" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from eval" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from eval" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from eval" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from annotate" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from annotate" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from annotate" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from ast" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from ast" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from ast" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "semantics" -d 'Parse & resolve, but don\'t lower into RQ'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "eval" -d 'Parse & evaluate expression down to a value'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "annotate" -d 'Parse, resolve & combine source with comments annotating relation type'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "ast" -d 'Print info about the AST data structure'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from semantics; and not __fish_seen_subcommand_from eval; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l format -r -f -a "{json	'',yaml	''}"
-complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l format -r -f -a "{json	,yaml	}"
+complete -c prqlc -n "__fish_seen_subcommand_from resolve" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from resolve" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from sql:preprocess" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from sql:preprocess" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from sql:preprocess" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l format -r -f -a "{json	'',yaml	''}"
-complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l format -r -f -a "{json	,yaml	}"
+complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from sql:anchor" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -s t -l target -d 'Target to compile to' -r
-complete -c prqlc -n "__fish_seen_subcommand_from compile" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from compile" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -l hide-signature-comment -d 'Exclude the signature comment containing the PRQL version'
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -l no-format -d 'Emit unformatted, dense SQL'
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c prqlc -n "__fish_seen_subcommand_from watch" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from watch" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from watch" -l no-format
 complete -c prqlc -n "__fish_seen_subcommand_from watch" -l no-signature
 complete -c prqlc -n "__fish_seen_subcommand_from watch" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from list-targets" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from list-targets" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from list-targets" -s h -l help -d 'Print help'
-complete -c prqlc -n "__fish_seen_subcommand_from shell-completion" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from shell-completion" -l color -d 'Controls when to use color' -r -f -a "{auto	,always	,never	}"
 complete -c prqlc -n "__fish_seen_subcommand_from shell-completion" -s h -l help -d 'Print help'
 complete -c prqlc -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from parse; and not __fish_seen_subcommand_from fmt; and not __fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from resolve; and not __fish_seen_subcommand_from sql:preprocess; and not __fish_seen_subcommand_from sql:anchor; and not __fish_seen_subcommand_from compile; and not __fish_seen_subcommand_from watch; and not __fish_seen_subcommand_from list-targets; and not __fish_seen_subcommand_from shell-completion; and not __fish_seen_subcommand_from help" -f -a "parse" -d 'Parse into PL AST'
 complete -c prqlc -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from parse; and not __fish_seen_subcommand_from fmt; and not __fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from resolve; and not __fish_seen_subcommand_from sql:preprocess; and not __fish_seen_subcommand_from sql:anchor; and not __fish_seen_subcommand_from compile; and not __fish_seen_subcommand_from watch; and not __fish_seen_subcommand_from list-targets; and not __fish_seen_subcommand_from shell-completion; and not __fish_seen_subcommand_from help" -f -a "fmt" -d 'Parse & generate PRQL code back'

--- a/crates/prqlc/tests/snapshots/test__shell_completion-3.snap
+++ b/crates/prqlc/tests/snapshots/test__shell_completion-3.snap
@@ -40,7 +40,7 @@ Register-ArgumentCompleter -Native -CommandName 'prqlc' -ScriptBlock {
             [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Controls when to use color')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('-V', 'V ', [CompletionResultType]::ParameterName, 'Print version')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version')
             [CompletionResult]::new('parse', 'parse', [CompletionResultType]::ParameterValue, 'Parse into PL AST')
             [CompletionResult]::new('fmt', 'fmt', [CompletionResultType]::ParameterValue, 'Parse & generate PRQL code back')

--- a/crates/prqlc/tests/snapshots/test__shell_completion-3.snap
+++ b/crates/prqlc/tests/snapshots/test__shell_completion-3.snap
@@ -7,9 +7,9 @@ info:
     - shell-completion
     - powershell
   env:
-    RUST_LOG: ""
-    CLICOLOR_FORCE: ""
     RUST_BACKTRACE: ""
+    CLICOLOR_FORCE: ""
+    RUST_LOG: ""
 ---
 success: true
 exit_code: 0
@@ -40,7 +40,7 @@ Register-ArgumentCompleter -Native -CommandName 'prqlc' -ScriptBlock {
             [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Controls when to use color')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
-            [CompletionResult]::new('-V', 'V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version')
             [CompletionResult]::new('parse', 'parse', [CompletionResultType]::ParameterValue, 'Parse into PL AST')
             [CompletionResult]::new('fmt', 'fmt', [CompletionResultType]::ParameterValue, 'Parse & generate PRQL code back')

--- a/crates/prqlc/tests/snapshots/test__shell_completion.snap
+++ b/crates/prqlc/tests/snapshots/test__shell_completion.snap
@@ -7,8 +7,8 @@ info:
     - shell-completion
     - bash
   env:
-    RUST_BACKTRACE: ""
     RUST_LOG: ""
+    RUST_BACKTRACE: ""
     CLICOLOR_FORCE: ""
 ---
 success: true
@@ -743,7 +743,7 @@ _prqlc() {
     esac
 }
 
-complete -F _prqlc -o nosort -o bashdefault -o default prqlc
+complete -F _prqlc -o bashdefault -o default prqlc
 
 ----- stderr -----
 

--- a/crates/prqlc/tests/snapshots/test__shell_completion.snap
+++ b/crates/prqlc/tests/snapshots/test__shell_completion.snap
@@ -7,9 +7,9 @@ info:
     - shell-completion
     - bash
   env:
-    CLICOLOR_FORCE: ""
-    RUST_LOG: ""
     RUST_BACKTRACE: ""
+    RUST_LOG: ""
+    CLICOLOR_FORCE: ""
 ---
 success: true
 exit_code: 0
@@ -743,7 +743,7 @@ _prqlc() {
     esac
 }
 
-complete -F _prqlc -o bashdefault -o default prqlc
+complete -F _prqlc -o nosort -o bashdefault -o default prqlc
 
 ----- stderr -----
 

--- a/crates/tests_misc/Cargo.toml
+++ b/crates/tests_misc/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 [dev-dependencies]
 insta = {version = "1.31", features = ["colors", "glob", "yaml"]}
-regex = "1.9.1"
+regex = "1.9.5"
 similar = {version = "2.2.1"}

--- a/web/book/Cargo.toml
+++ b/web/book/Cargo.toml
@@ -16,27 +16,27 @@ name = "mdbook-prql"
 test = false
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-ansi-to-html = "0.1.2"
-anyhow = "1.0.57"
+ansi-to-html = "0.1.3"
+anyhow = "1.0.75"
 itertools = "0.11.0"
-mdbook = {version = "0.4.21", default-features = false}
+mdbook = {version = "0.4.31", default-features = false}
 mdbook-preprocessor-boilerplate = "0.1.2"
 prql-compiler = {path = "../../crates/prql-compiler", default-features = false}
-pulldown-cmark = "0.9.1"
+pulldown-cmark = "0.9.3"
 pulldown-cmark-to-cmark = "11.0.0"
 strum = {version = "0.25.0", features = ["std", "derive"]}
-strum_macros = "0.25.0"
+strum_macros = "0.25.2"
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
 anstream = {version = "0.3.2"}
-globset = "0.4.8"
+globset = "0.4.13"
 insta = {version = "1.31", features = ["colors", "glob"]}
-log = "0.4.17"
-regex = "1.9.0"
-serde_json = "1.0.81"
+log = "0.4.20"
+regex = "1.9.5"
+serde_json = "1.0.105"
 serde_yaml = "0.9"
 similar-asserts = "1.5.0"
-walkdir = "2.3.2"
+walkdir = "2.4.0"
 
 [package.metadata.release]
 tag-name = "{{version}}"


### PR DESCRIPTION
Running `cargo outdated` is MSRV-aware, so does all the upgrades that are actually possible, from #3485 / #3479
