### PR TITLE
docs: Add Ace JavaScript editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 
 **Integrations**:
 
+- [Ace](https://ace.c9.io/), the JavaScript code editor now has syntax
+  highlightning for PRQL. (@vanillajonathan, #3493)
+
 **Internal changes**:
 
 - Simplify & speed up lexer (@max-sixty, #3426, #3418)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 **Integrations**:
 
 - [Ace](https://ace.c9.io/), the JavaScript code editor now has syntax
-  highlightning for PRQL. (@vanillajonathan, #3493)
+  highlighting for PRQL. (@vanillajonathan, #3493)
 
 **Internal changes**:
 

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -7,7 +7,8 @@ supports. Please raise any shortcomings in a GitHub issue.
 The definitions are somewhat scattered around the codebase; this page serves as
 an index.
 
-- [Ace](https://ace.c9.io/) — supported. The grammar is upstream ([prql_highlight_rules.js](https://github.com/ajaxorg/ace/blob/master/src/mode/prql_highlight_rules.js)).
+- [Ace](https://ace.c9.io/) — supported. The grammar is upstream
+  ([prql_highlight_rules.js](https://github.com/ajaxorg/ace/blob/master/src/mode/prql_highlight_rules.js)).
 
 - [Lezer](https://lezer.codemirror.net/) — used by CodeMirror editors. The PRQL
   file is at

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -7,6 +7,8 @@ supports. Please raise any shortcomings in a GitHub issue.
 The definitions are somewhat scattered around the codebase; this page serves as
 an index.
 
+- [Ace](https://ace.c9.io/) — supported. The grammar is upstream.
+
 - [Lezer](https://lezer.codemirror.net/) — used by CodeMirror editors. The PRQL
   file is at
   [`grammars/prql-lezer/README.md`](https://github.com/PRQL/prql/tree/main/grammars/prql-lezer/README.md).

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -7,7 +7,7 @@ supports. Please raise any shortcomings in a GitHub issue.
 The definitions are somewhat scattered around the codebase; this page serves as
 an index.
 
-- [Ace](https://ace.c9.io/) — supported. The grammar is upstream.
+- [Ace](https://ace.c9.io/) — supported. The grammar is upstream ([prql_highlight_rules.js](https://github.com/ajaxorg/ace/blob/master/src/mode/prql_highlight_rules.js)).
 
 - [Lezer](https://lezer.codemirror.net/) — used by CodeMirror editors. The PRQL
   file is at


### PR DESCRIPTION
**Ace** is an embeddable code editor written in JavaScript. It includes syntax highlighting for PRQL.

PR: https://github.com/ajaxorg/ace/pull/5307