### PR TITLE
chore: Revert "chore: bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -399,7 +399,7 @@ jobs:
           cargo tarpaulin --skip-clean --all-targets --features=test-dbs
           --out=Xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
       - name: Upload code coverage results
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Reverts PRQL/prql#3511

It seems the v4 tag has been removed.