### PR TITLE
fix!: Update case syntax to use brackets over braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 **Language**:
 
-- _Breaking:_ Case syntax now uses brackets `[]` rather than braces `{}`.
-
-  To convert previous PRQL queries to this new syntax simply change
-  `case { ... }` to `case [ ... ]`.
+- _Breaking:_ Case syntax now uses brackets `[]` rather than braces `{}`. To
+  convert previous PRQL queries to this new syntax simply change `case { ... }`
+  to `case [ ... ]`. (@AaronMoat, #3517)
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 **Language**:
 
+- _Breaking:_ Case syntax now uses brackets `[]` rather than braces `{}`.
+
+  To convert previous PRQL queries to this new syntax simply change
+  `case { ... }` to `case [ ... ]`.
+
 **Features**:
 
 **Fixes**:

--- a/crates/prql-compiler/src/codegen/ast.rs
+++ b/crates/prql-compiler/src/codegen/ast.rs
@@ -171,7 +171,7 @@ impl WriteSource for ExprKind {
                     inline: ", ",
                     line_end: ",",
                 }
-                .write_between("{", "}", opt)?;
+                .write_between("[", "]", opt)?;
                 Some(r)
             }
             Param(id) => Some(format!("${id}")),

--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -2908,10 +2908,10 @@ fn test_case() {
     assert_display_snapshot!(compile(
         r###"
     from employees
-    derive display_name = case {
+    derive display_name = case [
         nickname != null => nickname,
         true => f'{first_name} {last_name}'
-    }
+    ]
         "###).unwrap(),
         @r###"
     SELECT
@@ -2928,10 +2928,10 @@ fn test_case() {
     assert_display_snapshot!(compile(
         r###"
     from employees
-    derive display_name = case {
+    derive display_name = case [
         nickname != null => nickname,
         first_name != null => f'{first_name} {last_name}'
-    }
+    ]
         "###).unwrap(),
         @r###"
     SELECT
@@ -2949,9 +2949,9 @@ fn test_case() {
     assert_display_snapshot!(compile(
         r###"
     from tracks
-    select category = case {
+    select category = case [
         length > avg_length => 'long'
-    }
+    ]
     group category (aggregate {count this})
         "###).unwrap(),
         @r###"
@@ -3002,14 +3002,14 @@ fn test_static_analysis() {
         b = !(!(!(!(!(true))))),
         a3 = null ?? y,
 
-        a3 = case {
+        a3 = case [
             false == true => 1,
             7 == 3 => 2,
             7 == y => 3,
             7.3 == 7.3 => 4,
             z => 5,
             true => 6
-        },
+        ],
     }
         "###).unwrap(),
         @r###"

--- a/crates/prql-compiler/tests/integration/queries/switch.prql
+++ b/crates/prql-compiler/tests/integration/queries/switch.prql
@@ -1,9 +1,9 @@
 # mssql:test
 from tracks
 sort milliseconds
-select display = case {
+select display = case [
     composer != null => composer,
     genre_id < 17 => 'no composer',
     true => f'unknown composer'
-}
+]
 take 10

--- a/crates/prql-compiler/tests/integration/snapshots/integration__fmt@switch.prql.snap
+++ b/crates/prql-compiler/tests/integration/snapshots/integration__fmt@switch.prql.snap
@@ -1,14 +1,14 @@
 ---
 source: prql-compiler/tests/integration/main.rs
-expression: "from tracks\nsort milliseconds\nselect display = case {\n    composer != null => composer,\n    genre_id < 17 => 'no composer',\n    true => f'unknown composer'\n}\ntake 10\n"
+expression: "from tracks\nsort milliseconds\nselect display = case [\n    composer != null => composer,\n    genre_id < 17 => 'no composer',\n    true => f'unknown composer'\n]\ntake 10\n"
 input_file: prql-compiler/tests/integration/queries/switch.prql
 ---
 from tracks
 sort milliseconds
-select display = case {
+select display = case [
   composer != null => composer,
   genre_id < 17 => "no composer",
   true => f"unknown composer",
-}
+]
 take 10
 

--- a/crates/prql-compiler/tests/integration/snapshots/integration__sql@switch.prql.snap
+++ b/crates/prql-compiler/tests/integration/snapshots/integration__sql@switch.prql.snap
@@ -1,6 +1,6 @@
 ---
 source: prql-compiler/tests/integration/main.rs
-expression: "from tracks\nsort milliseconds\nselect display = case {\n    composer != null => composer,\n    genre_id < 17 => 'no composer',\n    true => f'unknown composer'\n}\ntake 10\n"
+expression: "from tracks\nsort milliseconds\nselect display = case [\n    composer != null => composer,\n    genre_id < 17 => 'no composer',\n    true => f'unknown composer'\n]\ntake 10\n"
 input_file: prql-compiler/tests/integration/queries/switch.prql
 ---
 WITH table_0 AS (

--- a/crates/prql-parser/src/expr.rs
+++ b/crates/prql-parser/src/expr.rs
@@ -111,7 +111,7 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
                     .separated_by(ctrl(','))
                     .allow_trailing()
                     .then_ignore(new_line().repeated())
-                    .delimited_by(ctrl('{'), ctrl('}')),
+                    .delimited_by(ctrl('['), ctrl(']')),
             )
             .map(ExprKind::Case);
 

--- a/crates/prql-parser/src/lib.rs
+++ b/crates/prql-parser/src/lib.rs
@@ -2241,10 +2241,10 @@ join s=salaries (==id)
 
     #[test]
     fn test_case() {
-        assert_yaml_snapshot!(parse_expr(r#"case {
+        assert_yaml_snapshot!(parse_expr(r#"case [
             nickname != null => nickname,
             true => null
-        }"#).unwrap(), @r###"
+        ]"#).unwrap(), @r###"
         ---
         Case:
           - condition:

--- a/web/book/src/reference/syntax/README.md
+++ b/web/book/src/reference/syntax/README.md
@@ -27,7 +27,7 @@ A summary of PRQL syntax:
 | `#`                  | [Comments](./comments.md)                                                      | `# A comment`                                           |
 | `==`                 | [Self-equality in `join`](../stdlib/transforms/join.md#self-equality-operator) | `join s=salaries (==id)`                                |
 | `->`                 | [Function definitions](../declarations/functions.md)                           | `let add = a b -> a + b`                                |
-| `=>`                 | [Case statement](./case.md)                                                    | `case {a==1 => c, a==2 => d }`                          |
+| `=>`                 | [Case statement](./case.md)                                                    | `case [a==1 => c, a==2 => d]`                           |
 | `+`,`-`              | [Sort order](../stdlib/transforms/sort.md)                                     | `sort {-amount, +date}`                                 |
 | `??`                 | [Coalesce](./operators.md#coalesce)                                            | `amount ?? 0`                                           |
 

--- a/web/book/src/reference/syntax/case.md
+++ b/web/book/src/reference/syntax/case.md
@@ -5,19 +5,19 @@ associated value. If none of the conditions match, `null` is returned.
 
 ```prql
 from employees
-derive distance = case {
+derive distance = case [
   city == "Calgary" => 0,
   city == "Edmonton" => 300,
-}
+]
 ```
 
 To set a default, a `true` condition can be used:
 
 ```prql
 from employees
-derive distance = case {
+derive distance = case [
   city == "Calgary" => 0,
   city == "Edmonton" => 300,
   true => "Unknown",
-}
+]
 ```

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__case__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__case__0.snap
@@ -1,6 +1,6 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from employees\nderive distance = case {\n  city == \"Calgary\" => 0,\n  city == \"Edmonton\" => 300,\n}\n"
+expression: "from employees\nderive distance = case [\n  city == \"Calgary\" => 0,\n  city == \"Edmonton\" => 300,\n]\n"
 ---
 SELECT
   *,

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__case__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__case__1.snap
@@ -1,6 +1,6 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from employees\nderive distance = case {\n  city == \"Calgary\" => 0,\n  city == \"Edmonton\" => 300,\n  true => \"Unknown\",\n}\n"
+expression: "from employees\nderive distance = case [\n  city == \"Calgary\" => 0,\n  city == \"Edmonton\" => 300,\n  true => \"Unknown\",\n]\n"
 ---
 SELECT
   *,


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking change to case syntax.

Resolves #3462