### PR TITLE
chore(prqlc): bump MSRV to 1.70.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 **Integrations**:
 
+- Bump `prqlc`'s MSRV to 1.70.0 (@eitsupi, #3521)
+
 **Internal changes**:
 
 **New Contributors**:

--- a/crates/prqlc/Cargo.toml
+++ b/crates/prqlc/Cargo.toml
@@ -5,10 +5,8 @@ name = "prqlc"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
+rust-version = "1.70.0"
 version.workspace = true
-
-metadata.msrv = "1.65.0"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 anstream = {version = "0.3.2", features = ["auto"]}


### PR DESCRIPTION
prqlc can now be binary installed on each platform.

I think the some of current problem with MSRV in dependencies is the prqlc dependency (#3520), so I think it makes sense to only update prqlc's MSRV.