### PR TITLE
feat: Allow cmd-/ (Mac) or ctrl-/ (Windows) to toggle playground comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 **Web**:
 
+- Allow cmd-/ (Mac) or ctrl-/ (Windows) to toggle comments in the playground
+  editor (@AaronMoat, #3522)
+
 **Integrations**:
 
 **Internal changes**:

--- a/web/playground/src/workbench/Workbench.js
+++ b/web/playground/src/workbench/Workbench.js
@@ -49,6 +49,11 @@ class Workbench extends React.Component {
     this.monaco = monaco;
     monaco.editor.defineTheme("blackboard", monacoTheme);
     monaco.languages.register({ id: "prql", extensions: ["prql"] });
+    monaco.languages.setLanguageConfiguration("prql", {
+      comments: {
+        lineComment: "#",
+      },
+    });
     monaco.languages.setMonarchTokensProvider("prql", prqlSyntax);
   }
 


### PR DESCRIPTION
Resolves #3475 

Docs: https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.LanguageConfiguration.html