### PR TITLE
feat: Allow cmd-/ (Mac) or ctrl-/ (Windows) to toggle playground comments (#3522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # PRQL Changelog
 
-## 0.9.5 — 2023-09-12
+## [unreleased]
+
+**Language**:
+
+**Features**:
+
+**Fixes**:
+
+**Documentation**:
+
+**Web**:
+
+- Allow cmd-/ (Mac) or ctrl-/ (Windows) to toggle comments in the playground
+  editor (@AaronMoat, #3522)
+
+**Integrations**:
+
+**Internal changes**:
+
+**New Contributors**:
+
+## 0.9.5 — 2023-09-16
 
 0.9.5 adds a line-wrapping character, fixes a few bugs, and improves our CI. The
 release has 77 commits from 8 contributors. Selected changes are below.

--- a/web/playground/src/workbench/Workbench.js
+++ b/web/playground/src/workbench/Workbench.js
@@ -49,6 +49,11 @@ class Workbench extends React.Component {
     this.monaco = monaco;
     monaco.editor.defineTheme("blackboard", monacoTheme);
     monaco.languages.register({ id: "prql", extensions: ["prql"] });
+    monaco.languages.setLanguageConfiguration("prql", {
+      comments: {
+        lineComment: "#",
+      },
+    });
     monaco.languages.setMonarchTokensProvider("prql", prqlSyntax);
   }
 


### PR DESCRIPTION
Just the backport to `web`, from https://github.com/PRQL/prql/pull/3522#issuecomment-1722409353