### PR TITLE
fix(web): Add max height to error panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Allow cmd-/ (Mac) or ctrl-/ (Windows) to toggle comments in the playground
   editor (@AaronMoat, #3522)
 
+- Limit maximum height of the playground editor's error panel to avoid taking
+  over whole screen (@AaronMoat, #3524)
+
 **Integrations**:
 
 **Internal changes**:

--- a/web/playground/src/workbench/Workbench.css
+++ b/web/playground/src/workbench/Workbench.css
@@ -62,6 +62,9 @@
   margin: 0;
   width: 100%;
 
+  max-height: 50%;
+  overflow-y: auto;
+
   font-family: monospace;
   white-space: pre-wrap;
 


### PR DESCRIPTION
Resolves #3348

Example:

<img width="1437" alt="image" src="https://github.com/PRQL/prql/assets/2937187/28f2f2b4-9bfe-41dd-8503-2f6517830ff4">
