### PR TITLE
feat: Special function to return PRQL version

### DIFF
--- a/crates/prql-compiler/src/semantic/eval/mod.rs
+++ b/crates/prql-compiler/src/semantic/eval/mod.rs
@@ -277,11 +277,6 @@ impl Evaluator {
                 ExprKind::Array(array)
             }
 
-            "std.prql_version" => {
-                let ver = COMPILER_VERSION.to_string();
-                ExprKind::Literal(String(ver))
-            }
-
             _ => {
                 return Err(Error::new_simple(format!("unknown function {func_name}"))
                     .with_span(span)
@@ -404,7 +399,6 @@ fn std_module() -> Expr {
             new_func("columnar", &["closure", "relation"]),
             new_func("sum", &["x"]),
             new_func("lag", &["x"]),
-            new_func("prql_version", &[]),
         ]
         .to_vec(),
     ))
@@ -542,21 +536,6 @@ mod test {
             std.columnar {g = std.lag b}
         ").unwrap(),
             @"[{g = null}, {g = 4}, {g = 5}]"
-        );
-    }
-
-    #[test]
-    fn prql_version() {
-        println!("{:?}", eval("std.prql_version"));
-        println!(
-            "{:?}",
-            crate::compile(
-                r"
-            from updates
-            filter version = prql_version
-        ",
-                &crate::Options::default()
-            )
         );
     }
 }

--- a/crates/prql-compiler/src/semantic/eval/mod.rs
+++ b/crates/prql-compiler/src/semantic/eval/mod.rs
@@ -6,7 +6,6 @@ use itertools::Itertools;
 use super::ast_expand;
 use crate::error::{Error, Span, WithErrorInfo};
 use crate::ir::pl::{Expr, ExprKind, Func, FuncParam, Ident, Literal, PlFold};
-use crate::COMPILER_VERSION;
 
 pub fn eval(expr: prql_ast::expr::Expr) -> Result<Expr> {
     let expr = ast_expand::expand_expr(expr)?;
@@ -105,7 +104,6 @@ fn lookup(base: Option<&Expr>, name: &str) -> Result<Expr> {
     if name == "std" {
         return Ok(std_module());
     }
-
     Err(Error::new_simple(format!("cannot find `{}` in {:?}", name, base)).into())
 }
 

--- a/crates/prql-compiler/src/semantic/eval/mod.rs
+++ b/crates/prql-compiler/src/semantic/eval/mod.rs
@@ -3,10 +3,10 @@ use std::iter::zip;
 use anyhow::Result;
 use itertools::Itertools;
 
+use super::ast_expand;
 use crate::error::{Error, Span, WithErrorInfo};
 use crate::ir::pl::{Expr, ExprKind, Func, FuncParam, Ident, Literal, PlFold};
-
-use super::ast_expand;
+use crate::COMPILER_VERSION;
 
 pub fn eval(expr: prql_ast::expr::Expr) -> Result<Expr> {
     let expr = ast_expand::expand_expr(expr)?;
@@ -277,6 +277,11 @@ impl Evaluator {
                 ExprKind::Array(array)
             }
 
+            "std.prql_version" => {
+                let ver = COMPILER_VERSION.to_string();
+                ExprKind::Literal(String(ver))
+            }
+
             _ => {
                 return Err(Error::new_simple(format!("unknown function {func_name}"))
                     .with_span(span)
@@ -399,6 +404,7 @@ fn std_module() -> Expr {
             new_func("columnar", &["closure", "relation"]),
             new_func("sum", &["x"]),
             new_func("lag", &["x"]),
+            new_func("prql_version", &[]),
         ]
         .to_vec(),
     ))
@@ -536,6 +542,21 @@ mod test {
             std.columnar {g = std.lag b}
         ").unwrap(),
             @"[{g = null}, {g = 4}, {g = 5}]"
+        );
+    }
+
+    #[test]
+    fn prql_version() {
+        println!("{:?}", eval("std.prql_version"));
+        println!(
+            "{:?}",
+            crate::compile(
+                r"
+            from updates
+            filter version = prql_version
+        ",
+                &crate::Options::default()
+            )
         );
     }
 }

--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-2.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/prql_compiler/src/semantic/resolver/mod.rs
+source: crates/prql-compiler/src/semantic/resolver/mod.rs
 expression: "resolve_lineage(r#\"\n            from table_1\n            join customers (==customer_no)\n            \"#).unwrap()"
 ---
 columns:
@@ -10,12 +10,12 @@ columns:
       input_name: customers
       except: []
 inputs:
-  - id: 185
+  - id: 186
     name: table_1
     table:
       - default_db
       - table_1
-  - id: 178
+  - id: 179
     name: customers
     table:
       - default_db

--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/prql_compiler/src/semantic/resolver/mod.rs
+source: crates/prql-compiler/src/semantic/resolver/mod.rs
 expression: "resolve_lineage(r#\"\n            from e = employees\n            join salaries (==emp_no)\n            group {e.emp_no, e.gender} (\n                aggregate {\n                    emp_salary = average salaries.salary\n                }\n            )\n            \"#).unwrap()"
 ---
 columns:
@@ -7,26 +7,26 @@ columns:
       name:
         - e
         - emp_no
-      target_id: 214
+      target_id: 215
       target_name: ~
   - Single:
       name:
         - e
         - gender
-      target_id: 215
+      target_id: 216
       target_name: ~
   - Single:
       name:
         - emp_salary
-      target_id: 239
+      target_id: 240
       target_name: ~
 inputs:
-  - id: 206
+  - id: 207
     name: e
     table:
       - default_db
       - employees
-  - id: 199
+  - id: 200
     name: salaries
     table:
       - default_db

--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/prql_compiler/src/semantic/resolver/mod.rs
+source: crates/prql-compiler/src/semantic/resolver/mod.rs
 expression: "resolve_lineage(r#\"\n            from orders\n            select {customer_no, gross, tax, gross - tax}\n            take 20\n            \"#).unwrap()"
 ---
 columns:
@@ -7,26 +7,26 @@ columns:
       name:
         - orders
         - customer_no
-      target_id: 202
-      target_name: ~
-  - Single:
-      name:
-        - orders
-        - gross
       target_id: 203
       target_name: ~
   - Single:
       name:
         - orders
-        - tax
+        - gross
       target_id: 204
       target_name: ~
   - Single:
-      name: ~
+      name:
+        - orders
+        - tax
       target_id: 205
       target_name: ~
+  - Single:
+      name: ~
+      target_id: 206
+      target_name: ~
 inputs:
-  - id: 201
+  - id: 202
     name: orders
     table:
       - default_db

--- a/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
+++ b/crates/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/prql_compiler/src/semantic/resolver/transforms.rs
+source: crates/prql-compiler/src/semantic/resolver/transforms.rs
 expression: expr
 ---
 TransformCall:
@@ -21,7 +21,7 @@ TransformCall:
             input_name: c_invoice
             except: []
       inputs:
-        - id: 194
+        - id: 195
           name: c_invoice
           table:
             - default_db
@@ -185,14 +185,14 @@ lineage:
         name:
           - c_invoice
           - issued_at
-        target_id: 195
+        target_id: 196
         target_name: ~
     - Single:
         name: ~
-        target_id: 218
+        target_id: 219
         target_name: ~
   inputs:
-    - id: 194
+    - id: 195
       name: c_invoice
       table:
         - default_db

--- a/crates/prql-compiler/src/semantic/resolver/transforms.rs
+++ b/crates/prql-compiler/src/semantic/resolver/transforms.rs
@@ -1078,18 +1078,4 @@ mod tests {
             - Wildcard
         "###);
     }
-
-    #[test]
-    fn test_prql_version() {
-        println!(
-            "{:?}",
-            crate::compile(
-                r"
-        from updates
-        derive version = prql_version
-    ",
-                &crate::Options::default()
-            )
-        )
-    }
 }

--- a/crates/prql-compiler/src/semantic/resolver/transforms.rs
+++ b/crates/prql-compiler/src/semantic/resolver/transforms.rs
@@ -10,6 +10,7 @@ use crate::generic::{SortDirection, WindowKind};
 use crate::ir::pl::PlFold;
 use crate::ir::pl::*;
 use crate::semantic::write_pl;
+use crate::COMPILER_VERSION;
 
 use super::super::decl::{Decl, DeclKind};
 use super::super::module::Module;
@@ -364,6 +365,12 @@ pub fn cast_transform(resolver: &mut Resolver, closure: Func) -> Result<Expr> {
                 ..res
             };
             return Ok(res);
+        }
+
+        "prql_version" => {
+            // yes, this is not a transform, but this is the most appropriate place for it
+            let ver = COMPILER_VERSION.to_string();
+            return Ok(Expr::new(ExprKind::Literal(Literal::String(ver))));
         }
 
         _ => {
@@ -1070,5 +1077,19 @@ mod tests {
             - Single: num_of_articles
             - Wildcard
         "###);
+    }
+
+    #[test]
+    fn test_prql_version() {
+        println!(
+            "{:?}",
+            crate::compile(
+                r"
+        from updates
+        derive version = prql_version
+    ",
+                &crate::Options::default()
+            )
+        )
     }
 }

--- a/crates/prql-compiler/src/semantic/std.prql
+++ b/crates/prql-compiler/src/semantic/std.prql
@@ -195,3 +195,8 @@ let upper = column -> <text> internal std.upper
 ## File-reading functions, primarily for DuckDB
 let read_parquet = source<text> -> <relation> internal std.read_parquet
 let read_csv = source<text> -> <relation> internal std.read_csv
+
+
+## PRQL compiler functions 
+
+let prql_version = -> <string> internal std.prql_version

--- a/crates/prql-compiler/src/semantic/std.prql
+++ b/crates/prql-compiler/src/semantic/std.prql
@@ -197,6 +197,6 @@ let read_parquet = source<text> -> <relation> internal std.read_parquet
 let read_csv = source<text> -> <relation> internal std.read_csv
 
 
-## PRQL compiler functions 
+## PRQL compiler functions
 
 let prql_version = -> <string> internal std.prql_version

--- a/crates/prql-compiler/src/semantic/std.prql
+++ b/crates/prql-compiler/src/semantic/std.prql
@@ -199,4 +199,4 @@ let read_csv = source<text> -> <relation> internal std.read_csv
 
 ## PRQL compiler functions
 
-let prql_version = -> <string> internal std.prql_version
+let prql_version = -> <text> internal std.prql_version

--- a/crates/prql-compiler/src/semantic/std.prql
+++ b/crates/prql-compiler/src/semantic/std.prql
@@ -199,4 +199,4 @@ let read_csv = source<text> -> <relation> internal std.read_csv
 
 ## PRQL compiler functions
 
-let prql_version = -> <text> internal std.prql_version
+let prql_version = -> <text> internal prql_version

--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -3403,6 +3403,16 @@ fn test_header_target_error() {
 }
 
 #[test]
+fn prql_version() {
+    assert_display_snapshot!(compile(r#"
+    from x
+    derive y = std.prql_version
+    "#).unwrap(),@r###"
+    Error: Unknown name
+    "###);
+}
+
+#[test]
 fn test_loop() {
     assert_display_snapshot!(compile(r#"
     from [{n = 1}]

--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -3408,7 +3408,11 @@ fn prql_version() {
     from x
     derive y = std.prql_version
     "#).unwrap(),@r###"
-    Error: Unknown name
+    SELECT
+      *,
+      '0.10.0' AS y
+    FROM
+      x
     "###);
 }
 


### PR DESCRIPTION
Add a new function to std library to return PRQL version (see #3260)

**Simple example** 
```elm
from updates
filter version = prql_version
```
```sql
Select 
  *
from 
  updates
WHERE
  version = "0.9.5"
```

