### PR TITLE
internal: Slightly improved error message on wrong type

### DIFF
--- a/crates/prql-compiler/src/semantic/resolver/root_module_impl.rs
+++ b/crates/prql-compiler/src/semantic/resolver/root_module_impl.rs
@@ -116,7 +116,7 @@ impl RootModule {
 
             // Was not able to infer.
             Err(None) => Err(Error::new_simple(
-                format!("Unknown name {}", &ident).to_string(),
+                format!("Unknown name `{}`", &ident).to_string(),
             )),
             Err(Some(msg)) => Err(msg),
         }

--- a/crates/prql-compiler/src/semantic/resolver/root_module_impl.rs
+++ b/crates/prql-compiler/src/semantic/resolver/root_module_impl.rs
@@ -107,14 +107,17 @@ impl RootModule {
             ident.clone()
         };
 
-        // fallback case: try to match with NS_INFER and infer the declaration from the original ident.
-        match self.resolve_ident_fallback(ident, NS_INFER) {
+        // fallback case: try to match with NS_INFER and infer the declaration
+        // from the original ident.
+        match self.resolve_ident_fallback(&ident, NS_INFER) {
             // The declaration and all needed parent modules were created
             // -> just return the fq ident
             Ok(inferred_ident) => Ok(inferred_ident),
 
             // Was not able to infer.
-            Err(None) => Err(Error::new_simple("Unknown name".to_string())),
+            Err(None) => Err(Error::new_simple(
+                format!("Unknown name {}", &ident).to_string(),
+            )),
             Err(Some(msg)) => Err(msg),
         }
     }
@@ -122,7 +125,7 @@ impl RootModule {
     /// Try lookup of the ident with name replaced. If unsuccessful, recursively retry parent ident.
     fn resolve_ident_fallback(
         &mut self,
-        ident: Ident,
+        ident: &Ident,
         name_replacement: &'static str,
     ) -> Result<Ident, Option<Error>> {
         let infer_ident = ident.clone().with_name(name_replacement);
@@ -133,7 +136,7 @@ impl RootModule {
         if decls.is_empty() {
             if let Some(parent) = infer_ident.clone().pop() {
                 // try to infer parent
-                let _ = self.resolve_ident_fallback(parent, NS_INFER_MODULE)?;
+                let _ = self.resolve_ident_fallback(&parent, NS_INFER_MODULE)?;
 
                 // module was successfully inferred, retry the lookup
                 decls = self.root_mod.lookup(&infer_ident)
@@ -144,7 +147,7 @@ impl RootModule {
             1 => {
                 // single match, great!
                 let infer_ident = decls.into_iter().next().unwrap();
-                self.infer_decl(infer_ident, &ident)
+                self.infer_decl(infer_ident, ident)
                     .map_err(|x| Some(Error::new_simple(x)))
             }
             0 => Err(None),

--- a/crates/prql-compiler/src/tests/test_bad_error_messages.rs
+++ b/crates/prql-compiler/src/tests/test_bad_error_messages.rs
@@ -49,7 +49,7 @@ fn test_bad_error_messages() {
        │
      5 │     filter f location
        │              ────┬───
-       │                  ╰───── Unknown name
+       │                  ╰───── Unknown name `location`
     ───╯
     "###);
 
@@ -125,7 +125,7 @@ fn select_with_extra_fstr() {
        │
      3 │     select lower f"{x}/{y}"
        │                    ─┬─
-       │                     ╰─── Unknown name
+       │                     ╰─── Unknown name `x`
     ───╯
     "###);
 }

--- a/crates/prql-compiler/src/tests/test_error_messages.rs
+++ b/crates/prql-compiler/src/tests/test_error_messages.rs
@@ -48,7 +48,7 @@ fn test_errors() {
        │
      4 │     select b
        │            ┬
-       │            ╰── Unknown name
+       │            ╰── Unknown name `b`
     ───╯
     "###);
 

--- a/crates/prqlc/src/cli.rs
+++ b/crates/prqlc/src/cli.rs
@@ -557,7 +557,7 @@ sort full
            │
          1 │ asdf
            │ ──┬─
-           │   ╰─── Unknown name
+           │   ╰─── Unknown name `asdf`
         ───╯
         "###);
     }

--- a/web/book/src/lib.rs
+++ b/web/book/src/lib.rs
@@ -304,7 +304,7 @@ this is an error
        <span style='color:#949494'>│</span>
      <span style='color:#949494'>1 │</span> this<span style='color:#b2b2b2'> is an error</span>
      <span style='color:#585858'>  │</span> ──┬─
-     <span style='color:#585858'>  │</span>   ╰─── Unknown name
+     <span style='color:#585858'>  │</span>   ╰─── Unknown name `this`
     <span style='color:#949494'>───╯</span>
     </code></pre>
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__parentheses__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__parentheses__1.snap
@@ -7,6 +7,6 @@ Error:
    │
  2 │ derive total_distance = sum distance
    │                             ────┬───
-   │                                 ╰───── Unknown name
+   │                                 ╰───── Unknown name `distance`
 ───╯
 


### PR DESCRIPTION
~This is mostly seen by developers, but the less someone has to add `dbg!`, the easier spotting issues is.~

Actually this comes up in two ways:
- When developing and not getting the full error message — e.g. when using `string` rather than `text` as a type in the stdlib #3533 — without the name it's difficult to know what's going on
- When using PRQL and getting the full error message — then maybe it's superfluous? I'm not sure — what do others think?

(tagging the core devs because a quick take would be good, not because it's terribly important)