### PR TITLE
feat(Lezer grammar): Improve grammar

### DIFF
--- a/grammars/prql-lezer/src/arrays.txt
+++ b/grammars/prql-lezer/src/arrays.txt
@@ -23,9 +23,9 @@ Query(Statements(Pipeline_stmt(Pipeline(Expr(Array(Expr(Ident),Expr(Ident),Expr(
 [
 
   foo,
-  
+
   bar,
-  
+
   baz
 
 ]

--- a/grammars/prql-lezer/src/arrays.txt
+++ b/grammars/prql-lezer/src/arrays.txt
@@ -1,0 +1,35 @@
+# Array on one line
+
+[foo, bar, baz]
+
+==>
+
+Query(Statements(Pipeline_stmt(Pipeline(Expr(Array(Expr(Ident),Expr(Ident),Expr(Ident)))))))
+
+# Array on multiple lines
+
+[
+  foo,
+  bar,
+  baz
+]
+
+==>
+
+Query(Statements(Pipeline_stmt(Pipeline(Expr(Array(Expr(Ident),Expr(Ident),Expr(Ident)))))))
+
+# Array on multiple lines with blank lines
+
+[
+
+  foo,
+  
+  bar,
+  
+  baz
+
+]
+
+==>
+
+Query(Statements(Pipeline_stmt(Pipeline(Expr(Array(Expr(Ident),Expr(Ident),Expr(Ident)))))))

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -16,7 +16,7 @@ Pipeline { expr_call (pipe+ expr_call)* }
 
 pipe { "|" | ~ambig_newline newline }
 
-Tuple { "{" newline? tuple_item (("," newline? ) tuple_item)* ","? newline? "}" }
+Tuple { "{" newline* tuple_item (("," newline* ) tuple_item)* ","? newline* "}" }
 
 tuple_item { Assign_call | expr_call | Case_branch }
 
@@ -36,7 +36,7 @@ Named_arg { ident_part ":" Expr }
 Assign { ident_part "=" Expr }
 Assign_call { ident_part "=" expr_call }
 Case_branch { Expr "=>" Expr }
-Array { "[" newline? Expr (("," newline? ) Expr)* ","? newline? "]" }
+Array { "[" newline* Expr (("," newline* ) Expr)* ","? newline* "]" }
 // Possibly we could only accept case branches inside the Tuple?
 Case {  @specialize<ident_part, "case"> Tuple }
 
@@ -46,7 +46,7 @@ Nested_pipeline { "(" newline* Pipeline ~ambig_newline newline? ")" }
 
 // Because this is outside tokens, we can't disallow whitespace.
 // It's outside tokens because otherwise it conflicts with Ident
-Ident { ident_part ( "." ident_part)* }
+Ident { ident_part ( "." (ident_part | "*"))* }
 
 // I don't think it's possible to have `Op_bin` & `Op_unary` as tokens — that
 // would mean `-` can't be both unary & bin.
@@ -96,7 +96,7 @@ Op_bin { op_bin_only | !term op_unary }
   // We need to give precedence to `Op_bin` so we don't get `x+y` as `x` & `+y`.
   // S & F strings have precedence over idents beginning with s / f (we could
   // use specialize but I think means we need to redefine `String` for each)
-  @precedence { R_string, S_string, F_string, Op_bin_only, ident_part }
+  @precedence { R_string, S_string, F_string, op_bin_only, ident_part }
 }
 
 Def { @specialize<ident_part, "let"> ident_part "=" (Nested_pipeline (newline+ | end) | Lambda) }

--- a/grammars/prql-lezer/src/tuples.txt
+++ b/grammars/prql-lezer/src/tuples.txt
@@ -1,0 +1,43 @@
+# Tuple on one line
+
+{foo, bar, baz}
+
+==>
+
+Query(Statements(Pipeline_stmt(Pipeline(Expr(Tuple(Expr(Ident),Expr(Ident),Expr(Ident)))))))
+
+# Tuple on multiple lines
+
+{
+  foo,
+  bar,
+  baz
+}
+
+==>
+
+Query(Statements(Pipeline_stmt(Pipeline(Expr(Tuple(Expr(Ident),Expr(Ident),Expr(Ident)))))))
+
+# Tuple on multiple lines with blank lines
+
+{
+
+  foo,
+  
+  bar,
+  
+  baz
+
+}
+
+==>
+
+Query(Statements(Pipeline_stmt(Pipeline(Expr(Tuple(Expr(Ident),Expr(Ident),Expr(Ident)))))))
+
+# Tuple with key and value
+
+{foo=bar}
+
+==>
+
+Query(Statements(Pipeline_stmt(Pipeline(Expr(Tuple(Assign_call(Expr(Ident))))))))

--- a/grammars/prql-lezer/src/tuples.txt
+++ b/grammars/prql-lezer/src/tuples.txt
@@ -23,9 +23,9 @@ Query(Statements(Pipeline_stmt(Pipeline(Expr(Tuple(Expr(Ident),Expr(Ident),Expr(
 {
 
   foo,
-  
+
   bar,
-  
+
   baz
 
 }


### PR DESCRIPTION
This patch relaxes the grammar so it allows multiple line breaks within arrays and tuples. It adds tests for it.

It also allows the use of the wildcard character `*` in identifiers which allows for the `/tests/integration/queries/distinct.prql` query.

It also fixes a incorrect reference in the grammar `Op_bin_only` when it was actually `op_bin_only`.