### PR TITLE
feat(highlight.js): New stuff

### DIFF
--- a/web/book/highlight-prql.js
+++ b/web/book/highlight-prql.js
@@ -40,15 +40,15 @@ formatting = function (hljs) {
   ];
 
   const DATATYPES = [
-    'bool',
-    'float', 
-    'int',
-    'int8',
-    'int16',
-    'int32',
-    'int64',
-    'text',
-    'timestamp'
+    "bool",
+    "float",
+    "int",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "text",
+    "timestamp",
   ];
 
   const TRANSFORMS = [
@@ -84,7 +84,7 @@ formatting = function (hljs) {
         begin: "#!",
         end: "$",
         subLanguage: "markdown",
-        relevance: 0
+        relevance: 0,
       },
       hljs.COMMENT("#", "$"),
       {
@@ -117,7 +117,8 @@ formatting = function (hljs) {
         // interval
         scope: "string",
         // Add more as needed
-        match: /\d+(years|months|weeks|days|hours|minutes|seconds|milliseconds|microseconds)/,
+        match:
+          /\d+(years|months|weeks|days|hours|minutes|seconds|milliseconds|microseconds)/,
         relevance: 10,
       },
       {
@@ -132,7 +133,7 @@ formatting = function (hljs) {
             begin: 'r"',
             end: '"',
           },
-        ]
+        ],
       },
       {
         // interpolation strings: s-strings are variables and f-strings are
@@ -224,7 +225,7 @@ formatting = function (hljs) {
             scope: "char.escape",
             match: /\\([bfnrt]|u\d{4})/,
           },
-         ]
+        ],
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {

--- a/web/book/highlight-prql.js
+++ b/web/book/highlight-prql.js
@@ -72,7 +72,7 @@ formatting = function (hljs) {
   const CHAR_ESCAPE = {
     scope: "char.escape",
     match: /\\\\|\\([bfnrt]|u\d{4})/,
-  }
+  };
 
   return {
     name: "PRQL",
@@ -226,7 +226,7 @@ formatting = function (hljs) {
             end: "'",
           },
         ],
-        contains: [ CHAR_ESCAPE ],
+        contains: [CHAR_ESCAPE],
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {

--- a/web/book/highlight-prql.js
+++ b/web/book/highlight-prql.js
@@ -69,6 +69,11 @@ formatting = function (hljs) {
 
   const KEYWORDS = ["let", "prql", "into", "case", "in", "as", "module"];
 
+  const CHAR_ESCAPE = {
+    scope: "char.escape",
+    match: /\\\\|\\([bfnrt]|u\d{4})/,
+  }
+
   return {
     name: "PRQL",
     case_insensitive: true,
@@ -177,6 +182,7 @@ formatting = function (hljs) {
           },
         ],
         contains: [
+          CHAR_ESCAPE,
           {
             scope: "variable",
             begin: "f",
@@ -220,12 +226,7 @@ formatting = function (hljs) {
             end: "'",
           },
         ],
-        contains: [
-          {
-            scope: "char.escape",
-            match: /\\([bfnrt]|u\d{4})/,
-          },
-        ],
+        contains: [ CHAR_ESCAPE ],
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {

--- a/web/book/highlight-prql.js
+++ b/web/book/highlight-prql.js
@@ -1,3 +1,10 @@
+/*
+Language: PRQL
+Description: PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.
+Category: common, database
+Website: https://prql-lang.org/
+*/
+
 // Syntax highlighting for PRQL.
 
 // Keep consistent with
@@ -20,6 +27,30 @@
 // - Can we represent the inner s & f string items?
 
 formatting = function (hljs) {
+  const BUILTIN_FUNCTIONS = [
+    "any",
+    "average",
+    "concat_array",
+    "count",
+    "every",
+    "max",
+    "min",
+    "stddev",
+    "sum",
+  ];
+
+  const DATATYPES = [
+    'bool',
+    'float', 
+    'int',
+    'int8',
+    'int16',
+    'int32',
+    'int64',
+    'text',
+    'timestamp'
+  ];
+
   const TRANSFORMS = [
     "aggregate",
     "append",
@@ -35,16 +66,26 @@ formatting = function (hljs) {
     "union",
     "window",
   ];
-  const BUILTIN_FUNCTIONS = ["case", "in", "as"];
-  const KEYWORDS = ["let", "prql", "into"];
+
+  const KEYWORDS = ["let", "prql", "into", "case", "in", "as", "module"];
+
   return {
     name: "PRQL",
     case_insensitive: true,
     keywords: {
+      built_in: BUILTIN_FUNCTIONS,
       keyword: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS],
-      literal: "false true null ",
+      literal: "false true null",
+      type: DATATYPES,
     },
     contains: [
+      {
+        // docblock
+        begin: "#!",
+        end: "$",
+        subLanguage: "markdown",
+        relevance: 0
+      },
       hljs.COMMENT("#", "$"),
       {
         // named arg
@@ -52,6 +93,11 @@ formatting = function (hljs) {
         begin: /\w+\s*:/,
         end: "",
         relevance: 10,
+      },
+      {
+        // meta prql for target and version
+        scope: "meta",
+        match: /^prql/,
       },
       // This seems much too strong at the moment, so disabling. I think ideally
       // we'd have it for aliases but not assigns.
@@ -64,15 +110,29 @@ formatting = function (hljs) {
       {
         // date
         scope: "string",
-        match: /@(\d*|-|\.\d|:)+/,
+        match: /@(\d*|-|\.\d|:|T)+Z?/,
         relevance: 10,
       },
       {
         // interval
         scope: "string",
         // Add more as needed
-        match: /\d+(days|hours|minutes|seconds|milliseconds)/,
+        match: /\d+(years|months|weeks|days|hours|minutes|seconds|milliseconds|microseconds)/,
         relevance: 10,
+      },
+      {
+        scope: "string",
+        relevance: 10,
+        variants: [
+          {
+            begin: 'r"""',
+            end: '"""',
+          },
+          {
+            begin: 'r"',
+            end: '"',
+          },
+        ]
       },
       {
         // interpolation strings: s-strings are variables and f-strings are
@@ -82,11 +142,11 @@ formatting = function (hljs) {
         relevance: 10,
         variants: [
           {
-            begin: '(s)"""',
+            begin: 's"""',
             end: '"""',
           },
           {
-            begin: '(s)"',
+            begin: 's"',
             end: '"',
           },
         ],
@@ -107,11 +167,11 @@ formatting = function (hljs) {
         relevance: 10,
         variants: [
           {
-            begin: '(f)"""',
+            begin: 'f"""',
             end: '"""',
           },
           {
-            begin: '(f)"',
+            begin: 'f"',
             end: '"',
           },
         ],
@@ -159,12 +219,17 @@ formatting = function (hljs) {
             end: "'",
           },
         ],
+        contains: [
+          {
+            scope: "char.escape",
+            match: /\\([bfnrt]|u\d{4})/,
+          },
+         ]
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {
         scope: "operator",
-        match:
-          /(>)|(<)|(==)|(\+)|(\-)|(\/)|(\*)|(!=)|(->)|(=>)|(<=)|(>=)|(&&)|(\|\|)/,
+        match: /==|~=|\+|\-|\/|\*|!=|->|=>|<=|>=|&&|\|\||<|>/,
         relevance: 10,
       },
       {

--- a/web/website/themes/prql-theme/static/plugins/highlight/prql.js
+++ b/web/website/themes/prql-theme/static/plugins/highlight/prql.js
@@ -57,6 +57,11 @@ formatting = function (hljs) {
 
   const KEYWORDS = ["let", "prql", "into", "case", "in", "as", "module"];
 
+  const CHAR_ESCAPE = {
+    scope: "char.escape",
+    match: /\\\\|\\([bfnrt]|u\d{4})/,
+  }
+
   return {
     name: "PRQL",
     case_insensitive: true,
@@ -165,6 +170,7 @@ formatting = function (hljs) {
           },
         ],
         contains: [
+          CHAR_ESCAPE,
           {
             scope: "variable",
             begin: "f",
@@ -208,12 +214,7 @@ formatting = function (hljs) {
             end: "'",
           },
         ],
-        contains: [
-          {
-            scope: "char.escape",
-            match: /\\([bfnrt]|u\d{4})/,
-          },
-        ],
+        contains: [ CHAR_ESCAPE ],
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {

--- a/web/website/themes/prql-theme/static/plugins/highlight/prql.js
+++ b/web/website/themes/prql-theme/static/plugins/highlight/prql.js
@@ -28,15 +28,15 @@ formatting = function (hljs) {
   ];
 
   const DATATYPES = [
-    'bool',
-    'float', 
-    'int',
-    'int8',
-    'int16',
-    'int32',
-    'int64',
-    'text',
-    'timestamp'
+    "bool",
+    "float",
+    "int",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "text",
+    "timestamp",
   ];
 
   const TRANSFORMS = [
@@ -72,7 +72,7 @@ formatting = function (hljs) {
         begin: "#!",
         end: "$",
         subLanguage: "markdown",
-        relevance: 0
+        relevance: 0,
       },
       hljs.COMMENT("#", "$"),
       {
@@ -105,7 +105,8 @@ formatting = function (hljs) {
         // interval
         scope: "string",
         // Add more as needed
-        match: /\d+(years|months|weeks|days|hours|minutes|seconds|milliseconds|microseconds)/,
+        match:
+          /\d+(years|months|weeks|days|hours|minutes|seconds|milliseconds|microseconds)/,
         relevance: 10,
       },
       {
@@ -120,7 +121,7 @@ formatting = function (hljs) {
             begin: 'r"',
             end: '"',
           },
-        ]
+        ],
       },
       {
         // interpolation strings: s-strings are variables and f-strings are
@@ -212,7 +213,7 @@ formatting = function (hljs) {
             scope: "char.escape",
             match: /\\([bfnrt]|u\d{4})/,
           },
-         ]
+        ],
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {

--- a/web/website/themes/prql-theme/static/plugins/highlight/prql.js
+++ b/web/website/themes/prql-theme/static/plugins/highlight/prql.js
@@ -60,7 +60,7 @@ formatting = function (hljs) {
   const CHAR_ESCAPE = {
     scope: "char.escape",
     match: /\\\\|\\([bfnrt]|u\d{4})/,
-  }
+  };
 
   return {
     name: "PRQL",
@@ -214,7 +214,7 @@ formatting = function (hljs) {
             end: "'",
           },
         ],
-        contains: [ CHAR_ESCAPE ],
+        contains: [CHAR_ESCAPE],
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {

--- a/web/website/themes/prql-theme/static/plugins/highlight/prql.js
+++ b/web/website/themes/prql-theme/static/plugins/highlight/prql.js
@@ -1,3 +1,10 @@
+/*
+Language: PRQL
+Description: PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.
+Category: common, database
+Website: https://prql-lang.org/
+*/
+
 // !!keep consistent with
 // https://github.com/PRQL/prql/blob/main/reference/highlight-prql.js
 //
@@ -8,6 +15,30 @@
 // Possibly we can even import parts at runtime, simplifying this file?
 
 formatting = function (hljs) {
+  const BUILTIN_FUNCTIONS = [
+    "any",
+    "average",
+    "concat_array",
+    "count",
+    "every",
+    "max",
+    "min",
+    "stddev",
+    "sum",
+  ];
+
+  const DATATYPES = [
+    'bool',
+    'float', 
+    'int',
+    'int8',
+    'int16',
+    'int32',
+    'int64',
+    'text',
+    'timestamp'
+  ];
+
   const TRANSFORMS = [
     "aggregate",
     "append",
@@ -23,16 +54,26 @@ formatting = function (hljs) {
     "union",
     "window",
   ];
-  const BUILTIN_FUNCTIONS = ["case", "in", "as"];
-  const KEYWORDS = ["let", "prql", "into"];
+
+  const KEYWORDS = ["let", "prql", "into", "case", "in", "as", "module"];
+
   return {
     name: "PRQL",
     case_insensitive: true,
     keywords: {
+      built_in: BUILTIN_FUNCTIONS,
       keyword: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS],
-      literal: "false true null ",
+      literal: "false true null",
+      type: DATATYPES,
     },
     contains: [
+      {
+        // docblock
+        begin: "#!",
+        end: "$",
+        subLanguage: "markdown",
+        relevance: 0
+      },
       hljs.COMMENT("#", "$"),
       {
         // named arg
@@ -40,6 +81,11 @@ formatting = function (hljs) {
         begin: /\w+\s*:/,
         end: "",
         relevance: 10,
+      },
+      {
+        // meta prql for target and version
+        scope: "meta",
+        match: /^prql/,
       },
       // This seems much too strong at the moment, so disabling. I think ideally
       // we'd have it for aliases but not assigns.
@@ -52,15 +98,29 @@ formatting = function (hljs) {
       {
         // date
         scope: "string",
-        match: /@(\d*|-|\.\d|:)+/,
+        match: /@(\d*|-|\.\d|:|T)+Z?/,
         relevance: 10,
       },
       {
         // interval
         scope: "string",
         // Add more as needed
-        match: /\d+(days|hours|minutes|seconds|milliseconds)/,
+        match: /\d+(years|months|weeks|days|hours|minutes|seconds|milliseconds|microseconds)/,
         relevance: 10,
+      },
+      {
+        scope: "string",
+        relevance: 10,
+        variants: [
+          {
+            begin: 'r"""',
+            end: '"""',
+          },
+          {
+            begin: 'r"',
+            end: '"',
+          },
+        ]
       },
       {
         // interpolation strings: s-strings are variables and f-strings are
@@ -70,11 +130,11 @@ formatting = function (hljs) {
         relevance: 10,
         variants: [
           {
-            begin: '(s)"""',
+            begin: 's"""',
             end: '"""',
           },
           {
-            begin: '(s)"',
+            begin: 's"',
             end: '"',
           },
         ],
@@ -95,11 +155,11 @@ formatting = function (hljs) {
         relevance: 10,
         variants: [
           {
-            begin: '(f)"""',
+            begin: 'f"""',
             end: '"""',
           },
           {
-            begin: '(f)"',
+            begin: 'f"',
             end: '"',
           },
         ],
@@ -147,12 +207,17 @@ formatting = function (hljs) {
             end: "'",
           },
         ],
+        contains: [
+          {
+            scope: "char.escape",
+            match: /\\([bfnrt]|u\d{4})/,
+          },
+         ]
       },
       { scope: "punctuation", match: /[\[\]{}(),]/ },
       {
         scope: "operator",
-        match:
-          /(>)|(<)|(==)|(\+)|(\-)|(\/)|(\*)|(!=)|(->)|(=>)|(<=)|(>=)|(&&)|(\|\|)/,
+        match: /==|~=|\+|\-|\/|\*|!=|->|=>|<=|>=|&&|\|\||<|>/,
         relevance: 10,
       },
       {


### PR DESCRIPTION
This fixes the broken regex which caused some operators to be added as two separate tokens.

Adds a comment header to align with upstream highlight.js files.

Highlight built-in functions and data types.

Adds support for `Z` suffix in dates.

Adds the years, months and microseconds time units.

Adds support for the `~=` regex operator.

Marks `prql` (for version and target) as meta.

Adds support for for `r"strings"`.

Adds support for escape sequences such as `\n`.

Adds `#!` as a new docblock token with Markdown as sublanguage.