### PR TITLE
chore(highlightjs): Add metadata

### DIFF
--- a/web/book/highlight-prql.js
+++ b/web/book/highlight-prql.js
@@ -2,6 +2,7 @@
 Language: PRQL
 Description: PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.
 Category: common, database
+Requires: markdown.js
 Website: https://prql-lang.org/
 */
 

--- a/web/website/themes/prql-theme/static/plugins/highlight/prql.js
+++ b/web/website/themes/prql-theme/static/plugins/highlight/prql.js
@@ -2,6 +2,7 @@
 Language: PRQL
 Description: PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.
 Category: common, database
+Requires: markdown.js
 Website: https://prql-lang.org/
 */
 


### PR DESCRIPTION
This adds the `requires` field to the metadata since we depend on Markdown for our docblocks, i.e. the `#!` comments.

https://highlightjs.readthedocs.io/en/latest/language-contribution.html?highlight=requires#add-language-metadata