### PR TITLE
docs: Example of hex escape sequences and long Unicode escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
 **Features**:
 
 - Add `std.prql_version` function to return PRQL version (@hulxv, #3533)
-- Add support for hex escape sequences in strings. (@vanillajonathan, #3568)
-- Add support for long Unicode escape sequences. (@vanillajonathan, #3569)
+- Add support for hex escape sequences in strings.
+  Example `"Hello \x51"`. (@vanillajonathan, #3568)
+- Add support for long Unicode escape sequences.
+  Example `"Hello \U0001F422"`. (@vanillajonathan, #3569)
 
 **Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@
 **Features**:
 
 - Add `std.prql_version` function to return PRQL version (@hulxv, #3533)
-- Add support for hex escape sequences in strings.
-  Example `"Hello \x51"`. (@vanillajonathan, #3568)
-- Add support for long Unicode escape sequences.
-  Example `"Hello \U0001F422"`. (@vanillajonathan, #3569)
+- Add support for hex escape sequences in strings. Example `"Hello \x51"`.
+  (@vanillajonathan, #3568)
+- Add support for long Unicode escape sequences. Example `"Hello \U0001F422"`.
+  (@vanillajonathan, #3569)
 
 **Fixes**:
 

--- a/web/book/src/reference/syntax/strings.md
+++ b/web/book/src/reference/syntax/strings.md
@@ -33,6 +33,8 @@ Strings can contain any escape character sequences defined by the
 from artists
 derive escapes = "\tXYZ\n \\ "                  # tab (\t), "XYZ", newline (\n), " ", \, " "
 derive world = "\u0048\u0065\u006C\u006C\u006F" # "Hello"
+derive hex = "\x48\x65\x6C\x6C\x6F"             # "Hello"
+derive turtle = "\U0001F422"                    # "🐢"
 ```
 
 ## Other string formats

--- a/web/book/src/reference/syntax/strings.md
+++ b/web/book/src/reference/syntax/strings.md
@@ -29,7 +29,9 @@ select {
 Strings can contain any escape character sequences defined by the
 [JSON standard](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
 
-```prql
+<!-- TODO: https://github.com/PRQL/prql/pull/3571 for why we currently need `no-fmt` here -->
+
+```prql no-fmt
 from artists
 derive escapes = "\tXYZ\n \\ "                  # tab (\t), "XYZ", newline (\n), " ", \, " "
 derive world = "\u0048\u0065\u006C\u006C\u006F" # "Hello"

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__strings__quoting-and-escape-characters__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__strings__quoting-and-escape-characters__1.snap
@@ -1,12 +1,14 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from artists\nderive escapes = \"\\tXYZ\\n \\\\ \"                  # tab (\\t), \"XYZ\", newline (\\n), \" \", \\, \" \"\nderive world = \"\\u0048\\u0065\\u006C\\u006C\\u006F\" # \"Hello\"\n"
+expression: "from artists\nderive escapes = \"\\tXYZ\\n \\\\ \"                  # tab (\\t), \"XYZ\", newline (\\n), \" \", \\, \" \"\nderive world = \"\\u0048\\u0065\\u006C\\u006C\\u006F\" # \"Hello\"\nderive hex = \"\\x48\\x65\\x6C\\x6C\\x6F\"             # \"Hello\"\nderive turtle = \"\\U0001F422\"                    # \"🐢\"\n"
 ---
 SELECT
   *,
   '	XYZ
  \ ' AS escapes,
-  'Hello' AS world
+  'Hello' AS world,
+  'Hello' AS hex,
+  '🐢' AS turtle
 FROM
   artists
 


### PR DESCRIPTION
This adds an escape sequence example to the change log as requested in #3569.