### PR TITLE
ci: Revert some of #3551

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.run_number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -5,7 +5,8 @@ on:
     types: [opened, edited, synchronize, labeled, closed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.run_number }}
+  # Generally we use `github.ref`, but in pull_request_target, that's always `main`.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.run_number }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
I'm not sure what I was thinking with some of the changes in #3551 -- clearly if we only discriminate by `run_number`, we're not going to cancel an earlier run when a later run gets pushed to the same branch / ref.

We saw this this morning when dependabot added labels -- the earlier runs didn't get canceled, and we had a long queue.
