### PR TITLE
ci: Bump cache version

### DIFF
--- a/.github/set_version.sh
+++ b/.github/set_version.sh
@@ -5,5 +5,4 @@
 # ref https://github.com/PRQL/prql/pull/2407
 
 version=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[] | select(.name == "prql-compiler") | .version')
-# Setting `2` on 2023-09-07 because of bloated cache can revert on next version
-echo "version=${version}.2" >>"$GITHUB_ENV"
+echo "version=${version}" >>"$GITHUB_ENV"


### PR DESCRIPTION
It's bloated again, so we can just remove the existing `.2`
