### PR TITLE
revert: #3591

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.33.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa511b2e298cd49b1856746f6bb73e17036bcd66b25f5e92cdcdbec9bd75686"
+checksum = "a3e02c584f4595792d09509a94cdb92a3cef7592b1eb2d9877ee6f527062d0ea"
 dependencies = [
  "console",
  "globset",

--- a/bindings/prql-python/Cargo.toml
+++ b/bindings/prql-python/Cargo.toml
@@ -20,7 +20,7 @@ pyo3 = {version = "0.19.2", features = ["abi3-py37"]}
 prql-compiler = {path = "../../crates/prql-compiler", default-features = false}
 
 [dev-dependencies]
-insta = {version = "1.33", features = ["colors", "glob", "yaml"]}
+insta = {version = "1.32", features = ["colors", "glob", "yaml"]}
 
 [build-dependencies]
 pyo3-build-config = "0.19.2"

--- a/crates/prql-compiler/Cargo.toml
+++ b/crates/prql-compiler/Cargo.toml
@@ -56,7 +56,7 @@ tokio-util = {version = "0.7", optional = true, features = ["compat"]}
 
 [dev-dependencies]
 cfg-if = "1.0"
-insta = {version = "1.33", features = ["colors", "glob", "yaml"]}
+insta = {version = "1.32", features = ["colors", "glob", "yaml"]}
 similar-asserts = "1.5.0"
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]

--- a/crates/prql-parser/Cargo.toml
+++ b/crates/prql-parser/Cargo.toml
@@ -25,4 +25,4 @@ chumsky = "0.9.2"
 chumsky = {version = "0.9.2", features = ["ahash", "std"], default-features = false}
 
 [dev-dependencies]
-insta = {version = "1.33", features = ["colors", "glob", "yaml"]}
+insta = {version = "1.32", features = ["colors", "glob", "yaml"]}

--- a/crates/prqlc/Cargo.toml
+++ b/crates/prqlc/Cargo.toml
@@ -35,5 +35,5 @@ walkdir = "2.4.0"
 minijinja = {version = "=0.31.0", features = ["unstable_machinery"]}
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
-insta = {version = "1.33", features = ["colors", "glob", "yaml"]}
+insta = {version = "1.32", features = ["colors", "glob", "yaml"]}
 insta-cmd = "0.4.0"

--- a/crates/tests_misc/Cargo.toml
+++ b/crates/tests_misc/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-insta = {version = "1.33", features = ["colors", "glob", "yaml"]}
+insta = {version = "1.32", features = ["colors", "glob", "yaml"]}
 regex = "1.9.5"
 similar = {version = "2.2.1"}

--- a/web/book/Cargo.toml
+++ b/web/book/Cargo.toml
@@ -30,7 +30,7 @@ strum_macros = "0.25.2"
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
 anstream = {version = "0.3.2"}
 globset = "0.4.13"
-insta = {version = "1.33", features = ["colors", "glob"]}
+insta = {version = "1.32", features = ["colors", "glob"]}
 log = "0.4.20"
 regex = "1.9.5"
 serde_json = "1.0.107"


### PR DESCRIPTION
Reverts PRQL/prql#3591

Actually possibly duckdb wasn't to blame — maybe a confluence of insta _and_ duckdb, given both passed pre-merge? Seems unlikely. Let's confirm whether reverting causes tests to pass... 