### PR TITLE
revert: re-revert #3590

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a46441ae78c0c5915f62aa32cad9910647c19241456dd24039646dd96d494a5"
+checksum = "7fab9e93ba8ce88a37d5a30dce4b9913b75413dc1ac56cb5d72e5a840543f829"
 dependencies = [
  "ahash 0.8.3",
  "arrow-arith",
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350c5067470aeeb38dcfcc1f7e9c397098116409c9087e43ca99c231020635d9"
+checksum = "bc1d4e368e87ad9ee64f28b9577a3834ce10fe2703a26b28417d485bbbdff956"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6049e031521c4e7789b7530ea5991112c0a375430094191f3b74bdf37517c9a9"
+checksum = "d02efa7253ede102d45a4e802a129e83bcc3f49884cab795b1ac223918e4318d"
 dependencies = [
  "ahash 0.8.3",
  "arrow-buffer",
@@ -225,25 +225,26 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half 2.2.1",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83450b94b9fe018b65ba268415aaab78757636f68b7f37b6bc1f2a3888af0a0"
+checksum = "fda119225204141138cb0541c692fbfef0e875ba01bfdeaed09e9d354f9d6195"
 dependencies = [
+ "bytes",
  "half 2.2.1",
  "num",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249198411254530414805f77e88e1587b0914735ea180f906506905721f7a44a"
+checksum = "1d825d51b9968868d50bc5af92388754056796dbc62a4e25307d588a1fc84dee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -252,15 +253,16 @@ dependencies = [
  "arrow-select",
  "chrono",
  "comfy-table",
+ "half 2.2.1",
  "lexical-core",
  "num",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d48dcbed83d741d4af712af17f6d952972b8f6491b24ee2415243a7e37c6438"
+checksum = "475a4c3699c8b4095ca61cecf15da6f67841847a5f5aac983ccb9a377d02f73a"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -270,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29be2d5fadaab29e4fa6a7e527ceaa1c2cddc57dc6d86c062f7a05adcd8df71e"
+checksum = "03b87aa408ea6a6300e49eb2eba0c032c88ed9dc19e0a9948489c55efdca71f4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -285,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e0bd6ad24d56679b3317b499b0de61bca16d3142896908cce1aa943e56e981"
+checksum = "114a348ab581e7c9b6908fcab23cb39ff9f060eb19e72b13f8fb8eaa37f65d22"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",
@@ -295,24 +297,25 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half 2.2.1",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b71d8d68d0bc2e648e4e395896dc518be8b90c5f0f763c59083187c3d46184b"
+checksum = "5d1d179c117b158853e0101bfbed5615e86fe97ee356b4af901f1c5001e1ce4b"
 dependencies = [
  "bitflags 2.4.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470cb8610bdfda56554a436febd4e457e506f3c42e01e545a1ea7ecf2a4c8823"
+checksum = "d5c71e003202e67e9db139e5278c79f5520bb79922261dfe140e4637ee8b6108"
 dependencies = [
+ "ahash 0.8.3",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -322,15 +325,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "41.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f8a2e4ff9dbbd51adbabf92098b71e3eb2ef0cfcb75236ca7c3ce087cce038"
+checksum = "c4cebbb282d6b9244895f4a9a912e55e57bce112554c7fa91fcec5459cb421ab"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "arrow-select",
+ "num",
  "regex",
  "regex-syntax",
 ]
@@ -858,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.4"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
+checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -1157,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "393c174261032fbed2d1a67ae78fd3aa5e9a42687a23bb105b2a00a646a36dda"
+checksum = "d1208468f8915a274a4e80831220ad0bb685e58227a207d75a3e0a75cd6da3fb"
 dependencies = [
  "arrow",
  "cast",
@@ -1171,7 +1175,7 @@ dependencies = [
  "memchr",
  "rust_decimal",
  "smallvec",
- "strum 0.24.1",
+ "strum 0.25.0",
 ]
 
 [[package]]
@@ -2040,9 +2044,9 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libduckdb-sys"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f1e0bc90f97fb7fe64f5d1d8450f4eef8db725efcf7a29a30b7fdfd2705d81"
+checksum = "2dfd1e3a301ee4f8e93aa9d3c02003be726ee9d7b2b4b96de65b53d1693616c7"
 dependencies = [
  "autocfg",
  "cc",
@@ -2435,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -3724,9 +3728,6 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
 
 [[package]]
 name = "strum"

--- a/crates/prql-compiler/Cargo.toml
+++ b/crates/prql-compiler/Cargo.toml
@@ -45,7 +45,7 @@ serde_yaml = {version = "0.9", optional = true}
 # For integration tests. These are gated by the `test-dbs` feature, rather than
 # dev-dependencies, because dev-dependencies can't be optional.
 chrono = {version = "0.4", optional = true, features = [], default-features = false}
-duckdb = {version = "0.8.1", optional = true, features = ["bundled", "chrono"]}
+duckdb = {version = "0.9.0", optional = true, features = ["bundled", "chrono"]}
 mysql = {version = "24", optional = true}
 pg_bigdecimal = {version = "0.1", optional = true}
 postgres = {version = "0.19", optional = true}

--- a/crates/prql-compiler/tests/integration/queries/invoice_totals.prql
+++ b/crates/prql-compiler/tests/integration/queries/invoice_totals.prql
@@ -19,7 +19,7 @@ group {city} (
         derive {running_total_num_tracks = sum num_tracks}
     )
 )
-sort city
+sort {city, street}
 derive {num_tracks_last_week = lag 7 num_tracks}
 select {
     city,
@@ -30,4 +30,3 @@ select {
     num_tracks_last_week
 }
 take 20
-sort city

--- a/crates/prql-compiler/tests/integration/snapshots/integration__fmt@invoice_totals.prql.snap
+++ b/crates/prql-compiler/tests/integration/snapshots/integration__fmt@invoice_totals.prql.snap
@@ -1,7 +1,7 @@
 ---
-source: prql-compiler/tests/integration/main.rs
-expression: "# clickhouse:skip (clickhouse doesn't have lag function)\nfrom i=invoices\njoin ii=invoice_items (==invoice_id)\nderive {\n    city = i.billing_city,\n    street = i.billing_address,\n}\ngroup {city, street} (\n    derive total = ii.unit_price * ii.quantity\n    aggregate {\n        num_orders = count_distinct i.invoice_id,\n        num_tracks = sum ii.quantity,\n        total_price = sum total,\n    }\n)\ngroup {city} (\n    sort street\n    window expanding:true (\n        derive {running_total_num_tracks = sum num_tracks}\n    )\n)\nsort city\nderive {num_tracks_last_week = lag 7 num_tracks}\nselect {\n    city,\n    street,\n    num_orders,\n    num_tracks,\n    running_total_num_tracks,\n    num_tracks_last_week\n}\ntake 20\nsort city\n"
-input_file: prql-compiler/tests/integration/queries/invoice_totals.prql
+source: crates/prql-compiler/tests/integration/main.rs
+expression: "# clickhouse:skip (clickhouse doesn't have lag function)\nfrom i=invoices\njoin ii=invoice_items (==invoice_id)\nderive {\n    city = i.billing_city,\n    street = i.billing_address,\n}\ngroup {city, street} (\n    derive total = ii.unit_price * ii.quantity\n    aggregate {\n        num_orders = count_distinct i.invoice_id,\n        num_tracks = sum ii.quantity,\n        total_price = sum total,\n    }\n)\ngroup {city} (\n    sort street\n    window expanding:true (\n        derive {running_total_num_tracks = sum num_tracks}\n    )\n)\nsort {city, street}\nderive {num_tracks_last_week = lag 7 num_tracks}\nselect {\n    city,\n    street,\n    num_orders,\n    num_tracks,\n    running_total_num_tracks,\n    num_tracks_last_week\n}\ntake 20\n"
+input_file: crates/prql-compiler/tests/integration/queries/invoice_totals.prql
 ---
 from i = invoices
 join ii = invoice_items (==invoice_id)
@@ -23,7 +23,7 @@ group {city} (
     running_total_num_tracks = sum num_tracks,
   })
 )
-sort city
+sort {city, street}
 derive {num_tracks_last_week = lag 7 num_tracks}
 select {
   city,
@@ -34,5 +34,4 @@ select {
   num_tracks_last_week,
 }
 take 20
-sort city
 

--- a/crates/prql-compiler/tests/integration/snapshots/integration__sql@invoice_totals.prql.snap
+++ b/crates/prql-compiler/tests/integration/snapshots/integration__sql@invoice_totals.prql.snap
@@ -1,9 +1,9 @@
 ---
-source: prql-compiler/tests/integration/main.rs
-expression: "# clickhouse:skip (clickhouse doesn't have lag function)\nfrom i=invoices\njoin ii=invoice_items (==invoice_id)\nderive {\n    city = i.billing_city,\n    street = i.billing_address,\n}\ngroup {city, street} (\n    derive total = ii.unit_price * ii.quantity\n    aggregate {\n        num_orders = count_distinct i.invoice_id,\n        num_tracks = sum ii.quantity,\n        total_price = sum total,\n    }\n)\ngroup {city} (\n    sort street\n    window expanding:true (\n        derive {running_total_num_tracks = sum num_tracks}\n    )\n)\nsort city\nderive {num_tracks_last_week = lag 7 num_tracks}\nselect {\n    city,\n    street,\n    num_orders,\n    num_tracks,\n    running_total_num_tracks,\n    num_tracks_last_week\n}\ntake 20\nsort city\n"
-input_file: prql-compiler/tests/integration/queries/invoice_totals.prql
+source: crates/prql-compiler/tests/integration/main.rs
+expression: "# clickhouse:skip (clickhouse doesn't have lag function)\nfrom i=invoices\njoin ii=invoice_items (==invoice_id)\nderive {\n    city = i.billing_city,\n    street = i.billing_address,\n}\ngroup {city, street} (\n    derive total = ii.unit_price * ii.quantity\n    aggregate {\n        num_orders = count_distinct i.invoice_id,\n        num_tracks = sum ii.quantity,\n        total_price = sum total,\n    }\n)\ngroup {city} (\n    sort street\n    window expanding:true (\n        derive {running_total_num_tracks = sum num_tracks}\n    )\n)\nsort {city, street}\nderive {num_tracks_last_week = lag 7 num_tracks}\nselect {\n    city,\n    street,\n    num_orders,\n    num_tracks,\n    running_total_num_tracks,\n    num_tracks_last_week\n}\ntake 20\n"
+input_file: crates/prql-compiler/tests/integration/queries/invoice_totals.prql
 ---
-WITH table_1 AS (
+WITH table_0 AS (
   SELECT
     i.billing_city AS city,
     i.billing_address AS street,
@@ -15,38 +15,27 @@ WITH table_1 AS (
   GROUP BY
     i.billing_city,
     i.billing_address
-),
-table_0 AS (
-  SELECT
-    city,
-    street,
-    num_orders,
-    num_tracks,
-    SUM(num_tracks) OVER (
-      PARTITION BY city
-      ORDER BY
-        street ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    ) AS running_total_num_tracks,
-    LAG(num_tracks, 7) OVER (
-      ORDER BY
-        city
-    ) AS num_tracks_last_week
-  FROM
-    table_1
-  ORDER BY
-    city
-  LIMIT
-    20
 )
 SELECT
   city,
   street,
   num_orders,
   num_tracks,
-  running_total_num_tracks,
-  num_tracks_last_week
+  SUM(num_tracks) OVER (
+    PARTITION BY city
+    ORDER BY
+      street ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+  ) AS running_total_num_tracks,
+  LAG(num_tracks, 7) OVER (
+    ORDER BY
+      city,
+      street
+  ) AS num_tracks_last_week
 FROM
   table_0
 ORDER BY
-  city
+  city,
+  street
+LIMIT
+  20
 


### PR DESCRIPTION
This upgrades duckdb to 0.9.0, undoing the reversion in #3593.

~I _think_ the reason it failed on `main` while passing in the #3590 PR was because a snapshot is now non-deterministic. I had thought our snapshots all had `sort` transforms in. So will need to look more.~

Worth re-running the tests a couple of times if it passes initially before merging

---

Edit: the table sorting wasn't fully specified. Now it is, and we only sort once, which tests our "persistent ordering" feature too, which is nice