### PR TITLE
feat: Add chroma grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@
 - [Pygments](https://pygments.org/), the generic syntax highlighting library now
   has syntax highlighting for PRQL. (@vanillajonathan, #3564)
 - [chroma](https://github.com/alecthomas/chroma), a syntax highlighting library
-  written in Go and used by the static website generator [Hugo](https://gohugo.io/).
-  (@vanillajonathan, #3597)
+  written in Go and used by the static website generator
+  [Hugo](https://gohugo.io/). (@vanillajonathan, #3597)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,11 @@
 **Integrations**:
 
 - Bump `prqlc`'s MSRV to 1.70.0 (@eitsupi, #3521)
-- [Pygments](https://pygments.org/), the generic syntax highlighter library now
+- [Pygments](https://pygments.org/), the generic syntax highlighting library now
   has syntax highlighting for PRQL. (@vanillajonathan, #3564)
+- [chroma](https://github.com/alecthomas/chroma), a syntax highlighting library
+  written in Go and used by the static website generator [Hugo](https://gohugo.io/).
+  (@vanillajonathan, #3597)
 
 **Internal changes**:
 

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -11,7 +11,9 @@ an index.
   ([prql_highlight_rules.js](https://github.com/ajaxorg/ace/blob/master/src/mode/prql_highlight_rules.js)).
   See the [demo](https://prql-lang.org/demos/ace-demo).
 
-- [chroma](https://github.com/alecthomas/chroma) — Go library used by the static website generator Hugo. The grammar is upstream ([prql.xml](https://github.com/alecthomas/chroma/blob/master/lexers/embedded/prql.xml)).
+- [chroma](https://github.com/alecthomas/chroma) — Go library used by the static
+  website generator Hugo. The grammar is upstream
+  ([prql.xml](https://github.com/alecthomas/chroma/blob/master/lexers/embedded/prql.xml)).
   See the [demo](https://swapoff.org/chroma/playground/).
 
 - [Lezer](https://lezer.codemirror.net/) — used by CodeMirror editors. The PRQL

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -11,6 +11,9 @@ an index.
   ([prql_highlight_rules.js](https://github.com/ajaxorg/ace/blob/master/src/mode/prql_highlight_rules.js)).
   See the [demo](https://prql-lang.org/demos/ace-demo).
 
+- [chroma](https://github.com/alecthomas/chroma) — Go library used by the static website generator Hugo. The grammar is upstream ([prql.xml](https://github.com/alecthomas/chroma/blob/master/lexers/embedded/prql.xml)).
+  See the [demo](https://swapoff.org/chroma/playground/).
+
 - [Lezer](https://lezer.codemirror.net/) — used by CodeMirror editors. The PRQL
   file is at
   [`grammars/prql-lezer/README.md`](https://github.com/PRQL/prql/tree/main/grammars/prql-lezer/README.md).


### PR DESCRIPTION
[chroma](https://github.com/alecthomas/chroma) is a syntax highlighting library written in Go and used by the static website generator [Hugo](https://gohugo.io/) and other software.