### PR TITLE
feat!: `std.sql.read_csv` is compiled to `read_csv` in SQL by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 **Features**:
 
+- _Breaking_: The `std.sql.read_csv` function is now compiled to `read_csv`
+  by default. Please set the target `sql.duckdb` to use the DuckDB's `read_csv_auto` function as previously. (@eitsupi, #3599)
 - Add `std.prql_version` function to return PRQL version (@hulxv, #3533)
 - Add support for hex escape sequences in strings. Example `"Hello \x51"`.
   (@vanillajonathan, #3568)
@@ -229,7 +231,7 @@ A small selection of the changes:
 - New arithmetic operators. These compile to different function or operator
   depending on the target.
 
-  - _Breaking:_ Operator `/` now always performs floating division (@aljazerzen,
+  - _Breaking_: Operator `/` now always performs floating division (@aljazerzen,
     #2684). _TODO: add link to division operator docs_
 
   - Truncated integer division operator `//` (@aljazerzen, #2684).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 
 **Features**:
 
-- _Breaking_: The `std.sql.read_csv` function is now compiled to `read_csv`
-  by default. Please set the target `sql.duckdb` to use the DuckDB's `read_csv_auto` function as previously. (@eitsupi, #3599)
+- _Breaking_: The `std.sql.read_csv` function is now compiled to `read_csv` by
+  default. Please set the target `sql.duckdb` to use the DuckDB's
+  `read_csv_auto` function as previously. (@eitsupi, #3599)
 - Add `std.prql_version` function to return PRQL version (@hulxv, #3533)
 - Add support for hex escape sequences in strings. Example `"Hello \x51"`.
   (@vanillajonathan, #3568)

--- a/crates/prql-compiler/src/sql/std.sql.prql
+++ b/crates/prql-compiler/src/sql/std.sql.prql
@@ -70,7 +70,7 @@ let upper = column -> s"UPPER({column:0})"
 
 # Source-reading functions, primarily for DuckDB
 let read_parquet = source -> s"read_parquet({source:0})"
-let read_csv = source -> s"read_csv_auto({source:0})"
+let read_csv = source -> s"read_csv({source:0})"
 
 @{binding_strength=11}
 let mul = l r -> null
@@ -156,6 +156,8 @@ module duckdb {
   let div_i = l r -> s"TRUNC({l:11} / {r:11})"
 
   let regex_search = text pattern -> s"REGEXP_MATCHES({text:0}, {pattern:0})"
+
+  let read_csv = source -> s"read_csv_auto({source:0})"
 }
 
 module mssql {

--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -3477,7 +3477,7 @@ fn test_loop_2() {
       SELECT
         *
       FROM
-        read_csv_auto('employees.csv')
+        read_csv('employees.csv')
     ),
     table_0 AS (
       SELECT

--- a/web/book/src/how-do-i/read-files.md
+++ b/web/book/src/how-do-i/read-files.md
@@ -1,10 +1,12 @@
 # How do I: read files?
 
-There are a couple of functions designed for DuckDB:
+There are a couple of functions mainly designed for DuckDB:
 
 ```prql
-from (read_parquet 'artists.parquet')
-join (read_csv 'albums.csv') (==track_id)
+prql target:sql.duckdb
+
+from (read_parquet "artists.parquet")
+join (read_csv "albums.csv") (==track_id)
 ```
 
 ```admonish note
@@ -16,6 +18,14 @@ please log an issue and it's a fairly easy addition.
 We may be able to reduce the boilerplate `WITH table_x AS SELECT * FROM...` in future versions.
 ```
 
+When specifying file names directly in the `FROM` clause without using functions, which is allowed in DuckDB,
+enclose the file names in backticks ``` `` ``` as follows:
+
+```prql
+from `artists.parquet`
+```
+
 ## See also
 
+- [Target and Version](../project/target.md)
 - [How do I: create ad-hoc relations?](./relation-literals.md)

--- a/web/book/src/how-do-i/read-files.md
+++ b/web/book/src/how-do-i/read-files.md
@@ -18,8 +18,9 @@ please log an issue and it's a fairly easy addition.
 We may be able to reduce the boilerplate `WITH table_x AS SELECT * FROM...` in future versions.
 ```
 
-When specifying file names directly in the `FROM` clause without using functions, which is allowed in DuckDB,
-enclose the file names in backticks ``` `` ``` as follows:
+When specifying file names directly in the `FROM` clause without using
+functions, which is allowed in DuckDB, enclose the file names in backticks
+` `` ` as follows:
 
 ```prql
 from `artists.parquet`

--- a/web/book/tests/documentation/snapshots/documentation__book__how-do-i__read-files__how-do-i-read-files__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__how-do-i__read-files__how-do-i-read-files__1.snap
@@ -1,0 +1,9 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "from `artists.parquet`\n"
+---
+SELECT
+  *
+FROM
+  "artists.parquet"
+


### PR DESCRIPTION
Currently the PRQL's `read_csv` function compiles to `read_csv_auto`, which exists only in DuckDB, but Polars SQL has `read_csv`, and `read_csv` may be also added in DataFusion in the future (apache/arrow-datafusion#4850).

I feel it would be more appropriate for PRQL's `read_csv` to compile to `read_csv` by default and only in the DuckDB dialect to compile to `read_csv_auto`.