### PR TITLE
docs(changelog): Add gcloc and cloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,11 @@
   written in Go and used by the static website generator
   [Hugo](https://gohugo.io/). (@vanillajonathan, #3597)
 - [scc](https://github.com/boyter/scc), a source lines of code counter now has
-  support for `.prql` files.
+  support for `.prql` files. (@vanillajonathan)
+- [gcloc](https://github.com/JoaoDanielRufino/gcloc) a source lines of code
+  counter now has support for `.prql` files. (@vanillajonathan)
+- [cloc](https://github.com/AlDanial/cloc) a source lines of code counter now
+  has support for `.prql` files. (@AlDanial)
 
 **Internal changes**:
 


### PR DESCRIPTION
gloc (written in Go) and cloc (written in Perl) are two source lines of code counters that now have support for `.prql` files.