### PR TITLE
refactor: Unicode with curly braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   [Hugo](https://gohugo.io/). (@vanillajonathan, #3597)
 - [scc](https://github.com/boyter/scc), a source lines of code counter now has
   support for `.prql` files.
+- [gcloc](https://github.com/JoaoDanielRufino/gcloc) a source lines of code
+  counter now has support for `.prql` files. (@vanillajonathan)
+- [cloc](https://github.com/AlDanial/cloc) a source lines of code counter now
+  has support for `.prql` files. (@AlDanial)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Add `std.prql_version` function to return PRQL version (@hulxv, #3533)
 - Add support for hex escape sequences in strings. Example `"Hello \x51"`.
   (@vanillajonathan, #3568)
-- Add support for long Unicode escape sequences. Example `"Hello \U0001F422"`.
+- Add support for long Unicode escape sequences. Example `"Hello \u{01F422}"`.
   (@vanillajonathan, #3569)
 
 **Fixes**:
@@ -40,11 +40,7 @@
   written in Go and used by the static website generator
   [Hugo](https://gohugo.io/). (@vanillajonathan, #3597)
 - [scc](https://github.com/boyter/scc), a source lines of code counter now has
-  support for `.prql` files. (@vanillajonathan)
-- [gcloc](https://github.com/JoaoDanielRufino/gcloc) a source lines of code
-  counter now has support for `.prql` files. (@vanillajonathan)
-- [cloc](https://github.com/AlDanial/cloc) a source lines of code counter now
-  has support for `.prql` files. (@AlDanial)
+  support for `.prql` files.
 
 **Internal changes**:
 

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -347,29 +347,19 @@ fn escaped_character() -> impl Parser<char, char, Error = Cheap<char>> {
         just('n').to('\n'),
         just('r').to('\r'),
         just('t').to('\t'),
-        (just('u').ignore_then(
+        (just("u{").ignore_then(
             filter(|c: &char| c.is_ascii_hexdigit())
                 .repeated()
-                .exactly(4)
+                .at_least(1)
+                .at_most(6)
                 .collect::<String>()
                 .validate(|digits, span, emit| {
                     char::from_u32(u32::from_str_radix(&digits, 16).unwrap()).unwrap_or_else(|| {
                         emit(Cheap::expected_input_found(span, None, None));
-                        '\u{FFFD}' // unicode replacement character
+                        '\u{FFFD}' // Unicode replacement character
                     })
-                }),
-        )),
-        (just("U00").ignore_then(
-            filter(|c: &char| c.is_ascii_hexdigit())
-                .repeated()
-                .exactly(6)
-                .collect::<String>()
-                .validate(|digits, span, emit| {
-                    char::from_u32(u32::from_str_radix(&digits, 16).unwrap()).unwrap_or_else(|| {
-                        emit(Cheap::expected_input_found(span, None, None));
-                        '\u{FFFD}'
-                    })
-                }),
+                })
+                .then_ignore(just('}')),
         )),
         (just('x').ignore_then(
             filter(|c: &char| c.is_ascii_hexdigit())
@@ -525,5 +515,5 @@ fn quotes() {
     assert_snapshot!(quoted_string(true).parse(r"'\x61\x62\x63'").unwrap(), @"abc");
 
     // Unicode escape
-    assert_snapshot!(quoted_string(true).parse(r"'\U0001F422'").unwrap(), @"🐢");
+    assert_snapshot!(quoted_string(true).parse(r"'\u{01f422}'").unwrap(), @"🐢");
 }

--- a/web/book/highlight-prql.js
+++ b/web/book/highlight-prql.js
@@ -94,7 +94,7 @@ formatting = function (hljs) {
 
   const CHAR_ESCAPE = {
     scope: "char.escape",
-    match: /\\\\|\\([bfnrt]|U00[0-9A-Fa-f]{6}|u[0-9A-Fa-f]{4}|x[0-9A-Fa-f]{2})/,
+    match: /\\\\|\\([bfnrt]|u{[0-9A-Fa-f]{1,6}}|x[0-9A-Fa-f]{2})/,
   };
 
   return {

--- a/web/book/src/reference/syntax/strings.md
+++ b/web/book/src/reference/syntax/strings.md
@@ -33,10 +33,10 @@ Strings can contain any escape character sequences defined by the
 
 ```prql no-fmt
 from artists
-derive escapes = "\tXYZ\n \\ "                  # tab (\t), "XYZ", newline (\n), " ", \, " "
-derive world = "\u0048\u0065\u006C\u006C\u006F" # "Hello"
-derive hex = "\x48\x65\x6C\x6C\x6F"             # "Hello"
-derive turtle = "\U0001F422"                    # "🐢"
+derive escapes = "\tXYZ\n \\ "                            # tab (\t), "XYZ", newline (\n), " ", \, " "
+derive world = "\u{0048}\u{0065}\u{006C}\u{006C}\u{006F}" # "Hello"
+derive hex = "\x48\x65\x6C\x6C\x6F"                       # "Hello"
+derive turtle = "\u{01F422}"                              # "🐢"
 ```
 
 ## Other string formats

--- a/web/book/src/reference/syntax/strings.md
+++ b/web/book/src/reference/syntax/strings.md
@@ -29,9 +29,7 @@ select {
 Strings can contain any escape character sequences defined by the
 [JSON standard](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
 
-<!-- TODO: https://github.com/PRQL/prql/pull/3571 for why we currently need `no-fmt` here -->
-
-```prql no-fmt
+```prql
 from artists
 derive escapes = "\tXYZ\n \\ "                            # tab (\t), "XYZ", newline (\n), " ", \, " "
 derive world = "\u{0048}\u{0065}\u{006C}\u{006C}\u{006F}" # "Hello"

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__strings__quoting-and-escape-characters__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__strings__quoting-and-escape-characters__1.snap
@@ -1,6 +1,6 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from artists\nderive escapes = \"\\tXYZ\\n \\\\ \"                  # tab (\\t), \"XYZ\", newline (\\n), \" \", \\, \" \"\nderive world = \"\\u0048\\u0065\\u006C\\u006C\\u006F\" # \"Hello\"\nderive hex = \"\\x48\\x65\\x6C\\x6C\\x6F\"             # \"Hello\"\nderive turtle = \"\\U0001F422\"                    # \"🐢\"\n"
+expression: "from artists\nderive escapes = \"\\tXYZ\\n \\\\ \"                  # tab (\\t), \"XYZ\", newline (\\n), \" \", \\, \" \"\nderive world = \"\\u{0048}\\u{0065}\\u{006C}\\u{006C}\\u{006F}\" # \"Hello\"\nderive hex = \"\\x48\\x65\\x6C\\x6C\\x6F\"             # \"Hello\"\nderive turtle = \"\\u{01F422}\"                    # \"🐢\"\n"
 ---
 SELECT
   *,

--- a/web/website/themes/prql-theme/static/plugins/highlight/prql.js
+++ b/web/website/themes/prql-theme/static/plugins/highlight/prql.js
@@ -82,7 +82,7 @@ formatting = function (hljs) {
 
   const CHAR_ESCAPE = {
     scope: "char.escape",
-    match: /\\\\|\\([bfnrt]|U00[0-9A-Fa-f]{6}|u[0-9A-Fa-f]{4}|x[0-9A-Fa-f]{2})/,
+    match: /\\\\|\\([bfnrt]|u{[0-9A-Fa-f]{1,6}}|x[0-9A-Fa-f]{2})/,
   };
 
   return {


### PR DESCRIPTION
This takes off where #3571 and #3569 left off, and changes the syntax for the Unicode escape sequence to use curly braces because maybe you wanted that instead?