### PR TITLE
docs(changelog): Add gocloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,13 @@
   written in Go and used by the static website generator
   [Hugo](https://gohugo.io/). (@vanillajonathan, #3597)
 - [scc](https://github.com/boyter/scc), a source lines of code counter now has
-  support for `.prql` files.
+  support for `.prql` files. (@vanillajonathan)
 - [gcloc](https://github.com/JoaoDanielRufino/gcloc) a source lines of code
   counter now has support for `.prql` files. (@vanillajonathan)
 - [cloc](https://github.com/AlDanial/cloc) a source lines of code counter now
   has support for `.prql` files. (@AlDanial)
+- [gocloc](https://github.com/hhatto/gocloc) a source lines of code counter now
+  has support for `.prql` files. (@vanillajonathan)
 
 **Internal changes**:
 


### PR DESCRIPTION
goclock now supports `.prql` file since PR https://github.com/hhatto/gocloc/pull/76