### PR TITLE
feat(Monarch grammar): Add token postfix and data types

### DIFF
--- a/web/playground/src/workbench/prql-syntax.js
+++ b/web/playground/src/workbench/prql-syntax.js
@@ -20,9 +20,23 @@ const LITERALS = ["null", "true", "false"];
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
+  tokenPostfix: '.prql',
 
   keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
 
+  typeKeywords: [
+    'bool',
+    'int8',
+    'int16',
+    'int32',
+    'int64',
+    'int128',
+    'int',
+    'float',
+    'text',
+    'set'
+  ],
+  
   operators: [
     "-",
     "*",
@@ -57,7 +71,15 @@ const def = {
       // identifiers and keywords
       [
         /[a-z_$][\w$]*/,
-        { cases: { "@keywords": "keyword", "@default": "identifier" } },
+        {
+          cases:
+          {
+            '@typeKeywords': 'keyword.type',
+            "@keywords": "keyword",
+            '@constants': 'keyword',
+            "@default": "identifier"
+          }
+        },
       ],
 
       // whitespace

--- a/web/playground/src/workbench/prql-syntax.js
+++ b/web/playground/src/workbench/prql-syntax.js
@@ -20,23 +20,23 @@ const LITERALS = ["null", "true", "false"];
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
-  tokenPostfix: '.prql',
+  tokenPostfix: ".prql",
 
   keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
 
   typeKeywords: [
-    'bool',
-    'int8',
-    'int16',
-    'int32',
-    'int64',
-    'int128',
-    'int',
-    'float',
-    'text',
-    'set'
+    "bool",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "int128",
+    "int",
+    "float",
+    "text",
+    "set",
   ],
-  
+
   operators: [
     "-",
     "*",
@@ -72,13 +72,12 @@ const def = {
       [
         /[a-z_$][\w$]*/,
         {
-          cases:
-          {
-            '@typeKeywords': 'keyword.type',
+          cases: {
+            "@typeKeywords": "keyword.type",
             "@keywords": "keyword",
-            '@constants': 'keyword',
-            "@default": "identifier"
-          }
+            "@constants": "keyword",
+            "@default": "identifier",
+          },
         },
       ],
 


### PR DESCRIPTION
From the Monaco website:
> Optional postfix attached to all returned tokens. By default this attaches the language name so in the CSS you can refer to your specific language. For example, for the Java language, we could use `.identifier.java` to target all Java identifiers specifically in CSS.

https://microsoft.github.io/monaco-editor/monarch.html