### PR TITLE
feat: Add hexadecimal numerical notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
   (@vanillajonathan, #3568)
 - Add support for long Unicode escape sequences. Example `"Hello \u{01F422}"`.
   (@vanillajonathan, #3569)
-- Add support for hexadecimal numerical notation.
-  Example `filter status == 0xff`. (@vanillajonathan, #3654)
+- Add support for hexadecimal numerical notation. Example
+  `filter status == 0xff`. (@vanillajonathan, #3654)
 
 **Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   (@vanillajonathan, #3568)
 - Add support for long Unicode escape sequences. Example `"Hello \u{01F422}"`.
   (@vanillajonathan, #3569)
+- Add support for hexadecimal numerical notation.
+  Example `filter status == 0xff`. (@vanillajonathan, #3654)
 
 **Fixes**:
 

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -157,14 +157,18 @@ pub fn ident_part() -> impl Parser<char, String, Error = Cheap<char>> + Clone {
 }
 
 fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
-    let hex_notation = just("0x").ignore_then(
-        filter(|c: &char| c.is_ascii_hexdigit())
-            .repeated()
-            .at_least(1)
-            .at_most(12)
-            .collect::<String>()
-            .try_map(|digits, _| Ok(Literal::Integer(i64::from_str_radix(&digits, 16).unwrap()))),
-    ).labelled("number");
+    let hex_notation = just("0x")
+        .ignore_then(
+            filter(|c: &char| c.is_ascii_hexdigit())
+                .repeated()
+                .at_least(1)
+                .at_most(12)
+                .collect::<String>()
+                .try_map(|digits, _| {
+                    Ok(Literal::Integer(i64::from_str_radix(&digits, 16).unwrap()))
+                }),
+        )
+        .labelled("number");
 
     let exp = one_of("eE").chain(one_of("+-").or_not().chain::<char, _, _>(text::digits(10)));
 

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -157,6 +157,15 @@ pub fn ident_part() -> impl Parser<char, String, Error = Cheap<char>> + Clone {
 }
 
 fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
+    let hex_notation = just("0x").ignore_then(
+        filter(|c: &char| c.is_ascii_hexdigit())
+            .repeated()
+            .at_least(1)
+            .at_most(12)
+            .collect::<String>()
+            .try_map(|digits, _| Ok(Literal::Integer(i64::from_str_radix(&digits, 16).unwrap()))),
+    ).labelled("number");
+
     let exp = one_of("eE").chain(one_of("+-").or_not().chain::<char, _, _>(text::digits(10)));
 
     let integer = filter(|c: &char| c.is_ascii_digit() && *c != '0')
@@ -286,6 +295,7 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
         .map(Literal::Timestamp);
 
     choice((
+        hex_notation,
         string,
         raw_string,
         value_and_unit,

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -496,6 +496,12 @@ fn test_line_wrap() {
 }
 
 #[test]
+fn numbers() {
+    // Hexadecimal notation
+    assert_eq!(literal().parse("0xff").unwrap(), Literal::Integer(255));
+}
+
+#[test]
 fn quotes() {
     use insta::assert_snapshot;
 


### PR DESCRIPTION
This lets you use hexadecimal notation to express numbers so you can do:
```elm
from products
filter status_flag == 0xff
```