### PR TITLE
feat: Add binary numerical notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   (@vanillajonathan, #3568)
 - Add support for long Unicode escape sequences. Example `"Hello \u{01F422}"`.
   (@vanillajonathan, #3569)
+- Add support for binary numerical notation. Example
+  `filter status == 0b1111000011110000`. (@vanillajonathan, #3661)
 - Add support for hexadecimal numerical notation. Example
   `filter status == 0xff`. (@vanillajonathan, #3654)
 

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -157,7 +157,22 @@ pub fn ident_part() -> impl Parser<char, String, Error = Cheap<char>> + Clone {
 }
 
 fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
-    let hex_notation = just("0x")
+    let binary_notation = just("0b")
+        .then_ignore(just("_").or_not())
+        .ignore_then(
+            filter(|c: &char| *c == '0' || *c == '1')
+                .repeated()
+                .at_least(1)
+                .at_most(32)
+                .collect::<String>()
+                .try_map(|digits, _| {
+                    Ok(Literal::Integer(i64::from_str_radix(&digits, 2).unwrap()))
+                }),
+        )
+        .labelled("number");
+
+    let hexadecimal_notation = just("0x")
+        .then_ignore(just("_").or_not())
         .ignore_then(
             filter(|c: &char| c.is_ascii_hexdigit())
                 .repeated()
@@ -299,7 +314,8 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
         .map(Literal::Timestamp);
 
     choice((
-        hex_notation,
+        binary_notation,
+        hexadecimal_notation,
         string,
         raw_string,
         value_and_unit,
@@ -497,8 +513,13 @@ fn test_line_wrap() {
 
 #[test]
 fn numbers() {
+    // Binary notation
+    assert_eq!(literal().parse("0b1111000011110000").unwrap(), Literal::Integer(61680));
+    assert_eq!(literal().parse("0b_1111000011110000").unwrap(), Literal::Integer(61680));
+
     // Hexadecimal notation
     assert_eq!(literal().parse("0xff").unwrap(), Literal::Integer(255));
+    assert_eq!(literal().parse("0x_deadbeef").unwrap(), Literal::Integer(3735928559));
 }
 
 #[test]

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -514,12 +514,21 @@ fn test_line_wrap() {
 #[test]
 fn numbers() {
     // Binary notation
-    assert_eq!(literal().parse("0b1111000011110000").unwrap(), Literal::Integer(61680));
-    assert_eq!(literal().parse("0b_1111000011110000").unwrap(), Literal::Integer(61680));
+    assert_eq!(
+        literal().parse("0b1111000011110000").unwrap(),
+        Literal::Integer(61680)
+    );
+    assert_eq!(
+        literal().parse("0b_1111000011110000").unwrap(),
+        Literal::Integer(61680)
+    );
 
     // Hexadecimal notation
     assert_eq!(literal().parse("0xff").unwrap(), Literal::Integer(255));
-    assert_eq!(literal().parse("0x_deadbeef").unwrap(), Literal::Integer(3735928559));
+    assert_eq!(
+        literal().parse("0x_deadbeef").unwrap(),
+        Literal::Integer(3735928559)
+    );
 }
 
 #[test]

--- a/web/book/src/reference/syntax/literals.md
+++ b/web/book/src/reference/syntax/literals.md
@@ -18,8 +18,8 @@ where the number after `e` is the exponent in 10-base.
 Underscores are ignored, so they can be placed at arbitrary positions, but it is
 advised to use them as thousand separators.
 
-Integers can, alternatively, be expressed using hexadecimal, or binary
-notation using these prefixes respectively: `0x` or `0b`.
+Integers can, alternatively, be expressed using hexadecimal, or binary notation
+using these prefixes respectively: `0x` or `0b`.
 
 ```prql
 from numbers

--- a/web/book/src/reference/syntax/literals.md
+++ b/web/book/src/reference/syntax/literals.md
@@ -18,12 +18,17 @@ where the number after `e` is the exponent in 10-base.
 Underscores are ignored, so they can be placed at arbitrary positions, but it is
 advised to use them as thousand separators.
 
+Integers can, alternatively, be expressed using hexadecimal, or binary
+notation using these prefixes respectively: `0x` or `0b`.
+
 ```prql
 from numbers
 select {
     small = 1.000_000_1,
     big = 5_000_000,
     huge = 5e9,
+    binary = 0x0011,
+    hex = 0x80,
 }
 ```
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__numbers__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__numbers__0.snap
@@ -5,7 +5,9 @@ expression: "from numbers\nselect {\n    small = 1.000_000_1,\n    big = 5_000_0
 SELECT
   1.0000001 AS small,
   5000000 AS big,
-  5000000000.0 AS huge
+  5000000000.0 AS huge,
+  17 AS binary,
+  128 AS hex
 FROM
   numbers
 


### PR DESCRIPTION
This lets you use binary notation to express numbers so you can do:
```elm
from foo
filter bar == 0b1111000011110000
```