### PR TITLE
docs: add docs about `std.prql_version` and more test

### DIFF
--- a/crates/prql-compiler/src/tests/test.rs
+++ b/crates/prql-compiler/src/tests/test.rs
@@ -3417,6 +3417,21 @@ fn prql_version() {
 }
 
 #[test]
+
+fn shortest_prql_version() {
+    assert_display_snapshot!(compile(r#"[{version = prql_version}]"#).unwrap(),@r###"
+  WITH table_0 AS (
+    SELECT
+      '0.10.0' AS version
+  )
+  SELECT
+    version
+  FROM
+    table_0
+  "###);
+}
+
+#[test]
 fn test_loop() {
     assert_display_snapshot!(compile(r#"
     from [{n = 1}]

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -93,3 +93,14 @@ This has two roles, one of which is implemented:
   language to evolve without breaking existing queries, or forcing multiple
   installations of the compiler. This isn't yet implemented, but is a gating
   feature for PRQL 1.0.
+
+The version of the compiler currently in use can be called using the special
+function `std.prql_version` in PRQL.
+
+```prql
+[{version = prql_version}]
+```
+
+```admonish note
+This function `std.prql_version` may be replaced in the future by something like `prql.version`.
+```

--- a/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
@@ -1,0 +1,13 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "[{version = prql_version}]\n"
+---
+WITH table_0 AS (
+  SELECT
+    '0.10.0' AS version
+)
+SELECT
+  version
+FROM
+  table_0
+


### PR DESCRIPTION
I think the most effective use of the `prql_vesion` function is in an environment where PRQL results are returned as tables, such as ClickHouse.
In such a case, the fastest way to call this function is with a query like `[{version = prql_version}]`, so I want to add this to the book and tests.