### PR TITLE
revert: #3652

### DIFF
--- a/web/playground/src/workbench/prql-syntax.js
+++ b/web/playground/src/workbench/prql-syntax.js
@@ -20,22 +20,8 @@ const LITERALS = ["null", "true", "false"];
 const def = {
   // Set defaultToken to invalid to see what you do not tokenize yet
   // defaultToken: 'invalid',
-  tokenPostfix: ".prql",
 
   keywords: [...TRANSFORMS, ...BUILTIN_FUNCTIONS, ...KEYWORDS, ...LITERALS],
-
-  typeKeywords: [
-    "bool",
-    "int8",
-    "int16",
-    "int32",
-    "int64",
-    "int128",
-    "int",
-    "float",
-    "text",
-    "set",
-  ],
 
   operators: [
     "-",
@@ -71,14 +57,7 @@ const def = {
       // identifiers and keywords
       [
         /[a-z_$][\w$]*/,
-        {
-          cases: {
-            "@typeKeywords": "keyword.type",
-            "@keywords": "keyword",
-            "@constants": "keyword",
-            "@default": "identifier",
-          },
-        },
+        { cases: { "@keywords": "keyword", "@default": "identifier" } },
       ],
 
       // whitespace


### PR DESCRIPTION
Part of the reason the Vite playground wasn't working is actually that the Monarch grammar has a small error: `Uncaught Error: prql: the @ match target 'constants' is not defined, in rule: tokenizer.root: [a-z_$][\w$]*`

So reverting, and we can re-revert and merge when fixed

Hope that's OK @vanillajonathan 