### PR TITLE
feat: Add octal numerical notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@
   `filter status == 0b1111000011110000`. (@vanillajonathan, #3661)
 - Add support for hexadecimal numerical notation. Example
   `filter status == 0xff`. (@vanillajonathan, #3654)
-- Add support for octal numerical notation. Example
-  `filter status == 0o777`. (@vanillajonathan, #3672)
+- Add support for octal numerical notation. Example `filter status == 0o777`.
+  (@vanillajonathan, #3672)
 - New compile target `sql.glaredb` for [GlareDB](https://docs.glaredb.com/) and
   integration tests for it (However, there is a bug in the test and it is
   currently not running). (@universalmind303, @scsmithr, @eitsupi, #3669)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   `filter status == 0b1111000011110000`. (@vanillajonathan, #3661)
 - Add support for hexadecimal numerical notation. Example
   `filter status == 0xff`. (@vanillajonathan, #3654)
+- Add support for octal numerical notation. Example
+  `filter status == 0o777`. (@vanillajonathan, #3672)
 - New compile target `sql.glaredb` for [GlareDB](https://docs.glaredb.com/) and
   integration tests for it (However, there is a bug in the test and it is
   currently not running). (@universalmind303, @scsmithr, @eitsupi, #3669)

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -189,12 +189,13 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
         .then_ignore(just("_").or_not())
         .ignore_then(
             filter(|&c| ('0'..='7').contains(&c))
-            })
-            .repeated()
-            .at_least(1)
-            .at_most(12)
-            .collect::<String>()
-            .try_map(|digits, _| Ok(Literal::Integer(i64::from_str_radix(&digits, 8).unwrap()))),
+                .repeated()
+                .at_least(1)
+                .at_most(12)
+                .collect::<String>()
+                .try_map(|digits, _| {
+                    Ok(Literal::Integer(i64::from_str_radix(&digits, 8).unwrap()))
+                }),
         )
         .labelled("number");
 

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -188,15 +188,7 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
     let octal_notation = just("0o")
         .then_ignore(just("_").or_not())
         .ignore_then(
-            filter(|c: &char| {
-                *c == '0'
-                    || *c == '1'
-                    || *c == '2'
-                    || *c == '3'
-                    || *c == '4'
-                    || *c == '5'
-                    || *c == '6'
-                    || *c == '7'
+            filter(|&c| ('0'..='7').contains(&c))
             })
             .repeated()
             .at_least(1)

--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -185,6 +185,27 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
         )
         .labelled("number");
 
+    let octal_notation = just("0o")
+        .then_ignore(just("_").or_not())
+        .ignore_then(
+            filter(|c: &char| {
+                *c == '0'
+                    || *c == '1'
+                    || *c == '2'
+                    || *c == '3'
+                    || *c == '4'
+                    || *c == '5'
+                    || *c == '6'
+                    || *c == '7'
+            })
+            .repeated()
+            .at_least(1)
+            .at_most(12)
+            .collect::<String>()
+            .try_map(|digits, _| Ok(Literal::Integer(i64::from_str_radix(&digits, 8).unwrap()))),
+        )
+        .labelled("number");
+
     let exp = one_of("eE").chain(one_of("+-").or_not().chain::<char, _, _>(text::digits(10)));
 
     let integer = filter(|c: &char| c.is_ascii_digit() && *c != '0')
@@ -316,6 +337,7 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
     choice((
         binary_notation,
         hexadecimal_notation,
+        octal_notation,
         string,
         raw_string,
         value_and_unit,
@@ -529,6 +551,9 @@ fn numbers() {
         literal().parse("0x_deadbeef").unwrap(),
         Literal::Integer(3735928559)
     );
+
+    // Octal notation
+    assert_eq!(literal().parse("0o777").unwrap(), Literal::Integer(511));
 }
 
 #[test]

--- a/web/book/src/reference/syntax/literals.md
+++ b/web/book/src/reference/syntax/literals.md
@@ -18,8 +18,8 @@ where the number after `e` is the exponent in 10-base.
 Underscores are ignored, so they can be placed at arbitrary positions, but it is
 advised to use them as thousand separators.
 
-Integers can, alternatively, be expressed using hexadecimal, or binary notation
-using these prefixes respectively: `0x` or `0b`.
+Integers can, alternatively, be expressed using hexadecimal, octal or binary
+notation using these prefixes respectively: `0x`, `0o` or `0b`.
 
 ```prql
 from numbers
@@ -29,6 +29,7 @@ select {
     huge = 5e9,
     binary = 0x0011,
     hex = 0x80,
+    octal = 0o777,
 }
 ```
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__numbers__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__numbers__0.snap
@@ -1,13 +1,14 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from numbers\nselect {\n    small = 1.000_000_1,\n    big = 5_000_000,\n    huge = 5e9,\n}\n"
+expression: "from numbers\nselect {\n    small = 1.000_000_1,\n    big = 5_000_000,\n    huge = 5e9,\n    binary = 0x0011,\n    hex = 0x80,\n    octal = 0o777,\n}\n"
 ---
 SELECT
   1.0000001 AS small,
   5000000 AS big,
   5000000000.0 AS huge,
   17 AS binary,
-  128 AS hex
+  128 AS hex,
+  511 AS octal
 FROM
   numbers
 


### PR DESCRIPTION
This lets you use octal notation to express numbers so you can do:
```elm
from files
filter permissions == 0o777
```