### PR TITLE
internal: Don't parse leading unaries in numbers

### DIFF
--- a/crates/prql-parser/src/lexer.rs
+++ b/crates/prql-parser/src/lexer.rs
@@ -195,9 +195,7 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
         .chain::<char, _, _>(filter(|c: &char| c.is_ascii_digit()))
         .chain::<char, _, _>(filter(|c: &char| c.is_ascii_digit() || *c == '_').repeated());
 
-    let number = one_of("+-")
-        .or_not()
-        .chain::<char, _, _>(integer)
+    let number = integer
         .chain::<char, _, _>(frac.or_not().flatten())
         .chain::<char, _, _>(exp.or_not().flatten())
         .try_map(|chars, span| {


### PR DESCRIPTION
Should we be parsing these as part of the numbers? My guess is that we should just do it in one place, and so `-5` and `-foo` are parsed similarly.