### PR TITLE
docs(CHANGELOG): update of Quarto VS Code extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@
   has support for `.prql` files. (@AlDanial)
 - [gocloc](https://github.com/hhatto/gocloc) a source lines of code counter now
   has support for `.prql` files. (@vanillajonathan)
+- [The Quarto VS Code extension](https://marketplace.visualstudio.com/items?itemName=quarto.quarto)
+  supports editing PRQL code blocks
+  ([`prqlr`](https://prql-lang.org/book/project/bindings/r.html) is required to
+  render Quarto Markdown with PRQL code blocks). (@jjallaire)
 
 **Internal changes**:
 


### PR DESCRIPTION
See quarto-dev/quarto#300

Currently PRQL code blocks do not have syntax highlighting and there is no option completion for code blocks, but the new version should apply proper syntax highlighting (if PRQL VS Code is installed) and auto-completion of options.

We will be able to add a page on this to the documentation after the new version of the Quarto VS Code extension is released.