### PR TITLE
feat: `std.sql.read_csv` and `std.sql.read_parquet` for ClickHouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - _Breaking_: The `std.sql.read_csv` function is now compiled to `read_csv` by
   default. Please set the target `sql.duckdb` to use the DuckDB's
   `read_csv_auto` function as previously. (@eitsupi, #3599)
+- The `std.sql.read_csv` function and the `std.sql.read_parquet` function
+  supports the `sql.clickhouse` target. (@eitsupi, #1533)
 - Add `std.prql_version` function to return PRQL version (@hulxv, #3533)
 - Add support for hex escape sequences in strings. Example `"Hello \x51"`.
   (@vanillajonathan, #3568)

--- a/crates/prql-compiler/src/sql/std.sql.prql
+++ b/crates/prql-compiler/src/sql/std.sql.prql
@@ -146,6 +146,10 @@ module clickhouse {
   let div_i = l r -> s"({l} DIV {r})"
 
   let regex_search = text pattern -> s"match({text:0}, {pattern:0})"
+
+  let read_csv = source -> s"file({source:0}, 'CSV')"
+
+  let read_parquet = source -> s"file({source:0}, 'Parquet')"
 }
 
 module duckdb {

--- a/crates/prql-compiler/tests/integration/main.rs
+++ b/crates/prql-compiler/tests/integration/main.rs
@@ -338,7 +338,7 @@ fn test_rdbms() {
             .and_then(|s| s.to_str())
             .unwrap_or_default();
 
-        let mut prql = fs::read_to_string(path).unwrap();
+        let prql = fs::read_to_string(path).unwrap();
 
         let is_contains_data_root = re.is_match(&prql);
 
@@ -350,6 +350,7 @@ fn test_rdbms() {
             }
             let dialect = con.dialect;
             let options = Options::default().with_target(Sql(Some(dialect)));
+            let mut prql = prql.clone();
             if is_contains_data_root {
                 prql = re.replace_all(&prql, &con.data_file_root).to_string();
             }

--- a/crates/prql-compiler/tests/integration/queries/read_csv.prql
+++ b/crates/prql-compiler/tests/integration/queries/read_csv.prql
@@ -1,6 +1,5 @@
 # sqlite:skip
 # postgres:skip
 # mysql:skip
-# clickhouse:skip (Not implemented yet)
 from (read_csv "data_file_root/media_types.csv")
 sort media_type_id


### PR DESCRIPTION
Close #3630