### PR TITLE
feat(Lezer grammar): Highlight the equals operator

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -16,6 +16,7 @@ export const prqlHighlight = styleTags({
   ArithOp: t.arithmeticOperator,
   CompareOp: t.compareOperator,
   LogicOp: t.logicOperator,
+  Equals: t.definitionOperator,
   VariableName: t.variableName,
   "( )": t.paren,
   "[ ]": t.squareBracket,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -141,6 +141,8 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
 
   interpolatedString<prefix> { prefix ( stringInterpolatedDouble | stringInterpolatedSingle ) }
 
+  "="[@name=Equals]
+
   FString { interpolatedString<'f'> }
   RString { interpolatedString<'r'> }
   SString { interpolatedString<'s'> }

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -29,7 +29,7 @@ let foo = (1)
 
 ==>
 
-Query(Statements(VariableDeclaration(VariableName,NestedPipeline(Pipeline(Integer)))))
+Query(Statements(VariableDeclaration(VariableName,Equals,NestedPipeline(Pipeline(Integer)))))
 
 # Function declaration
 
@@ -37,7 +37,7 @@ let my_func = arg1 -> arg1
 
 ==>
 
-Query(Statements(VariableDeclaration(VariableName,Lambda(LambdaParam,Identifier))))
+Query(Statements(VariableDeclaration(VariableName,Equals,Lambda(LambdaParam,Identifier))))
 
 # Function declaration with two args
 
@@ -45,7 +45,7 @@ let my_func = arg1 arg2 -> arg1 + arg2
 
 ==>
 
-Query(Statements(VariableDeclaration(VariableName,Lambda(LambdaParam,LambdaParam,BinaryExpression(Identifier,ArithOp,Identifier)))))
+Query(Statements(VariableDeclaration(VariableName,Equals,Lambda(LambdaParam,LambdaParam,BinaryExpression(Identifier,ArithOp,Identifier)))))
 
 # Simple pipeline
 
@@ -64,4 +64,4 @@ derive {
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,TupleExpression(AssignCall(Float),AssignCall(BinaryExpression(Identifier,ArithOp,Identifier))))))))
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier))))))))

--- a/grammars/prql-lezer/test/tuples.txt
+++ b/grammars/prql-lezer/test/tuples.txt
@@ -40,7 +40,7 @@ Query(Statements(PipelineStatement(Pipeline(TupleExpression(Identifier,Identifie
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TupleExpression(AssignCall(Identifier))))))
+Query(Statements(PipelineStatement(Pipeline(TupleExpression(AssignCall(Equals,Identifier))))))
 
 # Tuple with keys and values
 
@@ -50,4 +50,4 @@ string    =    "string"
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TupleExpression(AssignCall(Identifier),AssignCall(Integer),AssignCall(Float),AssignCall(String))))))
+Query(Statements(PipelineStatement(Pipeline(TupleExpression(AssignCall(Equals,Identifier),AssignCall(Equals,Integer),AssignCall(Equals,Float),AssignCall(Equals,String))))))


### PR DESCRIPTION
This exposes a token named `Equals` for the equals operator `=`, we then map the `Equals` token to the Lezer highlighting tag [`definitionOperator`](https://lezer.codemirror.net/docs/ref/#highlight.tags.definitionOperator).