### PR TITLE
feat(Lezer grammar): Add Boolean token

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -6,6 +6,7 @@ export const prqlHighlight = styleTags({
   in: t.operatorKeyword,
   Comment: t.lineComment,
   Docblock: t.docString,
+  Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,
   String: t.string,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -69,10 +69,13 @@ expression[@isGroup=Expression] {
   DateTime |
   RangeExpression |
   Identifier |
+  boolean |
   number |
   String | FString | RString | SString |
   TimeUnit
 }
+
+boolean { @specialize[@name=Boolean]<identPart, "true" | "false"> }
 
 ArrayExpression { "[" commaSep<test | "*" expression>? "]" }
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -6,7 +6,7 @@ true
 
 Query(Statements(PipelineStatement(Pipeline(Boolean))))
 
-# Boolan: false
+# Boolean: false
 
 false
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -1,3 +1,19 @@
+# Boolean: true
+
+true
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(Boolean))))
+
+# Boolan: false
+
+false
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(Boolean))))
+
 # Range: 10..20
 
 10..20


### PR DESCRIPTION
This exposes a token named `Boolean` for `true` and `false`, we then map the `Boolean` token to the Lezer highlighting tag [`bool`](https://lezer.codemirror.net/docs/ref/#highlight.tags.bool).