### PR TITLE
feat(Lezer grammar): Highlight null, this and that

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -6,6 +6,8 @@ export const prqlHighlight = styleTags({
   in: t.operatorKeyword,
   Comment: t.lineComment,
   Docblock: t.docString,
+  "this that": t.self,
+	null: t.null,
   Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,

--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -7,7 +7,7 @@ export const prqlHighlight = styleTags({
   Comment: t.lineComment,
   Docblock: t.docString,
   "this that": t.self,
-	null: t.null,
+  null: t.null,
   Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -62,6 +62,8 @@ binaryTest[@name="BinaryExpression"] {
 unaryTest[@name="UnaryExpression"] { kw<"!"> testInner }
 
 expression[@isGroup=Expression] {
+  kw<"this"> | kw<"that"> |
+  kw<"null"> |
   BinaryExpression |
   ArrayExpression |
   TupleExpression |
@@ -91,7 +93,7 @@ VariableName { identPart }
 
 number { Integer | Float }
 
-kw<term> { @specialize[@name={term}]<identifier, term> }
+kw<term> { @specialize[@name={term}]<identPart, term> }
 
 VariableDeclaration { @specialize<identPart, "let"> VariableName "=" (NestedPipeline (newline+ | end) | Lambda) }
 
@@ -110,14 +112,16 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   TimeUnit { @digit+ ("years" | "months" | "weeks" | "days" | "hours" | "minutes" | "seconds" | "milliseconds" | "microseconds") }
   identifierChar { @asciiLetter | $[_\u{a1}-\u{10ffff}] }
   identPart { identifierChar (identifierChar | "_" | @digit )* }
-  identifier { identPart }
   Integer { @digit ( @digit | "_" )* ("e" Integer)? }
   Float { @digit ( @digit | "_" )* "." @digit ( @digit | "_" )* ("e" Integer)? }
   // TODO: This is not as precise as PRQL, which doesn't allow trailing
   // underscores and allows no digit before the decimal point.
   space { " "+ }
+
   Docblock { "#!" ![\n]* }
   Comment { "#" ![\n]* }
+  @precedence { Docblock, Comment }
+
   //op_bin_only { "*" | "/" | "//" | "%" | "!=" | ">=" | "<=" | "~=" | ">" | "<" | "??" | "&&" | "||" }
   //op_unary { "-" | "+" | "==" }
   end { @eof }
@@ -153,7 +157,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   // We need to give precedence to `Op_bin` so we don't get `x+y` as `x` & `+y`.
   // R, S & F strings have precedence over idents beginning with r / s / f (we could
   // use specialize but I think means we need to redefine `String` for each)
-  @precedence { RangeExpression, FString, RString, SString, Float, TimeUnit, Integer, identPart, identifier, Docblock, Comment }
+  @precedence { RangeExpression, FString, RString, SString, Float, TimeUnit, Integer, identPart }
 }
 
 @external propSource prqlHighlight from "./highlight"

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -14,6 +14,30 @@ false
 
 Query(Statements(PipelineStatement(Pipeline(Boolean))))
 
+# Null
+
+null
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(null))))
+
+# Keyword: this
+
+this
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(this))))
+
+# Keyword: that
+
+that
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(that))))
+
 # Range: 10..20
 
 10..20

--- a/web/prql-codemirror-demo/src/lang-prql/complete.ts
+++ b/web/prql-codemirror-demo/src/lang-prql/complete.ts
@@ -9,9 +9,9 @@ const dontComplete = [
   "Comment",
   "Docblock",
   "String",
-  "FormatString",
-  "RawString",
-  "ServerString",
+  "FString",
+  "RString",
+  "SString",
 ];
 
 const globals: readonly Completion[] = ["false", "null", "true"]


### PR DESCRIPTION
This exposes `null`, `this` and `that` as keywords which we map to the Lezer highlighting tag [`null`](https://lezer.codemirror.net/docs/ref/#highlight.tags.null) and [`self`](https://lezer.codemirror.net/docs/ref/#highlight.tags.self) respectively.

This `@precedence` block has been split. Parse tree tests have been added for `null`, `this` and `that`.