### PR TITLE
revert: check github links

### DIFF
--- a/.config/.markdown-link-check-local.json
+++ b/.config/.markdown-link-check-local.json
@@ -4,7 +4,7 @@
       "_comment_1": "Our pipeline should only depend on our assets.",
       "_comment_2": "If some third-party website breaks a link, we cover that in ./.markdown-link-check-all.json",
       "_comment_3": "So this excludes anything that's not a relative link to a file in our repo or a link to our file on the web.",
-      "pattern": "^(?!https://prql-lang\\.org|https://raw\\.githubusercontent\\.com/(PRQL|prql)|[./]+|file://).*$"
+      "pattern": "^(?!https://github\\.com/(PRQL|prql)|https://prql-lang\\.org|https://raw\\.githubusercontent\\.com/(PRQL|prql)|[./]+|file://).*$"
     }
   ]
 }

--- a/web/book/src/project/bindings/dotnet.md
+++ b/web/book/src/project/bindings/dotnet.md
@@ -1,1 +1,1 @@
-{{#include ../../../../../prqlc/bindings/prql-dotnet/README.md}}
+{{#include ../../../../../prqlc/bindings/dotnet/README.md}}


### PR DESCRIPTION
Followup for #3683

Because I've moved a bunch of files, links to github.com repo main branch were broken.
So I've disabled the check, merged and now they should work again.
