### PR TITLE
feat(Lezer grammar): Highlight `let`

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -95,7 +95,7 @@ number { Integer | Float }
 
 kw<term> { @specialize[@name={term}]<identPart, term> }
 
-VariableDeclaration { @specialize<identPart, "let"> VariableName "=" (NestedPipeline (newline+ | end) | Lambda) }
+VariableDeclaration { kw<"let"> VariableName "=" (NestedPipeline (newline+ | end) | Lambda) }
 
 Lambda { LambdaParam* "->" exprCall ( newline+ | end ) }
 TypeDefinition { "<" TypeTerm ( "|" TypeTerm)* ">" }

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -69,7 +69,7 @@ let foo = (1)
 
 ==>
 
-Query(Statements(VariableDeclaration(VariableName,Equals,NestedPipeline(Pipeline(Integer)))))
+Query(Statements(VariableDeclaration(let,VariableName,Equals,NestedPipeline(Pipeline(Integer)))))
 
 # Function declaration
 
@@ -77,7 +77,7 @@ let my_func = arg1 -> arg1
 
 ==>
 
-Query(Statements(VariableDeclaration(VariableName,Equals,Lambda(LambdaParam,Identifier))))
+Query(Statements(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,Identifier))))
 
 # Function declaration with two args
 
@@ -85,7 +85,7 @@ let my_func = arg1 arg2 -> arg1 + arg2
 
 ==>
 
-Query(Statements(VariableDeclaration(VariableName,Equals,Lambda(LambdaParam,LambdaParam,BinaryExpression(Identifier,ArithOp,Identifier)))))
+Query(Statements(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,LambdaParam,BinaryExpression(Identifier,ArithOp,Identifier)))))
 
 # Simple pipeline
 


### PR DESCRIPTION
This exposes `let` as a keyword which we map to the Lezer highlighting tag [`definitionKeyword`](https://lezer.codemirror.net/docs/ref/#highlight.tags.definitionKeyword).