### PR TITLE
internal: Update playground's package-lock

### DIFF
--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -29,6 +29,7 @@
       }
     },
     "../../prqlc/bindings/js": {
+      "name": "prql-js",
       "version": "0.10.0",
       "license": "Apache-2.0",
       "devDependencies": {


### PR DESCRIPTION
This seemed to be missing a field, and so changes on `task run-playground`
