### PR TITLE
devops: Move a command to `postStartCommand`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,15 @@
     }
   ],
   "postCreateCommand": {
-    "install-python-deps": "task install-maturin && task install-pre-commit && pre-commit install-hooks",
     "install-npm-dependencies": "task install-npm-dependencies"
+  },
+  // When this is in `postCreateCommand`, it can cause a permission issue with
+  // the local path; see
+  // https://github.com/PRQL/prql/issues/3709#issuecomment-1772739134. (though
+  // not every time, and difficult to debug). The disadvantage of having it
+  // `postStartCommand` is it'll run on every start, but it's quite cheap after
+  // the first run.
+  "postStartCommand": {
+    "install-python-deps": "task install-maturin && task install-pre-commit && pre-commit install-hooks"
   }
 }


### PR DESCRIPTION
- Disabling the moved `task` command solves the file system problem
- Putting it back generally, but not always, causes the problem again
- Moving it to `postStartCommand` seems to solve it too. The disadvantage is that it'll run on every start, but that's not too bad

Would close #3709
