### PR TITLE
web: Button without inline svg

### DIFF
--- a/web/website/themes/prql-theme/layouts/partials/header.html
+++ b/web/website/themes/prql-theme/layouts/partials/header.html
@@ -13,10 +13,8 @@
     </a>
 
     <nav id="navbar" class="navbar navbar-expand-lg">
-      <button class="navbar-toggler border-0 bg-white" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-controls="offcanvasNavbar" aria-label="Toggle navigation">
-        <svg viewBox="0 0 16 16" style="width: 1.5rem; height: 1.5rem">
-          <path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"></path>
-        </svg>
+      <button class="navbar-toggler border-0 bg-white p-0" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-controls="offcanvasNavbar" aria-label="Toggle navigation">
+        <i class="bx bx-dots-horizontal-rounded fs-2"></i>
       </button>
       <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
         <div class="offcanvas-header">


### PR DESCRIPTION
This is a follow up to #3710 that uses an icon from the Box Icons font instead of an inline SVG element.