### PR TITLE
feat(Lezer grammar): Add bin, oct and hex notation

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -114,7 +114,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   identPart { identifierChar (identifierChar | "_" | @digit )* }
 
   hex { @digit | $[a-fA-F] }
-  
+
   Integer {
     @digit ( @digit | "_" )* ("e" Integer)? |
     "0x" (hex | "_")+ |

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -116,7 +116,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   hex { @digit | $[a-fA-F] }
 
   Integer {
-    @digit ( @digit | "_" )* ("e" Integer)? |
+    @digit ( @digit | "_" )* ("e" ("+" | "-")? Integer)? |
     "0x" (hex | "_")+ |
     "0b" $[01_]+ |
     "0o" $[0-7_]+

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -112,7 +112,16 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   TimeUnit { @digit+ ("years" | "months" | "weeks" | "days" | "hours" | "minutes" | "seconds" | "milliseconds" | "microseconds") }
   identifierChar { @asciiLetter | $[_\u{a1}-\u{10ffff}] }
   identPart { identifierChar (identifierChar | "_" | @digit )* }
-  Integer { @digit ( @digit | "_" )* ("e" Integer)? }
+
+  hex { @digit | $[a-fA-F] }
+  
+  Integer {
+    @digit ( @digit | "_" )* ("e" Integer)? |
+    "0x" (hex | "_")+ |
+    "0b" $[01_]+ |
+    "0o" $[0-7_]+
+  }
+
   Float { @digit ( @digit | "_" )* "." @digit ( @digit | "_" )* ("e" Integer)? }
   // TODO: This is not as precise as PRQL, which doesn't allow trailing
   // underscores and allows no digit before the decimal point.
@@ -157,7 +166,8 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   // We need to give precedence to `Op_bin` so we don't get `x+y` as `x` & `+y`.
   // R, S & F strings have precedence over idents beginning with r / s / f (we could
   // use specialize but I think means we need to redefine `String` for each)
-  @precedence { RangeExpression, FString, RString, SString, Float, TimeUnit, Integer, identPart }
+  @precedence { RangeExpression, Float, TimeUnit, Integer }
+  @precedence { FString, RString, SString, identPart }
 }
 
 @external propSource prqlHighlight from "./highlight"

--- a/grammars/prql-lezer/test/numbers.txt
+++ b/grammars/prql-lezer/test/numbers.txt
@@ -45,3 +45,27 @@ Query(Statements(PipelineStatement(Pipeline(Integer))))
 ==>
 
 Query(Statements(PipelineStatement(Pipeline(TimeUnit))))
+
+# Binary notation
+
+0b1111
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(Integer))))
+
+# Hex notation
+
+0xff
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(Integer))))
+
+# Octal notation
+
+0o777
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(Integer))))


### PR DESCRIPTION
This adds support for binary, octal and hexadecimal notation along with tests.

This also allows plus and minus signs after the `e` in scientific notation.