### PR TITLE
feat(Lezer grammar): Add escape sequence

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -11,6 +11,7 @@ export const prqlHighlight = styleTags({
   Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,
+  Escape: t.escape,
   String: t.string,
   FString: t.special(t.string),
   RString: t.special(t.string),

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -124,7 +124,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   identPart { identifierChar (identifierChar | "_" | @digit )* }
 
   hex { @digit | $[a-fA-F] }
-  
+
   Integer {
     @digit ( @digit | "_" )* ("e" ("+" | "-")? Integer)? |
     "0x" (hex | "_")+ |
@@ -136,7 +136,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   // TODO: This is not as precise as PRQL, which doesn't allow trailing
   // underscores and allows no digit before the decimal point.
   space { " "+ }
-  
+
   Escape {
     "\\" ("x" hex hex | "u" "{" hex+ "}" | ![xu])
   }

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -102,6 +102,16 @@ TypeDefinition { "<" TypeTerm ( "|" TypeTerm)* ">" }
 TypeTerm { identPart TypeDefinition? }
 LambdaParam { identPart TypeDefinition? (":" expression)? }
 
+@skip {} {
+  // Couldn't manage to do these & the interpolated as a template.
+  String {
+    '"""' (stringContentDouble | Escape)* '"""' |
+    "'''" (stringContentSingle | Escape)* "'''" |
+    '"' (stringContentDouble | Escape)* '"' |
+    "'" (stringContentSingle | Escape)* "'"
+  }
+}
+
 @tokens {
   CompareOp { "==" | "!=" | "~=" | ">=" | "<=" | ">" | "<" }
   date { @digit+ "-" @digit+ "-" @digit+ }
@@ -114,7 +124,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   identPart { identifierChar (identifierChar | "_" | @digit )* }
 
   hex { @digit | $[a-fA-F] }
-
+  
   Integer {
     @digit ( @digit | "_" )* ("e" ("+" | "-")? Integer)? |
     "0x" (hex | "_")+ |
@@ -126,6 +136,14 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   // TODO: This is not as precise as PRQL, which doesn't allow trailing
   // underscores and allows no digit before the decimal point.
   space { " "+ }
+  
+  Escape {
+    "\\" ("x" hex hex | "u" "{" hex+ "}" | ![xu])
+  }
+
+  stringContentSingle { ![\\']+ }
+
+  stringContentDouble { ![\\"]+ }
 
   Docblock { "#!" ![\n]* }
   Comment { "#" ![\n]* }
@@ -137,13 +155,10 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   lineWrap { "\\" }
   wrappedLine { newline+ (Comment newline+)* lineWrap }
   newline { "\n" }
+
   // TODO: Because this can also be used to compile to BETWEEN, ranges should
   // allow any literal, and arguably any expression.
   RangeExpression { @digit+ ".." @digit+ }
-  // Couldn't manage to do these & the interpolated as a template; couldn't
-  // find how to negate a variable template
-  // Matches any character except hamburger. This is a workaround.
-  String { '"""' ![🍔]* '"""' | "'''" ![🍔]* "'''" | $["] !["]* $["] | $['] ![']* $['] }
 
   // TODO: not getting the interpolations highlighted; it just shows the whole
   // string as a string, because these are all within the `@tokens` block. But

--- a/grammars/prql-lezer/test/strings.txt
+++ b/grammars/prql-lezer/test/strings.txt
@@ -77,3 +77,11 @@ Query(Statements(PipelineStatement(Pipeline(String))))
 ==>
 
 Query(Statements(PipelineStatement(Pipeline(String))))
+
+# Escape sequence
+
+"\xff"
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(String(Escape)))))


### PR DESCRIPTION
This adds support for escape sequences though a new token called `Escape` which we map to the Lezer highlighting tag [`escape`](https://lezer.codemirror.net/docs/ref/#highlight.tags.escape). A test is included.

This also does away with the any-char-but-hamburger workaround.