### PR TITLE
feat(Lezer grammar): Add nested pipeline

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -34,7 +34,7 @@ exprCall { expression | CallExpression }
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we
 // can't seem to force a space because it's in our skip, and I can't see
 // a way of changing the skip expression to only specialize on a single item
-CallExpression { Identifier ( (NamedArg | Assign | expression))+ }
+CallExpression { Identifier (NamedArg | Assign | expression)+ }
 
 NamedArg { identPart ":" expression }
 Assign { identPart "=" expression }
@@ -67,6 +67,7 @@ expression[@isGroup=Expression] {
   BinaryExpression |
   ArrayExpression |
   TupleExpression |
+  NestedPipeline |
   CaseExpression |
   DateTime |
   RangeExpression |
@@ -138,7 +139,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   space { " "+ }
 
   Escape {
-    "\\" ("x" hex hex | "u" "{" hex+ "}" | ![xu])
+    "\\" ("x" hex hex | "u" "{" hex+ "}" | $[bfnrt])
   }
 
   stringContentSingle { ![\\']+ }

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -105,3 +105,15 @@ derive {
 ==>
 
 Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier))))))))
+
+# Nested pipeline
+
+group customer_id (
+  aggregate {
+    average total
+  }
+)
+
+==>
+
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,Identifier,NestedPipeline(Pipeline(CallExpression(Identifier,TupleExpression(CallExpression(Identifier,Identifier))))))))))


### PR DESCRIPTION
This PR adds the token `NestedPipeline` to the list of expressions in order to get the included test to pass.

It also removes a redundant set of parenthesis in the `CallExpression` token, and makes the escape sequence matching more strict.