### PR TITLE
devops: Add task to exclude some crates from tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -247,6 +247,18 @@ tasks:
         cargo build --all-targets -p {{ . }}
         {{ end -}}
 
+  test-rust-api:
+    summary: |
+      Run tests, excluding some internal crates
+    vars:
+      PACKAGES:
+        sh:
+          cargo metadata --format-version=1 | jq -r '.workspace_members[] |
+          split(" ")[0]'
+    cmds:
+      - |
+        cargo test {{ range without (splitLines .PACKAGES) "prqlc-ast" "prqlc-parser" }} -p={{ . }} {{ end }}
+
   test-all:
     desc: Test everything, accepting snapshots.
     summary: |


### PR DESCRIPTION
I said I'd write a task for doing the equivalent of https://github.com/PRQL/prql/pull/3735. 

@aljazerzen it's in the Taskfile, but the output is easily copied!