### PR TITLE
feat(Lezer grammar): Allow tabs

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -11,6 +11,7 @@ export const prqlHighlight = styleTags({
   Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,
+  TypeTerm: t.typeName,
   Escape: t.escape,
   String: t.string,
   FString: t.special(t.string),

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -136,7 +136,7 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   Float { @digit ( @digit | "_" )* "." @digit ( @digit | "_" )* ("e" Integer)? }
   // TODO: This is not as precise as PRQL, which doesn't allow trailing
   // underscores and allows no digit before the decimal point.
-  space { " "+ }
+  space { $[ \t] }
 
   Escape {
     "\\" ("x" hex hex | "u" "{" hex+ "}" | $[bfnrt])

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -87,6 +87,14 @@ let my_func = arg1 arg2 -> arg1 + arg2
 
 Query(Statements(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,LambdaParam,BinaryExpression(Identifier,ArithOp,Identifier)))))
 
+# Function declaration with type annotation
+
+let my_func = arg1<int32> -> arg1
+
+==>
+
+Query(Statements(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam(TypeDefinition(TypeTerm)),Identifier))))
+
 # Simple pipeline
 
 from foo | select bar
@@ -117,3 +125,11 @@ group customer_id (
 ==>
 
 Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,Identifier,NestedPipeline(Pipeline(CallExpression(Identifier,TupleExpression(CallExpression(Identifier,Identifier))))))))))
+
+# Tabs as spaces
+
+let		foo		=		(1)
+
+==>
+
+Query(Statements(VariableDeclaration(let,VariableName,Equals,NestedPipeline(Pipeline(Integer)))))


### PR DESCRIPTION
This allows the use tabs instead of spaces to separate stuff.

It also highlights the data type when using type annotations and adds a test for type annotations when using lambdas. This is done by mapping our `TypeTerm` token to the Lezer highlighting tag [`typeName`](https://lezer.codemirror.net/docs/ref/#highlight.tags.typeName).