### PR TITLE
feat(Lezer grammar): Highlight functions

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -1,6 +1,7 @@
 import { styleTags, tags as t } from "@lezer/highlight";
 
 export const prqlHighlight = styleTags({
+  "CallExpression/Identifier": t.function(t.variableName),
   let: t.definitionKeyword,
   case: t.controlKeyword,
   in: t.operatorKeyword,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -19,13 +19,13 @@ Statements { newline* QueryDefinition? VariableDeclaration* PipelineStatement? e
 
 QueryDefinition { @specialize<identPart, "prql"> NamedArg+ newline+ }
 
-PipelineStatement { Pipeline ( ~ambigNewline newline+ | end )}
+PipelineStatement { Pipeline (~ambigNewline newline+ | end)}
 
-Pipeline { exprCall (pipe+ exprCall)* | test }
+Pipeline { exprCall (pipe exprCall)* | test }
 
 pipe { "|" | ~ambigNewline newline }
 
-TupleExpression { "{" newline* tupleItem (("," newline* ) tupleItem)* ","? newline* "}" }
+TupleExpression { "{" newline* tupleItem (("," newline*) tupleItem)* ","? newline* "}" }
 
 tupleItem { AssignCall | exprCall | CaseBranch }
 
@@ -34,7 +34,7 @@ exprCall { expression | CallExpression }
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we
 // can't seem to force a space because it's in our skip, and I can't see
 // a way of changing the skip expression to only specialize on a single item
-CallExpression { Identifier (NamedArg | Assign | expression)+ }
+CallExpression { Identifier ArgList { (NamedArg | Assign | expression)+ } }
 
 NamedArg { identPart ":" expression }
 Assign { identPart "=" expression }
@@ -89,7 +89,7 @@ BinaryExpression {
 
 // Because this is outside tokens, we can't disallow whitespace.
 // It's outside tokens because otherwise it conflicts with Identifier
-Identifier { identPart ( "." (identPart | "*"))* }
+Identifier { identPart ("." (identPart | "*"))* }
 VariableName { identPart }
 
 number { Integer | Float }
@@ -98,8 +98,8 @@ kw<term> { @specialize[@name={term}]<identPart, term> }
 
 VariableDeclaration { kw<"let"> VariableName "=" (NestedPipeline (newline+ | end) | Lambda) }
 
-Lambda { LambdaParam* "->" exprCall ( newline+ | end ) }
-TypeDefinition { "<" TypeTerm ( "|" TypeTerm)* ">" }
+Lambda { LambdaParam* "->" exprCall (newline+ | end) }
+TypeDefinition { "<" TypeTerm ("|" TypeTerm)* ">" }
 TypeTerm { identPart TypeDefinition? }
 LambdaParam { identPart TypeDefinition? (":" expression)? }
 
@@ -116,24 +116,24 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
 @tokens {
   CompareOp { "==" | "!=" | "~=" | ">=" | "<=" | ">" | "<" }
   date { @digit+ "-" @digit+ "-" @digit+ }
-  time { @digit+ ":" @digit+ ( ":" @digit+ ( "." @digit+ )? )? }
+  time { @digit+ ":" @digit+ (":" @digit+ ("." @digit+)?)? }
   // We can't seem to set the number of digits, so this will allow any
   // combination of digits & hyphens.
-  DateTime { "@" ( date | time | date "T" time ( "Z" | ( "-" | "+" ) @digit+ ":" @digit+ )? ) }
+  DateTime { "@" (date | time | date "T" time ("Z" | ("-" | "+") @digit+ ":" @digit+)?) }
   TimeUnit { @digit+ ("years" | "months" | "weeks" | "days" | "hours" | "minutes" | "seconds" | "milliseconds" | "microseconds") }
   identifierChar { @asciiLetter | $[_\u{a1}-\u{10ffff}] }
-  identPart { identifierChar (identifierChar | "_" | @digit )* }
+  identPart { identifierChar (identifierChar | "_" | @digit)* }
 
   hex { @digit | $[a-fA-F] }
 
   Integer {
-    @digit ( @digit | "_" )* ("e" ("+" | "-")? Integer)? |
+    @digit (@digit | "_")* ("e" ("+" | "-")? Integer)? |
     "0x" (hex | "_")+ |
     "0b" $[01_]+ |
     "0o" $[0-7_]+
   }
 
-  Float { @digit ( @digit | "_" )* "." @digit ( @digit | "_" )* ("e" Integer)? }
+  Float { @digit (@digit | "_")* "." @digit (@digit | "_")* ("e" Integer)? }
   // TODO: This is not as precise as PRQL, which doesn't allow trailing
   // underscores and allows no digit before the decimal point.
   space { $[ \t] }
@@ -165,13 +165,13 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   // string as a string, because these are all within the `@tokens` block. But
   // they need to be within this block, because it's not possible to have
   // negations (e.g. `![{'}` outside it.
-  stringInterpolatedSingle { $['] ( ![{'] | interpolationInnerSingle )* $['] }
-  stringInterpolatedDouble { $["] ( ![{"] | interpolationInnerDouble )* $["] }
+  stringInterpolatedSingle { $['] (![{'] | interpolationInnerSingle)* $['] }
+  stringInterpolatedDouble { $["] (![{"] | interpolationInnerDouble)* $["] }
 
   interpolationInnerSingle { "{" ![}']* "}" }
   interpolationInnerDouble { "{" ![}"]* "}" }
 
-  interpolatedString<prefix> { prefix ( stringInterpolatedDouble | stringInterpolatedSingle ) }
+  interpolatedString<prefix> { prefix (stringInterpolatedDouble | stringInterpolatedSingle) }
 
   "="[@name=Equals]
 

--- a/grammars/prql-lezer/test/identifiers.txt
+++ b/grammars/prql-lezer/test/identifiers.txt
@@ -4,7 +4,8 @@ filter foo
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,Identifier)))))
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier))))))
+
 
 # Identifier with underscore and digit
 
@@ -12,7 +13,7 @@ filter foo_123
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,Identifier)))))
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier))))))
 
 # Unicode identifier
 
@@ -20,4 +21,4 @@ filter räksmörgås
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,Identifier)))))
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier))))))

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -101,7 +101,7 @@ from foo | select bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,Identifier),CallExpression(Identifier,Identifier)))))
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(Identifier))))))
 
 # Derive
 
@@ -112,7 +112,7 @@ derive {
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier))))))))
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))))
 
 # Nested pipeline
 
@@ -124,7 +124,7 @@ group customer_id (
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,Identifier,NestedPipeline(Pipeline(CallExpression(Identifier,TupleExpression(CallExpression(Identifier,Identifier))))))))))
+Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier,NestedPipeline(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(CallExpression(Identifier,ArgList(Identifier)))))))))))))
 
 # Tabs as spaces
 


### PR DESCRIPTION
This PR introduces a token called `ArgList`. Such a token is common in upstream grammars (such as C++, JavaScript, Python, PHP and Rust). Those languages use it together with `(`, `,` and `)` which we don't have, but its nice have token to represent the semantics of arguments anyway. Upstream grammars don't have any separate token for the function names so I followed and did the same. The highlight for functions is applied by "CallExpression/Identifier" which highlights all the `Identifier` tokens within a `CallExpression`, but since we now have a `ArgList` token to group the other `Identifier` tokens just the immediate `Identifier` token gets highlighted.

This PR also changes `pipe+` to `pipe` so that one and only one pipe character (`|`) can be used. This prevents `from foo ||||| select bar`.

This PR also changes the formatting to be more similar to that of the upstream grammars.