### PR TITLE
feat: enable integration tests for GlareDB and `std.sql.read_csv` and `std.sql.read_parquet` for GlareDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 **Integrations**:
 
+- Enable integration tests for GlareDB. (@eitsupi, #3749)
+
 **Internal changes**:
 
 **New Contributors**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 **Features**:
 
+- The `std.sql.read_csv` function and the `std.sql.read_parquet` function
+  supports the `sql.glaredb` target. (@eitsupi, #3749)
+
 **Fixes**:
 
 **Documentation**:

--- a/prqlc/prql-compiler/src/sql/dialect.rs
+++ b/prqlc/prql-compiler/src/sql/dialect.rs
@@ -83,12 +83,11 @@ impl Dialect {
             | Dialect::Postgres
             | Dialect::MySql
             | Dialect::Generic
-            | Dialect::ClickHouse => SupportLevel::Supported,
-            Dialect::MsSql
             | Dialect::GlareDb
-            | Dialect::Ansi
-            | Dialect::BigQuery
-            | Dialect::Snowflake => SupportLevel::Unsupported,
+            | Dialect::ClickHouse => SupportLevel::Supported,
+            Dialect::MsSql | Dialect::Ansi | Dialect::BigQuery | Dialect::Snowflake => {
+                SupportLevel::Unsupported
+            }
         }
     }
 

--- a/prqlc/prql-compiler/src/sql/std.sql.prql
+++ b/prqlc/prql-compiler/src/sql/std.sql.prql
@@ -211,6 +211,10 @@ module glaredb {
 
   @{binding_strength=9}
   let regex_search = text pattern -> s"{text} ~ {pattern}"
+
+  let read_csv = source -> s"csv_scan({source:0})"
+
+  let read_parquet = source -> s"parquet_scan({source:0})"
 }
 
 module sqlite {

--- a/prqlc/prql-compiler/tests/integration/queries/loop.prql
+++ b/prqlc/prql-compiler/tests/integration/queries/loop.prql
@@ -1,4 +1,5 @@
 # clickhouse:skip (DB::Exception: Syntax error)
+# glaredb:skip
 from [{n = 1}]
 select n = n - 2
 loop (filter n < 4 | select n = n + 1)

--- a/prqlc/prql-compiler/tests/integration/queries/loop.prql
+++ b/prqlc/prql-compiler/tests/integration/queries/loop.prql
@@ -1,5 +1,5 @@
 # clickhouse:skip (DB::Exception: Syntax error)
-# glaredb:skip
+# glaredb:skip (DataFusion does not support recursive CTEs https://github.com/apache/arrow-datafusion/issues/462)
 from [{n = 1}]
 select n = n - 2
 loop (filter n < 4 | select n = n + 1)

--- a/prqlc/prql-compiler/tests/integration/queries/read_csv.prql
+++ b/prqlc/prql-compiler/tests/integration/queries/read_csv.prql
@@ -1,6 +1,6 @@
 # sqlite:skip
 # postgres:skip
 # mysql:skip
-# glaredb:skip (Not implimented yet)
+# glaredb:skip (Not implemented yet)
 from (read_csv "data_file_root/media_types.csv")
 sort media_type_id

--- a/prqlc/prql-compiler/tests/integration/queries/read_csv.prql
+++ b/prqlc/prql-compiler/tests/integration/queries/read_csv.prql
@@ -1,6 +1,5 @@
 # sqlite:skip
 # postgres:skip
 # mysql:skip
-# glaredb:skip (Not implemented yet)
 from (read_csv "data_file_root/media_types.csv")
 sort media_type_id

--- a/prqlc/prql-compiler/tests/integration/queries/read_csv.prql
+++ b/prqlc/prql-compiler/tests/integration/queries/read_csv.prql
@@ -1,5 +1,6 @@
 # sqlite:skip
 # postgres:skip
 # mysql:skip
+# glaredb:skip (Not implimented yet)
 from (read_csv "data_file_root/media_types.csv")
 sort media_type_id

--- a/prqlc/prql-compiler/tests/integration/queries/switch.prql
+++ b/prqlc/prql-compiler/tests/integration/queries/switch.prql
@@ -1,3 +1,4 @@
+# glaredb:skip (May be a bag of String type conversion for Postgres Client)
 # mssql:test
 from tracks
 sort milliseconds

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -34,6 +34,7 @@ on every commit, and we'll endeavor to fix bugs.
 - `sql.duckdb`
 - `sql.generic`
   {{footnote: while there's no "generic" DB to test `sql.generic` against, we still count it as supported.}}
+- `sql.glaredb`
 - `sql.mysql`
 - `sql.postgres`
 - `sql.sqlite`
@@ -46,7 +47,6 @@ minimally or not at all, and may have gaps for some features.
 We're open to contributions to improve our coverage of these, and to adding
 additional dialects.
 
-- `sql.glaredb`
 - `sql.mssql`
 - `sql.ansi`
 - `sql.bigquery`


### PR DESCRIPTION
Close #3658