### PR TITLE
refactor(Lezer grammar): Trim the tree

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -11,15 +11,15 @@
   or @left
 }
 
-@top Query { Statements }
+@top Query { statements }
 
 @skip { space | Comment | Docblock | wrappedLine }
 
-Statements { newline* QueryDefinition? VariableDeclaration* PipelineStatement? end }
+statements { newline* QueryDefinition? VariableDeclaration* pipelineStatement? end }
 
 QueryDefinition { @specialize<identPart, "prql"> NamedArg+ newline+ }
 
-PipelineStatement { Pipeline (~ambigNewline newline+ | end)}
+pipelineStatement { Pipeline (~ambigNewline newline+ | end)}
 
 Pipeline { exprCall (pipe exprCall)* | test }
 

--- a/grammars/prql-lezer/test/arithmetics.txt
+++ b/grammars/prql-lezer/test/arithmetics.txt
@@ -4,7 +4,7 @@
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Float)))))
+Query(Pipeline(BinaryExpression(Integer,ArithOp,Float)))
 
 # Minus
 
@@ -12,7 +12,7 @@ Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Flo
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))))
+Query(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))
 
 # Multiply
 
@@ -20,7 +20,7 @@ Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Int
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))))
+Query(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))
 
 # Divide
 
@@ -28,7 +28,7 @@ Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Int
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))))
+Query(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))
 
 # Multiple ops
 
@@ -36,4 +36,4 @@ Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Integer,ArithOp,Int
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(BinaryExpression(Integer,ArithOp,Integer),ArithOp,Integer)))))
+Query(Pipeline(BinaryExpression(BinaryExpression(Integer,ArithOp,Integer),ArithOp,Integer)))

--- a/grammars/prql-lezer/test/arrays.txt
+++ b/grammars/prql-lezer/test/arrays.txt
@@ -4,7 +4,7 @@
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))))
+Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
 
 # Array on multiple lines
 
@@ -16,7 +16,7 @@ Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Identifier,Identifie
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))))
+Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
 
 # Array on multiple lines with blank lines
 
@@ -32,7 +32,7 @@ Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Identifier,Identifie
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))))
+Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
 
 # Array of integers
 
@@ -40,7 +40,7 @@ Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Identifier,Identifie
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Integer,Integer,Integer)))))
+Query(Pipeline(ArrayExpression(Integer,Integer,Integer)))
 
 # Array of floats
 
@@ -48,7 +48,7 @@ Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Integer,Integer,Inte
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Float,Float,Float)))))
+Query(Pipeline(ArrayExpression(Float,Float,Float)))
 
 # Array of strings
 
@@ -56,4 +56,4 @@ Query(Statements(PipelineStatement(Pipeline(ArrayExpression(Float,Float,Float)))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(ArrayExpression(String,FString,RString,SString)))))
+Query(Pipeline(ArrayExpression(String,FString,RString,SString)))

--- a/grammars/prql-lezer/test/datetime.txt
+++ b/grammars/prql-lezer/test/datetime.txt
@@ -4,7 +4,7 @@
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(DateTime))))
+Query(Pipeline(DateTime))
 
 # Time HH:MM
 
@@ -12,7 +12,7 @@ Query(Statements(PipelineStatement(Pipeline(DateTime))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(DateTime))))
+Query(Pipeline(DateTime))
 
 # Time HH:MM:SS
 
@@ -20,7 +20,7 @@ Query(Statements(PipelineStatement(Pipeline(DateTime))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(DateTime))))
+Query(Pipeline(DateTime))
 
 # Time HH:MM:SS.xxx
 
@@ -28,7 +28,7 @@ Query(Statements(PipelineStatement(Pipeline(DateTime))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(DateTime))))
+Query(Pipeline(DateTime))
 
 # Date and time
 
@@ -36,7 +36,7 @@ Query(Statements(PipelineStatement(Pipeline(DateTime))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(DateTime))))
+Query(Pipeline(DateTime))
 
 # Date and time with timezone
 
@@ -44,7 +44,7 @@ Query(Statements(PipelineStatement(Pipeline(DateTime))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(DateTime))))
+Query(Pipeline(DateTime))
 
 # Date and time in UTC
 
@@ -52,4 +52,4 @@ Query(Statements(PipelineStatement(Pipeline(DateTime))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(DateTime))))
+Query(Pipeline(DateTime))

--- a/grammars/prql-lezer/test/identifiers.txt
+++ b/grammars/prql-lezer/test/identifiers.txt
@@ -4,7 +4,7 @@ filter foo
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier))))
 
 
 # Identifier with underscore and digit
@@ -13,7 +13,7 @@ filter foo_123
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier))))
 
 # Unicode identifier
 
@@ -21,4 +21,4 @@ filter räksmörgås
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier))))

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -4,7 +4,7 @@ true
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Boolean))))
+Query(Pipeline(Boolean))
 
 # Boolean: false
 
@@ -12,7 +12,7 @@ false
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Boolean))))
+Query(Pipeline(Boolean))
 
 # Null
 
@@ -20,7 +20,7 @@ null
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(null))))
+Query(Pipeline(null))
 
 # Keyword: this
 
@@ -28,7 +28,7 @@ this
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(this))))
+Query(Pipeline(this))
 
 # Keyword: that
 
@@ -36,7 +36,7 @@ that
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(that))))
+Query(Pipeline(that))
 
 # Range: 10..20
 
@@ -44,7 +44,7 @@ Query(Statements(PipelineStatement(Pipeline(that))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(RangeExpression))))
+Query(Pipeline(RangeExpression))
 
 # Comment
 
@@ -52,7 +52,7 @@ Query(Statements(PipelineStatement(Pipeline(RangeExpression))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))),Comment)
+Query(Pipeline(Integer),Comment)
 
 # Docblock
 
@@ -61,7 +61,7 @@ Query(Statements(PipelineStatement(Pipeline(Integer))),Comment)
 
 ==>
 
-Query(Docblock,Statements(PipelineStatement(Pipeline(Integer))))
+Query(Docblock,Pipeline(Integer))
 
 # Variable declaration
 
@@ -69,7 +69,7 @@ let foo = (1)
 
 ==>
 
-Query(Statements(VariableDeclaration(let,VariableName,Equals,NestedPipeline(Pipeline(Integer)))))
+Query(VariableDeclaration(let,VariableName,Equals,NestedPipeline(Pipeline(Integer))))
 
 # Function declaration
 
@@ -77,7 +77,7 @@ let my_func = arg1 -> arg1
 
 ==>
 
-Query(Statements(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,Identifier))))
+Query(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,Identifier)))
 
 # Function declaration with two args
 
@@ -85,7 +85,7 @@ let my_func = arg1 arg2 -> arg1 + arg2
 
 ==>
 
-Query(Statements(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,LambdaParam,BinaryExpression(Identifier,ArithOp,Identifier)))))
+Query(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,LambdaParam,BinaryExpression(Identifier,ArithOp,Identifier))))
 
 # Function declaration with type annotation
 
@@ -93,7 +93,7 @@ let my_func = arg1<int32> -> arg1
 
 ==>
 
-Query(Statements(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam(TypeDefinition(TypeTerm)),Identifier))))
+Query(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam(TypeDefinition(TypeTerm)),Identifier)))
 
 # Simple pipeline
 
@@ -101,7 +101,7 @@ from foo | select bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(Identifier))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(Identifier))))
 
 # Derive
 
@@ -112,7 +112,7 @@ derive {
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))
 
 # Nested pipeline
 
@@ -124,7 +124,7 @@ group customer_id (
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(CallExpression(Identifier,ArgList(Identifier,NestedPipeline(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(CallExpression(Identifier,ArgList(Identifier)))))))))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier,NestedPipeline(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(CallExpression(Identifier,ArgList(Identifier)))))))))))
 
 # Tabs as spaces
 
@@ -132,4 +132,4 @@ let		foo		=		(1)
 
 ==>
 
-Query(Statements(VariableDeclaration(let,VariableName,Equals,NestedPipeline(Pipeline(Integer)))))
+Query(VariableDeclaration(let,VariableName,Equals,NestedPipeline(Pipeline(Integer))))

--- a/grammars/prql-lezer/test/numbers.txt
+++ b/grammars/prql-lezer/test/numbers.txt
@@ -4,7 +4,7 @@
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))))
+Query(Pipeline(Integer))
 
 # Integer with underscore
 
@@ -12,7 +12,7 @@ Query(Statements(PipelineStatement(Pipeline(Integer))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))))
+Query(Pipeline(Integer))
 
 # Integer with underscores
 
@@ -20,7 +20,7 @@ Query(Statements(PipelineStatement(Pipeline(Integer))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))))
+Query(Pipeline(Integer))
 
 # Decimal
 
@@ -28,7 +28,7 @@ Query(Statements(PipelineStatement(Pipeline(Integer))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Float))))
+Query(Pipeline(Float))
 
 # Scientific notation
 
@@ -36,7 +36,7 @@ Query(Statements(PipelineStatement(Pipeline(Float))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))))
+Query(Pipeline(Integer))
 
 # Number with time unit
 
@@ -44,7 +44,7 @@ Query(Statements(PipelineStatement(Pipeline(Integer))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TimeUnit))))
+Query(Pipeline(TimeUnit))
 
 # Binary notation
 
@@ -52,7 +52,7 @@ Query(Statements(PipelineStatement(Pipeline(TimeUnit))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))))
+Query(Pipeline(Integer))
 
 # Hex notation
 
@@ -60,7 +60,7 @@ Query(Statements(PipelineStatement(Pipeline(Integer))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))))
+Query(Pipeline(Integer))
 
 # Octal notation
 
@@ -68,4 +68,4 @@ Query(Statements(PipelineStatement(Pipeline(Integer))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(Integer))))
+Query(Pipeline(Integer))

--- a/grammars/prql-lezer/test/operators.txt
+++ b/grammars/prql-lezer/test/operators.txt
@@ -4,7 +4,7 @@ foo == bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
 
 # != Not equals
 
@@ -12,7 +12,7 @@ foo != bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
 
 # >= Greater than
 
@@ -20,7 +20,7 @@ foo >= bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
 
 # <= Less than
 
@@ -28,7 +28,7 @@ foo <= bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
 
 # ~= Regex match
 
@@ -36,7 +36,7 @@ foo ~= bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
 
 # && And
 
@@ -44,7 +44,7 @@ foo && bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))
 
 # || Or
 
@@ -52,7 +52,7 @@ foo || bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))
 
 # ?? Coalesce
 
@@ -60,4 +60,4 @@ foo ?? bar
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))))
+Query(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))

--- a/grammars/prql-lezer/test/strings.txt
+++ b/grammars/prql-lezer/test/strings.txt
@@ -4,7 +4,7 @@
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(String))))
+Query(Pipeline(String))
 
 # Double-quoted string
 
@@ -12,7 +12,7 @@ Query(Statements(PipelineStatement(Pipeline(String))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(String))))
+Query(Pipeline(String))
 
 # Single-quoted f-string
 
@@ -20,7 +20,7 @@ f'Hello {name}!'
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(FString))))
+Query(Pipeline(FString))
 
 # Double-quoted f-string
 
@@ -28,7 +28,7 @@ f"Hello {name}!"
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(FString))))
+Query(Pipeline(FString))
 
 # Single-quoted r-string
 
@@ -36,7 +36,7 @@ r'version()'
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(RString))))
+Query(Pipeline(RString))
 
 # Double-quoted r-string
 
@@ -44,7 +44,7 @@ r"version()"
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(RString))))
+Query(Pipeline(RString))
 
 # Single-quoted s-string
 
@@ -52,7 +52,7 @@ s'version()'
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(SString))))
+Query(Pipeline(SString))
 
 # Double-quoted s-string
 
@@ -60,7 +60,7 @@ s"version()"
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(SString))))
+Query(Pipeline(SString))
 
 # Triple-quoted single-quoted string
 
@@ -68,7 +68,7 @@ Query(Statements(PipelineStatement(Pipeline(SString))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(String))))
+Query(Pipeline(String))
 
 # Triple-quoted double-quoted string
 
@@ -76,7 +76,7 @@ Query(Statements(PipelineStatement(Pipeline(String))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(String))))
+Query(Pipeline(String))
 
 # Escape sequence
 
@@ -84,4 +84,4 @@ Query(Statements(PipelineStatement(Pipeline(String))))
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(String(Escape)))))
+Query(Pipeline(String(Escape)))

--- a/grammars/prql-lezer/test/tuples.txt
+++ b/grammars/prql-lezer/test/tuples.txt
@@ -4,7 +4,7 @@
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))))
+Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
 
 # Tuple on multiple lines
 
@@ -16,7 +16,7 @@ Query(Statements(PipelineStatement(Pipeline(TupleExpression(Identifier,Identifie
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))))
+Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
 
 # Tuple on multiple lines with blank lines
 
@@ -32,7 +32,7 @@ Query(Statements(PipelineStatement(Pipeline(TupleExpression(Identifier,Identifie
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))))
+Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
 
 # Tuple with key and value
 
@@ -40,7 +40,7 @@ Query(Statements(PipelineStatement(Pipeline(TupleExpression(Identifier,Identifie
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TupleExpression(AssignCall(Equals,Identifier))))))
+Query(Pipeline(TupleExpression(AssignCall(Equals,Identifier))))
 
 # Tuple with keys and values
 
@@ -50,4 +50,4 @@ string    =    "string"
 
 ==>
 
-Query(Statements(PipelineStatement(Pipeline(TupleExpression(AssignCall(Equals,Identifier),AssignCall(Equals,Integer),AssignCall(Equals,Float),AssignCall(Equals,String))))))
+Query(Pipeline(TupleExpression(AssignCall(Equals,Identifier),AssignCall(Equals,Integer),AssignCall(Equals,Float),AssignCall(Equals,String))))


### PR DESCRIPTION
This PR trims the tree to do away with the redundant tokens `Statement` and `PipelineStatement`. We do this by just changing `Statement` to `statement` and `PipelineStatement` to `pipelineStatement` which makes them internal to the grammar and does not expose them in the tree. This is a quick and safe way to fix it for now, but if we want we could rework the grammar to do away with the internal `pipelineStatement` token altogether.

The upstream JavaScript grammar also have a internal token named `statement`.