### PR TITLE
fix(Lezer grammar): Highlight CompareOp

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -34,7 +34,7 @@ exprCall { expression | CallExpression }
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we
 // can't seem to force a space because it's in our skip, and I can't see
 // a way of changing the skip expression to only specialize on a single item
-CallExpression { Identifier ArgList { (NamedArg | Assign | expression)+ } }
+CallExpression { Identifier ArgList { (NamedArg | Assign | test)+ } }
 
 NamedArg { identPart ":" expression }
 Assign { identPart "=" expression }

--- a/grammars/prql-lezer/test/arithmetics.txt
+++ b/grammars/prql-lezer/test/arithmetics.txt
@@ -1,39 +1,39 @@
 # Plus
 
-10 + 10.5
+test 10 + 10.5
 
 ==>
 
-Query(Pipeline(BinaryExpression(Integer,ArithOp,Float)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithOp,Float)))))
 
 # Minus
 
-10 - 10
+test 10 - 10
 
 ==>
 
-Query(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithOp,Integer)))))
 
 # Multiply
 
-10 * 10
+test 10 * 10
 
 ==>
 
-Query(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithOp,Integer)))))
 
 # Divide
 
-10 / 10
+test 10 / 10
 
 ==>
 
-Query(Pipeline(BinaryExpression(Integer,ArithOp,Integer)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithOp,Integer)))))
 
 # Multiple ops
 
-10 + 10 + 10
+test 10 + 10 + 10
 
 ==>
 
-Query(Pipeline(BinaryExpression(BinaryExpression(Integer,ArithOp,Integer),ArithOp,Integer)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(BinaryExpression(Integer,ArithOp,Integer),ArithOp,Integer)))))

--- a/grammars/prql-lezer/test/arithmetics.txt
+++ b/grammars/prql-lezer/test/arithmetics.txt
@@ -1,6 +1,6 @@
 # Plus
 
-test 10 + 10.5
+filter 10 + 10.5
 
 ==>
 
@@ -8,7 +8,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithO
 
 # Minus
 
-test 10 - 10
+filter 10 - 10
 
 ==>
 
@@ -16,7 +16,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithO
 
 # Multiply
 
-test 10 * 10
+filter 10 * 10
 
 ==>
 
@@ -24,7 +24,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithO
 
 # Divide
 
-test 10 / 10
+filter 10 / 10
 
 ==>
 
@@ -32,7 +32,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Integer,ArithO
 
 # Multiple ops
 
-test 10 + 10 + 10
+filter 10 + 10 + 10
 
 ==>
 

--- a/grammars/prql-lezer/test/arrays.txt
+++ b/grammars/prql-lezer/test/arrays.txt
@@ -1,14 +1,14 @@
 # Array on one line
 
-[foo, bar, baz]
+test [foo, bar, baz]
 
 ==>
 
-Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Identifier,Identifier,Identifier)))))
 
 # Array on multiple lines
 
-[
+test [
   foo,
   bar,
   baz
@@ -16,11 +16,11 @@ Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
 
 ==>
 
-Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Identifier,Identifier,Identifier)))))
 
 # Array on multiple lines with blank lines
 
-[
+test [
 
   foo,
 
@@ -32,28 +32,28 @@ Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
 
 ==>
 
-Query(Pipeline(ArrayExpression(Identifier,Identifier,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Identifier,Identifier,Identifier)))))
 
 # Array of integers
 
-[1, 2, 3]
+test [1, 2, 3]
 
 ==>
 
-Query(Pipeline(ArrayExpression(Integer,Integer,Integer)))
+Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Integer,Integer,Integer)))))
 
 # Array of floats
 
-[1.1, 2.2, 3.3]
+test [1.1, 2.2, 3.3]
 
 ==>
 
-Query(Pipeline(ArrayExpression(Float,Float,Float)))
+Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Float,Float,Float)))))
 
 # Array of strings
 
-["string", f"format", r"raw", s"server"]
+test ["string", f"format", r"raw", s"server"]
 
 ==>
 
-Query(Pipeline(ArrayExpression(String,FString,RString,SString)))
+Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(String,FString,RString,SString)))))

--- a/grammars/prql-lezer/test/arrays.txt
+++ b/grammars/prql-lezer/test/arrays.txt
@@ -1,6 +1,6 @@
 # Array on one line
 
-test [foo, bar, baz]
+filter [foo, bar, baz]
 
 ==>
 
@@ -8,7 +8,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Identifier,Iden
 
 # Array on multiple lines
 
-test [
+filter [
   foo,
   bar,
   baz
@@ -20,7 +20,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Identifier,Iden
 
 # Array on multiple lines with blank lines
 
-test [
+filter [
 
   foo,
 
@@ -36,7 +36,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Identifier,Iden
 
 # Array of integers
 
-test [1, 2, 3]
+filter [1, 2, 3]
 
 ==>
 
@@ -44,7 +44,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Integer,Integer
 
 # Array of floats
 
-test [1.1, 2.2, 3.3]
+filter [1.1, 2.2, 3.3]
 
 ==>
 
@@ -52,7 +52,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(ArrayExpression(Float,Float,Flo
 
 # Array of strings
 
-test ["string", f"format", r"raw", s"server"]
+filter ["string", f"format", r"raw", s"server"]
 
 ==>
 

--- a/grammars/prql-lezer/test/datetime.txt
+++ b/grammars/prql-lezer/test/datetime.txt
@@ -1,6 +1,6 @@
 # Date YYYY-MM-DD
 
-test @1970-01-01
+filter @1970-01-01
 
 ==>
 
@@ -8,7 +8,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Time HH:MM
 
-test @08:30
+filter @08:30
 
 ==>
 
@@ -16,7 +16,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Time HH:MM:SS
 
-test @12:00:00
+filter @12:00:00
 
 ==>
 
@@ -24,7 +24,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Time HH:MM:SS.xxx
 
-test @12:00:00.500
+filter @12:00:00.500
 
 ==>
 
@@ -32,7 +32,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Date and time
 
-test @1970-01-01T12:00:00
+filter @1970-01-01T12:00:00
 
 ==>
 
@@ -40,7 +40,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Date and time with timezone
 
-test @1970-01-01T12:00:00+01:00
+filter @1970-01-01T12:00:00+01:00
 
 ==>
 
@@ -48,7 +48,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Date and time in UTC
 
-test @1970-01-01T12:00:00Z
+filter @1970-01-01T12:00:00Z
 
 ==>
 

--- a/grammars/prql-lezer/test/datetime.txt
+++ b/grammars/prql-lezer/test/datetime.txt
@@ -1,55 +1,55 @@
 # Date YYYY-MM-DD
 
-@1970-01-01
+test @1970-01-01
 
 ==>
 
-Query(Pipeline(DateTime))
+Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Time HH:MM
 
-@08:30
+test @08:30
 
 ==>
 
-Query(Pipeline(DateTime))
+Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Time HH:MM:SS
 
-@12:00:00
+test @12:00:00
 
 ==>
 
-Query(Pipeline(DateTime))
+Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Time HH:MM:SS.xxx
 
-@12:00:00.500
+test @12:00:00.500
 
 ==>
 
-Query(Pipeline(DateTime))
+Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Date and time
 
-@1970-01-01T12:00:00
+test @1970-01-01T12:00:00
 
 ==>
 
-Query(Pipeline(DateTime))
+Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Date and time with timezone
 
-@1970-01-01T12:00:00+01:00
+test @1970-01-01T12:00:00+01:00
 
 ==>
 
-Query(Pipeline(DateTime))
+Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))
 
 # Date and time in UTC
 
-@1970-01-01T12:00:00Z
+test @1970-01-01T12:00:00Z
 
 ==>
 
-Query(Pipeline(DateTime))
+Query(Pipeline(CallExpression(Identifier,ArgList(DateTime))))

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -1,6 +1,6 @@
 # Boolean: true
 
-test true
+filter true
 
 ==>
 
@@ -8,7 +8,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Boolean))))
 
 # Boolean: false
 
-test false
+filter false
 
 ==>
 
@@ -16,7 +16,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Boolean))))
 
 # Null
 
-test null
+filter null
 
 ==>
 
@@ -24,7 +24,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(null))))
 
 # Keyword: this
 
-test this
+filter this
 
 ==>
 
@@ -32,7 +32,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(this))))
 
 # Keyword: that
 
-test that
+filter that
 
 ==>
 
@@ -40,7 +40,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(that))))
 
 # Range: 10..20
 
-test 10..20
+filter 10..20
 
 ==>
 
@@ -48,7 +48,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(RangeExpression))))
 
 # Comment
 
-test 1 # Hello
+filter 1 # Hello
 
 ==>
 
@@ -66,7 +66,7 @@ Query(Comment,Comment)
 # Docblock
 
 #! Hello
-test 1
+filter 1
 
 ==>
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -1,67 +1,76 @@
 # Boolean: true
 
-true
+test true
 
 ==>
 
-Query(Pipeline(Boolean))
+Query(Pipeline(CallExpression(Identifier,ArgList(Boolean))))
 
 # Boolean: false
 
-false
+test false
 
 ==>
 
-Query(Pipeline(Boolean))
+Query(Pipeline(CallExpression(Identifier,ArgList(Boolean))))
 
 # Null
 
-null
+test null
 
 ==>
 
-Query(Pipeline(null))
+Query(Pipeline(CallExpression(Identifier,ArgList(null))))
 
 # Keyword: this
 
-this
+test this
 
 ==>
 
-Query(Pipeline(this))
+Query(Pipeline(CallExpression(Identifier,ArgList(this))))
 
 # Keyword: that
 
-that
+test that
 
 ==>
 
-Query(Pipeline(that))
+Query(Pipeline(CallExpression(Identifier,ArgList(that))))
 
 # Range: 10..20
 
-10..20
+test 10..20
 
 ==>
 
-Query(Pipeline(RangeExpression))
+Query(Pipeline(CallExpression(Identifier,ArgList(RangeExpression))))
 
 # Comment
 
-1 # Hello
+test 1 # Hello
 
 ==>
 
-Query(Pipeline(Integer),Comment)
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))),Comment)
+
+# Two comments
+
+# Hello
+# Bar
+
+==>
+
+Query(Comment,Comment)
 
 # Docblock
 
 #! Hello
-1
+test 1
 
 ==>
 
-Query(Docblock,Pipeline(Integer))
+Query(Docblock,Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Variable declaration
 

--- a/grammars/prql-lezer/test/numbers.txt
+++ b/grammars/prql-lezer/test/numbers.txt
@@ -1,6 +1,6 @@
 # Integer
 
-test 123
+filter 123
 
 ==>
 
@@ -8,7 +8,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Integer with underscore
 
-test 123_456
+filter 123_456
 
 ==>
 
@@ -16,7 +16,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Integer with underscores
 
-test 123_456_789
+filter 123_456_789
 
 ==>
 
@@ -24,7 +24,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Decimal
 
-test 123.45
+filter 123.45
 
 ==>
 
@@ -32,7 +32,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Float))))
 
 # Scientific notation
 
-test 123e10
+filter 123e10
 
 ==>
 
@@ -40,7 +40,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Number with time unit
 
-test 5years
+filter 5years
 
 ==>
 
@@ -48,7 +48,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(TimeUnit))))
 
 # Binary notation
 
-test 0b1111
+filter 0b1111
 
 ==>
 
@@ -56,7 +56,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Hex notation
 
-test 0xff
+filter 0xff
 
 ==>
 
@@ -64,7 +64,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Octal notation
 
-test 0o777
+filter 0o777
 
 ==>
 

--- a/grammars/prql-lezer/test/numbers.txt
+++ b/grammars/prql-lezer/test/numbers.txt
@@ -1,71 +1,71 @@
 # Integer
 
-123
+test 123
 
 ==>
 
-Query(Pipeline(Integer))
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Integer with underscore
 
-123_456
+test 123_456
 
 ==>
 
-Query(Pipeline(Integer))
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Integer with underscores
 
-123_456_789
+test 123_456_789
 
 ==>
 
-Query(Pipeline(Integer))
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Decimal
 
-123.45
+test 123.45
 
 ==>
 
-Query(Pipeline(Float))
+Query(Pipeline(CallExpression(Identifier,ArgList(Float))))
 
 # Scientific notation
 
-123e10
+test 123e10
 
 ==>
 
-Query(Pipeline(Integer))
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Number with time unit
 
-5years
+test 5years
 
 ==>
 
-Query(Pipeline(TimeUnit))
+Query(Pipeline(CallExpression(Identifier,ArgList(TimeUnit))))
 
 # Binary notation
 
-0b1111
+test 0b1111
 
 ==>
 
-Query(Pipeline(Integer))
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Hex notation
 
-0xff
+test 0xff
 
 ==>
 
-Query(Pipeline(Integer))
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))
 
 # Octal notation
 
-0o777
+test 0o777
 
 ==>
 
-Query(Pipeline(Integer))
+Query(Pipeline(CallExpression(Identifier,ArgList(Integer))))

--- a/grammars/prql-lezer/test/operators.txt
+++ b/grammars/prql-lezer/test/operators.txt
@@ -1,6 +1,6 @@
 # == Equals
 
-test foo == bar
+filter foo == bar
 
 ==>
 
@@ -8,7 +8,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,Com
 
 # != Not equals
 
-test foo != bar
+filter foo != bar
 
 ==>
 
@@ -16,7 +16,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,Com
 
 # >= Greater than
 
-test foo >= bar
+filter foo >= bar
 
 ==>
 
@@ -24,7 +24,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,Com
 
 # <= Less than
 
-test foo <= bar
+filter foo <= bar
 
 ==>
 
@@ -32,7 +32,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,Com
 
 # ~= Regex match
 
-test foo ~= bar
+filter foo ~= bar
 
 ==>
 
@@ -40,7 +40,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,Com
 
 # && And
 
-test foo && bar
+filter foo && bar
 
 ==>
 
@@ -48,7 +48,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,Log
 
 # || Or
 
-test foo || bar
+filter foo || bar
 
 ==>
 
@@ -56,7 +56,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,Log
 
 # ?? Coalesce
 
-test foo ?? bar
+filter foo ?? bar
 
 ==>
 

--- a/grammars/prql-lezer/test/operators.txt
+++ b/grammars/prql-lezer/test/operators.txt
@@ -1,63 +1,63 @@
 # == Equals
 
-foo == bar
+test foo == bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Identifier)))))
 
 # != Not equals
 
-foo != bar
+test foo != bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Identifier)))))
 
 # >= Greater than
 
-foo >= bar
+test foo >= bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Identifier)))))
 
 # <= Less than
 
-foo <= bar
+test foo <= bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Identifier)))))
 
 # ~= Regex match
 
-foo ~= bar
+test foo ~= bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,CompareOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Identifier)))))
 
 # && And
 
-foo && bar
+test foo && bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,LogicOp,Identifier)))))
 
 # || Or
 
-foo || bar
+test foo || bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,LogicOp,Identifier)))))
 
 # ?? Coalesce
 
-foo ?? bar
+test foo ?? bar
 
 ==>
 
-Query(Pipeline(BinaryExpression(Identifier,LogicOp,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,LogicOp,Identifier)))))

--- a/grammars/prql-lezer/test/strings.txt
+++ b/grammars/prql-lezer/test/strings.txt
@@ -1,87 +1,87 @@
 # Single-quoted string
 
-'Hello'
+test 'Hello'
 
 ==>
 
-Query(Pipeline(String))
+Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Double-quoted string
 
-"Hello"
+test "Hello"
 
 ==>
 
-Query(Pipeline(String))
+Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Single-quoted f-string
 
-f'Hello {name}!'
+test f'Hello {name}!'
 
 ==>
 
-Query(Pipeline(FString))
+Query(Pipeline(CallExpression(Identifier,ArgList(FString))))
 
 # Double-quoted f-string
 
-f"Hello {name}!"
+test f"Hello {name}!"
 
 ==>
 
-Query(Pipeline(FString))
+Query(Pipeline(CallExpression(Identifier,ArgList(FString))))
 
 # Single-quoted r-string
 
-r'version()'
+test r'version()'
 
 ==>
 
-Query(Pipeline(RString))
+Query(Pipeline(CallExpression(Identifier,ArgList(RString))))
 
 # Double-quoted r-string
 
-r"version()"
+test r"version()"
 
 ==>
 
-Query(Pipeline(RString))
+Query(Pipeline(CallExpression(Identifier,ArgList(RString))))
 
 # Single-quoted s-string
 
-s'version()'
+test s'version()'
 
 ==>
 
-Query(Pipeline(SString))
+Query(Pipeline(CallExpression(Identifier,ArgList(SString))))
 
 # Double-quoted s-string
 
-s"version()"
+test s"version()"
 
 ==>
 
-Query(Pipeline(SString))
+Query(Pipeline(CallExpression(Identifier,ArgList(SString))))
 
 # Triple-quoted single-quoted string
 
-'''Hello world!'''
+test '''Hello world!'''
 
 ==>
 
-Query(Pipeline(String))
+Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Triple-quoted double-quoted string
 
-"""Hello world!"""
+test """Hello world!"""
 
 ==>
 
-Query(Pipeline(String))
+Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Escape sequence
 
-"\xff"
+test "\xff"
 
 ==>
 
-Query(Pipeline(String(Escape)))
+Query(Pipeline(CallExpression(Identifier,ArgList(String(Escape)))))

--- a/grammars/prql-lezer/test/strings.txt
+++ b/grammars/prql-lezer/test/strings.txt
@@ -1,6 +1,6 @@
 # Single-quoted string
 
-test 'Hello'
+filter 'Hello'
 
 ==>
 
@@ -8,7 +8,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Double-quoted string
 
-test "Hello"
+filter "Hello"
 
 ==>
 
@@ -16,7 +16,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Single-quoted f-string
 
-test f'Hello {name}!'
+filter f'Hello {name}!'
 
 ==>
 
@@ -24,7 +24,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(FString))))
 
 # Double-quoted f-string
 
-test f"Hello {name}!"
+filter f"Hello {name}!"
 
 ==>
 
@@ -32,7 +32,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(FString))))
 
 # Single-quoted r-string
 
-test r'version()'
+filter r'version()'
 
 ==>
 
@@ -40,7 +40,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(RString))))
 
 # Double-quoted r-string
 
-test r"version()"
+filter r"version()"
 
 ==>
 
@@ -48,7 +48,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(RString))))
 
 # Single-quoted s-string
 
-test s'version()'
+filter s'version()'
 
 ==>
 
@@ -56,7 +56,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(SString))))
 
 # Double-quoted s-string
 
-test s"version()"
+filter s"version()"
 
 ==>
 
@@ -64,7 +64,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(SString))))
 
 # Triple-quoted single-quoted string
 
-test '''Hello world!'''
+filter '''Hello world!'''
 
 ==>
 
@@ -72,7 +72,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Triple-quoted double-quoted string
 
-test """Hello world!"""
+filter """Hello world!"""
 
 ==>
 
@@ -80,7 +80,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(String))))
 
 # Escape sequence
 
-test "\xff"
+filter "\xff"
 
 ==>
 

--- a/grammars/prql-lezer/test/tuples.txt
+++ b/grammars/prql-lezer/test/tuples.txt
@@ -1,14 +1,14 @@
 # Tuple on one line
 
-{foo, bar, baz}
+test {foo, bar, baz}
 
 ==>
 
-Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Identifier,Identifier,Identifier)))))
 
 # Tuple on multiple lines
 
-{
+test {
   foo,
   bar,
   baz
@@ -16,11 +16,11 @@ Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
 
 ==>
 
-Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Identifier,Identifier,Identifier)))))
 
 # Tuple on multiple lines with blank lines
 
-{
+test {
 
   foo,
 
@@ -32,22 +32,22 @@ Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
 
 ==>
 
-Query(Pipeline(TupleExpression(Identifier,Identifier,Identifier)))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Identifier,Identifier,Identifier)))))
 
 # Tuple with key and value
 
-{foo=bar}
+test {foo=bar}
 
 ==>
 
-Query(Pipeline(TupleExpression(AssignCall(Equals,Identifier))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Identifier))))))
 
 # Tuple with keys and values
 
-{identifier=identifier,int  =3, float=  3.14 ,
+test {identifier=identifier,int  =3, float=  3.14 ,
 string    =    "string"
 }
 
 ==>
 
-Query(Pipeline(TupleExpression(AssignCall(Equals,Identifier),AssignCall(Equals,Integer),AssignCall(Equals,Float),AssignCall(Equals,String))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Identifier),AssignCall(Equals,Integer),AssignCall(Equals,Float),AssignCall(Equals,String))))))


### PR DESCRIPTION
This PR changes the tests to use `CallExpression` because we don't want expressions at the root. The grammar still allows it tho, but we should fix that.

Changing the tests resulted in that the operator tests breaking which led me to change `expresssion` inside the `CallExpression` token to `test` which made the test pass, and which also made the comparison operators properly highlight in CodeMirror when used in the context of a call expression.

This PR also adds a test for two subsequent comments which is something that produced a weird tree before we got rid of the `Statement` and `PipelineStatement` tokens.