### PR TITLE
devops: Use internal volume for `target` in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,9 +31,15 @@
       "source": "devcontainer-cargo-cache-${devcontainerId}",
       "target": "/usr/local/cargo/registry",
       "type": "volume"
+    },
+    {
+      "source": "${localWorkspaceFolderBasename}-target",
+      "target": "${containerWorkspaceFolder}/target",
+      "type": "volume"
     }
   ],
   "postCreateCommand": {
+    "set-ownership": "sudo chown vscode target",
     "install-python-deps": "task install-maturin",
     // Disabling because of the issues in #3709
     // "install-python-deps": "task install-maturin && task install-pre-commit && pre-commit install-hooks",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
       "type": "volume"
     },
     {
-      "source": "${localWorkspaceFolderBasename}-target",
+      "source": "devcontainer-cargo-target-${devcontainerId}",
       "target": "${containerWorkspaceFolder}/target",
       "type": "volume"
     }


### PR DESCRIPTION
This seems to fix https://github.com/PRQL/prql/issues/3813 for me.

The volume isn't shared with the host. But it should be faster, and it's persistent across restarts.
