### PR TITLE
feat: Fix Playground tabs and error message

### DIFF
--- a/web/playground/src/output/Output.jsx
+++ b/web/playground/src/output/Output.jsx
@@ -29,10 +29,10 @@ class Output extends React.Component {
     return (
       <div className="tab">
         <div className="tab-top">
-          <Tab text="output.sql" name="sql" parent={this.props} />
-          <Tab text="output.arrow" name="arrow" parent={this.props} />
-          <Tab text="output.pl.yaml" name="pl" parent={this.props} />
-          <Tab text="output.rq.yaml" name="rq" parent={this.props} />
+          <Tab text="Compiled SQL" name="sql" parent={this.props} />
+          <Tab text="Query Results" name="arrow" parent={this.props} />
+          <Tab text="PL.yaml" name="pl" parent={this.props} />
+          <Tab text="RQ.yaml" name="rq" parent={this.props} />
 
           <div className="spacer"></div>
 

--- a/web/playground/src/output/Output.jsx
+++ b/web/playground/src/output/Output.jsx
@@ -29,8 +29,8 @@ class Output extends React.Component {
     return (
       <div className="tab">
         <div className="tab-top">
-          <Tab text="Compiled SQL" name="sql" parent={this.props} />
-          <Tab text="Query Results" name="arrow" parent={this.props} />
+          <Tab text="Compiled&nbsp;SQL" name="sql" parent={this.props} />
+          <Tab text="Query&nbsp;Results" name="arrow" parent={this.props} />
           <Tab text="PL.yaml" name="pl" parent={this.props} />
           <Tab text="RQ.yaml" name="rq" parent={this.props} />
 

--- a/web/playground/src/workbench/Workbench.css
+++ b/web/playground/src/workbench/Workbench.css
@@ -33,7 +33,7 @@
 }
 .tab-top button {
   border: 0;
-  background: transparent;
+  background: dimgrey;
   color: inherit;
   font-size: inherit;
   font-family: inherit;

--- a/web/playground/src/workbench/Workbench.css
+++ b/web/playground/src/workbench/Workbench.css
@@ -64,6 +64,7 @@
 
   max-height: 50%;
   overflow-y: auto;
+  flex-shrink: 0;
 
   font-family: monospace;
   white-space: pre-wrap;

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -86,7 +86,7 @@ class Workbench extends React.Component {
       this.monaco.editor.setModelMarkers(
         this.editor.getModel(),
         "prql",
-        monacoErrors,
+        monacoErrors
       );
       return;
     }
@@ -190,6 +190,7 @@ class Workbench extends React.Component {
           ></Output>
         </div>
 
+        {/* Display an error message relevant to the tab */}
         {this.state.prqlError && (
           <div className="error-pane">{this.state.prqlError}</div>
         )}

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -86,7 +86,7 @@ class Workbench extends React.Component {
       this.monaco.editor.setModelMarkers(
         this.editor.getModel(),
         "prql",
-        monacoErrors
+        monacoErrors,
       );
       return;
     }


### PR DESCRIPTION
Two easy fixes:

1. Rename Playground tabs as suggested in #3822 

   Tab names use `&nbsp;` to prevent the label from getting broken onto separate lines if the tab width gets narrow. Also change background color of inactive tabs to `dimgrey` to set them off from active tab.

2. Fix height of the error message depending on #3807 

   The `error-pane` \<div> was adjusting its height based on the number of lines in the right-hand pane. Long panes caused the `error-pane` to be short. I was lucky to notice the `flex-shrink` CSS property in the Inspector. It appears to default to 1, but when set to 0, seems to allow the \<div> to grow to contain the message, while growing to no more than 50% of the main pane's height.