### PR TITLE
chore(prql-php): Require PHP 8.1

### DIFF
--- a/prqlc/bindings/php/.editorconfig
+++ b/prqlc/bindings/php/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.php]
+indent_size = 4
+indent_style = space

--- a/prqlc/bindings/php/composer.json
+++ b/prqlc/bindings/php/composer.json
@@ -29,7 +29,7 @@
     "docs": "https://prql-lang.org/book/"
   },
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "ext-ffi": "*"
   },
   "require-dev": {

--- a/web/website/content/demos/ace-demo.html
+++ b/web/website/content/demos/ace-demo.html
@@ -38,7 +38,7 @@ select {
 }
 derive db_version = s"version()"</div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.31.1/ace.min.js" integrity="sha512-iUK+dRJntrD/66cOBtnhcNLxHLSX56pfDw3K3jolmy9hxfpAgHQhIvfsraWd6rJZMy2zewMoynUvYonma81Oqw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.31.2/ace.min.js" integrity="sha512-4qIbBlcJOvbOmEB50FfnviJ9jOCen2yhi4skodkbTLU/uJJdULPxlX2R9Enf1oOBleUK9KD3fGmMcnItFQdNeA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script>
     var editor = ace.edit("editor");
     editor.setTheme("ace/theme/monokai");


### PR DESCRIPTION
Bump the PHP version requirement from version 8.0 to 8.1 since we use enums.