### PR TITLE
feat: infer types of transforms

### DIFF
--- a/prqlc/prql-compiler/src/ir/decl.rs
+++ b/prqlc/prql-compiler/src/ir/decl.rs
@@ -68,7 +68,7 @@ pub enum DeclKind {
 
     TableDecl(TableDecl),
 
-    InstanceOf(Ident),
+    InstanceOf(Ident, Option<Ty>),
 
     /// A single column. Contains id of target which is either:
     /// - an input relation that is source of this column or
@@ -190,7 +190,7 @@ impl std::fmt::Display for DeclKind {
                     ty.as_ref().map(write_ty).unwrap_or_default()
                 )
             }
-            Self::InstanceOf(arg0) => write!(f, "InstanceOf: {arg0}"),
+            Self::InstanceOf(arg0, _) => write!(f, "InstanceOf: {arg0}"),
             Self::Column(arg0) => write!(f, "Column (target {arg0})"),
             Self::Infer(arg0) => write!(f, "Infer (default: {arg0})"),
             Self::Expr(arg0) => write!(f, "Expr: {}", write_pl(*arg0.clone())),

--- a/prqlc/prql-compiler/src/ir/pl/expr.rs
+++ b/prqlc/prql-compiler/src/ir/pl/expr.rs
@@ -64,8 +64,8 @@ pub struct Expr {
 pub enum ExprKind {
     Ident(Ident),
     All {
-        within: Ident,
-        except: Vec<Expr>,
+        within: Box<Expr>,
+        except: Box<Expr>,
     },
     Literal(Literal),
 

--- a/prqlc/prql-compiler/src/ir/pl/fold.rs
+++ b/prqlc/prql-compiler/src/ir/pl/fold.rs
@@ -74,8 +74,8 @@ pub fn fold_expr_kind<T: ?Sized + PlFold>(fold: &mut T, expr_kind: ExprKind) -> 
     Ok(match expr_kind {
         Ident(ident) => Ident(ident),
         All { within, except } => All {
-            within,
-            except: fold.fold_exprs(except)?,
+            within: Box::new(fold.fold_expr(*within)?),
+            except: Box::new(fold.fold_expr(*except)?),
         },
         Tuple(items) => Tuple(fold.fold_exprs(items)?),
         Array(items) => Array(fold.fold_exprs(items)?),

--- a/prqlc/prql-compiler/src/semantic/ast_expand.rs
+++ b/prqlc/prql-compiler/src/semantic/ast_expand.rs
@@ -326,7 +326,7 @@ fn restrict_expr_kind(value: pl::ExprKind) -> ExprKind {
         pl::ExprKind::Internal(v) => ExprKind::Internal(v),
 
         // TODO: these are not correct, they are producing invalid PRQL
-        pl::ExprKind::All { within, .. } => ExprKind::Ident(within),
+        pl::ExprKind::All { within, .. } => restrict_expr(*within).kind,
         pl::ExprKind::TransformCall(tc) => ExprKind::Ident(Ident::from_name(format!(
             "({} ...)",
             tc.kind.as_ref().as_ref()
@@ -459,7 +459,7 @@ fn restrict_decl(name: String, value: decl::Decl) -> Option<Stmt> {
             ty: table_decl.ty,
         }),
 
-        decl::DeclKind::InstanceOf(ident) => {
+        decl::DeclKind::InstanceOf(ident, _) => {
             new_internal_stmt(name, format!("instance_of.{ident}"))
         }
         decl::DeclKind::Column(id) => new_internal_stmt(name, format!("column.{id}")),

--- a/prqlc/prql-compiler/src/semantic/module.rs
+++ b/prqlc/prql-compiler/src/semantic/module.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use prqlc_ast::stmt::QueryDef;
-use prqlc_ast::{Span, TupleField, Ty};
+use prqlc_ast::{Literal, Span, TupleField, Ty, TyKind};
 
 use crate::ir::pl::{Annotation, Expr, Ident, Lineage, LineageColumn};
 use crate::Error;
@@ -196,14 +196,18 @@ impl Module {
         res
     }
 
-    pub(super) fn insert_frame(&mut self, frame: &Lineage, namespace: &str) {
+    pub(super) fn insert_frame(&mut self, lineage: &Lineage, namespace: &str, columnar: bool) {
         let namespace = self.names.entry(namespace.to_string()).or_default();
         let namespace = namespace.kind.as_module_mut().unwrap();
 
-        for (col_index, column) in frame.columns.iter().enumerate() {
+        let lin_ty = *ty_of_lineage(lineage).kind.into_array().unwrap();
+
+        for (col_index, column) in lineage.columns.iter().enumerate() {
             // determine input name
             let input_name = match column {
-                LineageColumn::All { input_id, .. } => frame.find_input(*input_id).map(|i| &i.name),
+                LineageColumn::All { input_id, .. } => {
+                    lineage.find_input(*input_id).map(|i| &i.name)
+                }
                 LineageColumn::Single { name, .. } => name.as_ref().and_then(|n| n.path.first()),
             };
 
@@ -215,12 +219,29 @@ impl Module {
                     None => {
                         namespace.redirects.push(Ident::from_name(input_name));
 
-                        let input = frame.find_input_by_name(input_name).unwrap();
+                        let input = lineage.find_input_by_name(input_name).unwrap();
                         let mut sub_ns = Module::default();
+
+                        let self_ty = lin_ty.clone().kind.into_tuple().unwrap();
+                        let self_ty = self_ty
+                            .into_iter()
+                            .flat_map(|x| x.into_single())
+                            .find(|(name, _)| name.as_ref() == Some(input_name))
+                            .and_then(|(_, ty)| ty)
+                            .or(Some(Ty::new(TyKind::Tuple(vec![TupleField::Wildcard(
+                                None,
+                            )]))))
+                            .map(|ty| {
+                                if columnar {
+                                    Ty::new(TyKind::Array(Box::new(ty)))
+                                } else {
+                                    ty
+                                }
+                            });
 
                         let self_decl = Decl {
                             declared_at: Some(input.id),
-                            kind: DeclKind::InstanceOf(input.table.clone()),
+                            kind: DeclKind::InstanceOf(input.table.clone(), self_ty),
                             ..Default::default()
                         };
                         sub_ns.names.insert(NS_SELF.to_string(), self_decl);
@@ -242,7 +263,7 @@ impl Module {
             // insert column decl
             match column {
                 LineageColumn::All { input_id, .. } => {
-                    let input = frame.find_input(*input_id).unwrap();
+                    let input = lineage.find_input(*input_id).unwrap();
 
                     let kind = DeclKind::Infer(Box::new(DeclKind::Column(input.id)));
                     let declared_at = Some(input.id);
@@ -270,6 +291,17 @@ impl Module {
                 _ => {}
             }
         }
+
+        // insert namespace._self with correct type
+        let lin_ty = if columnar {
+            Ty::new(TyKind::Array(Box::new(lin_ty)))
+        } else {
+            lin_ty
+        };
+        namespace.names.insert(
+            NS_SELF.to_string(),
+            Decl::from(DeclKind::InstanceOf(Ident::from_name(""), Some(lin_ty))),
+        );
     }
 
     pub(super) fn insert_frame_col(&mut self, namespace: &str, name: String, id: usize) {
@@ -464,6 +496,22 @@ impl RootModule {
     pub fn find_mains(&self) -> Vec<Ident> {
         self.module.find_by_suffix(NS_MAIN)
     }
+}
+
+pub fn ty_of_lineage(lineage: &Lineage) -> Ty {
+    Ty::relation(
+        lineage
+            .columns
+            .iter()
+            .map(|col| match col {
+                LineageColumn::All { .. } => TupleField::Wildcard(None),
+                LineageColumn::Single { name, .. } => TupleField::Single(
+                    name.as_ref().map(|i| i.name.clone()),
+                    Some(Ty::new(Literal::Null)),
+                ),
+            })
+            .collect(),
+    )
 }
 
 #[cfg(test)]

--- a/prqlc/prql-compiler/src/semantic/module.rs
+++ b/prqlc/prql-compiler/src/semantic/module.rs
@@ -196,7 +196,7 @@ impl Module {
         res
     }
 
-    pub(super) fn insert_frame(&mut self, lineage: &Lineage, namespace: &str, columnar: bool) {
+    pub(super) fn insert_frame(&mut self, lineage: &Lineage, namespace: &str) {
         let namespace = self.names.entry(namespace.to_string()).or_default();
         let namespace = namespace.kind.as_module_mut().unwrap();
 
@@ -230,14 +230,7 @@ impl Module {
                             .and_then(|(_, ty)| ty)
                             .or(Some(Ty::new(TyKind::Tuple(vec![TupleField::Wildcard(
                                 None,
-                            )]))))
-                            .map(|ty| {
-                                if columnar {
-                                    Ty::new(TyKind::Array(Box::new(ty)))
-                                } else {
-                                    ty
-                                }
-                            });
+                            )]))));
 
                         let self_decl = Decl {
                             declared_at: Some(input.id),
@@ -293,11 +286,6 @@ impl Module {
         }
 
         // insert namespace._self with correct type
-        let lin_ty = if columnar {
-            Ty::new(TyKind::Array(Box::new(lin_ty)))
-        } else {
-            lin_ty
-        };
         namespace.names.insert(
             NS_SELF.to_string(),
             Decl::from(DeclKind::InstanceOf(Ident::from_name(""), Some(lin_ty))),

--- a/prqlc/prql-compiler/src/semantic/reporting.rs
+++ b/prqlc/prql-compiler/src/semantic/reporting.rs
@@ -76,7 +76,7 @@ impl<'a> PlFold for Labeler<'a> {
                         DeclKind::Expr(_) => Color::Blue,
                         DeclKind::Ty(_) => Color::Green,
                         DeclKind::Column { .. } => Color::Yellow,
-                        DeclKind::InstanceOf(_) => Color::Yellow,
+                        DeclKind::InstanceOf(_, _) => Color::Yellow,
                         DeclKind::TableDecl { .. } => Color::Red,
                         DeclKind::Module(module) => {
                             self.label_module(module);

--- a/prqlc/prql-compiler/src/semantic/resolver/functions.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/functions.rs
@@ -424,7 +424,7 @@ fn env_of_closure(closure: Func) -> (Module, Expr) {
     (func_env, *closure.body)
 }
 
-fn expr_of_func(func: Func, span: Option<Span>) -> Expr {
+pub fn expr_of_func(func: Func, span: Option<Span>) -> Expr {
     let ty = TyFunc {
         args: func
             .params
@@ -432,7 +432,7 @@ fn expr_of_func(func: Func, span: Option<Span>) -> Expr {
             .skip(func.args.len())
             .map(|a| a.ty.clone())
             .collect(),
-        return_ty: Box::new(func.return_ty.clone()),
+        return_ty: Box::new(func.return_ty.clone().or_else(|| func.body.ty.clone())),
         name_hint: func.name_hint.clone(),
     };
 

--- a/prqlc/prql-compiler/src/semantic/resolver/functions.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/functions.rs
@@ -193,6 +193,11 @@ impl Resolver<'_> {
 
         let func_name = &closure.name_hint;
 
+        // a hack, but a temporary one (obviously)
+        let columnar = func_name
+            .as_ref()
+            .map_or(false, |x| x.name == "aggregate" || x.name == "window");
+
         let (relations, other): (Vec<_>, Vec<_>) = zip(&closure.params, to_resolve.args)
             .enumerate()
             .partition(|(_, (param, _))| {
@@ -230,9 +235,9 @@ impl Resolver<'_> {
                 if partial_application_position.is_none() {
                     let frame = arg.lineage.as_ref().unwrap();
                     if is_last {
-                        self.root_mod.module.insert_frame(frame, NS_THIS);
+                        self.root_mod.module.insert_frame(frame, NS_THIS, columnar);
                     } else {
-                        self.root_mod.module.insert_frame(frame, NS_THAT);
+                        self.root_mod.module.insert_frame(frame, NS_THAT, columnar);
                     }
                 }
 

--- a/prqlc/prql-compiler/src/semantic/resolver/functions.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/functions.rs
@@ -193,11 +193,6 @@ impl Resolver<'_> {
 
         let func_name = &closure.name_hint;
 
-        // a hack, but a temporary one (obviously)
-        let columnar = func_name
-            .as_ref()
-            .map_or(false, |x| x.name == "aggregate" || x.name == "window");
-
         let (relations, other): (Vec<_>, Vec<_>) = zip(&closure.params, to_resolve.args)
             .enumerate()
             .partition(|(_, (param, _))| {
@@ -235,9 +230,9 @@ impl Resolver<'_> {
                 if partial_application_position.is_none() {
                     let frame = arg.lineage.as_ref().unwrap();
                     if is_last {
-                        self.root_mod.module.insert_frame(frame, NS_THIS, columnar);
+                        self.root_mod.module.insert_frame(frame, NS_THIS);
                     } else {
-                        self.root_mod.module.insert_frame(frame, NS_THAT, columnar);
+                        self.root_mod.module.insert_frame(frame, NS_THAT);
                     }
                 }
 

--- a/prqlc/prql-compiler/src/semantic/resolver/names.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/names.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use itertools::Itertools;
 
+use prqlc_ast::Literal;
 use prqlc_ast::expr::Ident;
 
 use crate::ir::decl::{Decl, DeclKind, Module};
@@ -161,7 +162,7 @@ impl Resolver<'_> {
 
         // infer table columns
         if let Some(decl) = module.names.get(NS_SELF).cloned() {
-            if let DeclKind::InstanceOf(table_ident) = decl.kind {
+            if let DeclKind::InstanceOf(table_ident, _) = decl.kind {
                 log::debug!("inferring {original} to be from table {table_ident}");
                 self.infer_table_column(&table_ident, &original.name)?;
             }
@@ -208,8 +209,8 @@ impl Resolver<'_> {
             // Columns can be inferred, which means that we don't know all column names at
             // compile time: use ExprKind::All
             vec![Expr::new(ExprKind::All {
-                within: mod_ident.clone(),
-                except: Vec::new(),
+                within: Box::new(Expr::new(mod_ident.clone())),
+                except: Box::new(Expr::new(Literal::Null)),
             })]
         } else {
             // Columns cannot be inferred, what's in the namespace is all there

--- a/prqlc/prql-compiler/src/semantic/resolver/names.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/names.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use anyhow::Result;
 use itertools::Itertools;
 
-use prqlc_ast::Literal;
 use prqlc_ast::expr::Ident;
+use prqlc_ast::Literal;
 
 use crate::ir::decl::{Decl, DeclKind, Module};
 use crate::ir::pl::{Expr, ExprKind};

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
@@ -18,7 +18,7 @@ columns:
   - Single:
       name:
         - emp_salary
-      target_id: 109
+      target_id: 110
       target_name: ~
 inputs:
   - id: 89

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
@@ -218,14 +218,86 @@ ty:
     Array:
       kind:
         Tuple:
-          - Wildcard:
-              kind: Any
-              span: "2:2183-2190"
-              name: ~
-      span: "2:2182-2193"
-      name: tuple
-  span: "2:2298-2305"
-  name: relation
+          - Single:
+              - ~
+              - kind:
+                  Union:
+                    - - ~
+                      - kind:
+                          Union:
+                            - - ~
+                              - kind:
+                                  Primitive: Int
+                                span: "2:2103-2106"
+                                name: ~
+                            - - ~
+                              - kind:
+                                  Primitive: Float
+                                span: "2:2110-2115"
+                                name: ~
+                            - - ~
+                              - kind:
+                                  Primitive: Bool
+                                span: "2:2119-2123"
+                                name: ~
+                            - - ~
+                              - kind:
+                                  Primitive: Text
+                                span: "2:2127-2131"
+                                name: ~
+                            - - ~
+                              - kind:
+                                  Primitive: Date
+                                span: "2:2135-2139"
+                                name: ~
+                            - - ~
+                              - kind:
+                                  Primitive: Time
+                                span: "2:2143-2147"
+                                name: ~
+                            - - ~
+                              - kind:
+                                  Primitive: Timestamp
+                                span: "2:2151-2160"
+                                name: ~
+                            - - ~
+                              - kind:
+                                  Singleton: "Null"
+                                span: "2:2164-2168"
+                                name: ~
+                        span: "2:2103-2168"
+                        name: scalar
+                    - - ~
+                      - kind:
+                          Tuple:
+                            - Wildcard:
+                                kind: Any
+                                span: "2:2183-2190"
+                                name: ~
+                        span: "2:2182-2193"
+                        name: tuple
+                span: "2:3192-3207"
+                name: ~
+          - Single:
+              - ~
+              - kind:
+                  Union:
+                    - - ~
+                      - kind:
+                          Primitive: Float
+                        span: "2:4365-4370"
+                        name: ~
+                    - - ~
+                      - kind:
+                          Singleton: "Null"
+                        span: "2:4374-4378"
+                        name: ~
+                span: "2:4365-4378"
+                name: ~
+      span: ~
+      name: ~
+  span: ~
+  name: ~
 lineage:
   columns:
     - Single:

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
@@ -152,7 +152,7 @@ TransformCall:
       kind:
         Tuple:
           - Single:
-              - ~
+              - issued_at
               - kind:
                   Union:
                     - - ~
@@ -219,7 +219,7 @@ ty:
       kind:
         Tuple:
           - Single:
-              - ~
+              - issued_at
               - kind:
                   Union:
                     - - ~
@@ -308,7 +308,7 @@ lineage:
         target_name: ~
     - Single:
         name: ~
-        target_id: 99
+        target_id: 100
         target_name: ~
   inputs:
     - id: 85

--- a/prqlc/prql-compiler/src/semantic/resolver/transforms.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/transforms.rs
@@ -593,10 +593,6 @@ impl Resolver<'_> {
         // now, we need wrap the result into a closure and replace
         // the dummy node with closure's parameter.
 
-        // extract reference to the dummy node
-        // let mut tbl_node = extract_ref_to_first(&mut pipeline);
-        // *tbl_node = Expr::new(ExprKind::Ident("x".to_string()));
-
         // validate that the return type is a relation
         // this can be removed after we have proper type checking for all std functions
         let expected = Some(Ty::relation(vec![TupleField::Wildcard(None)]));

--- a/prqlc/prql-compiler/src/semantic/resolver/types.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/types.rs
@@ -168,6 +168,12 @@ impl Resolver<'_> {
             return Ok(());
         }
 
+        // A temporary hack for allowing calling window functions from within
+        // aggregate and derive.
+        if expected.kind.is_array() && !found.is_function() {
+            return Ok(());
+        }
+
         // if type is a generic, infer the constraint
         // TODO
         if false {

--- a/prqlc/prql-compiler/tests/sql/bad_error_messages.rs
+++ b/prqlc/prql-compiler/tests/sql/bad_error_messages.rs
@@ -158,8 +158,9 @@ fn invalid_lineage_in_transform() {
     sort -val
   )
   "###).unwrap_err(), @r###"
-  Error: "Invalid lineage in group, verify the contents of the group call"
-  "###);
+    Error: expected a pipeline that resolves to a table, but found `internal std.sub`
+    ↳ Hint: are you missing `from` statement?
+    "###);
 }
 
 #[test]

--- a/prqlc/prql-compiler/tests/sql/sql.rs
+++ b/prqlc/prql-compiler/tests/sql/sql.rs
@@ -1116,7 +1116,7 @@ fn test_window_functions_11() {
     assert_display_snapshot!((compile(r###"
     from employees
     sort age
-    derive {num = row_number this})
+    derive {num = row_number this}
     "###).unwrap()), @r###"
     SELECT
       *,

--- a/prqlc/prql-compiler/tests/sql/sql.rs
+++ b/prqlc/prql-compiler/tests/sql/sql.rs
@@ -1116,7 +1116,7 @@ fn test_window_functions_11() {
     assert_display_snapshot!((compile(r###"
     from employees
     sort age
-    derive {num = row_number this}
+    derive {num = row_number this})
     "###).unwrap()), @r###"
     SELECT
       *,
@@ -1497,7 +1497,7 @@ fn test_take() {
 }
 
 #[test]
-fn test_distinct() {
+fn test_distinct_01() {
     // window functions cannot materialize into where statement: CTE is needed
     assert_display_snapshot!((compile(r###"
     from employees
@@ -1518,7 +1518,10 @@ fn test_distinct() {
     WHERE
       rn > 2
     "###);
+}
 
+#[test]
+fn test_distinct_02() {
     // basic distinct
     assert_display_snapshot!((compile(r###"
     from employees
@@ -1530,7 +1533,10 @@ fn test_distinct() {
     FROM
       employees
     "###);
+}
 
+#[test]
+fn test_distinct_03() {
     // distinct on two columns
     assert_display_snapshot!((compile(r###"
     from employees
@@ -1543,7 +1549,9 @@ fn test_distinct() {
     FROM
       employees
     "###);
-
+}
+#[test]
+fn test_distinct_04() {
     // We want distinct only over first_name and last_name, so we can't use a
     // `DISTINCT *` here.
     assert_display_snapshot!((compile(r###"
@@ -1564,14 +1572,18 @@ fn test_distinct() {
     WHERE
       _expr_0 <= 1
     "###);
-
+}
+#[test]
+fn test_distinct_05() {
     // Check that a different order doesn't stop distinct from being used.
     assert!(compile(
         "from employees | select {first_name, last_name} | group {last_name, first_name} (take 1)"
     )
     .unwrap()
     .contains("DISTINCT"));
-
+}
+#[test]
+fn test_distinct_06() {
     // head
     assert_display_snapshot!((compile(r###"
     from employees
@@ -1591,7 +1603,9 @@ fn test_distinct() {
     WHERE
       _expr_0 <= 3
     "###);
-
+}
+#[test]
+fn test_distinct_07() {
     assert_display_snapshot!((compile(r###"
     from employees
     group department (sort salary | take 2..3)
@@ -1614,7 +1628,9 @@ fn test_distinct() {
     WHERE
       _expr_0 BETWEEN 2 AND 3
     "###);
-
+}
+#[test]
+fn test_distinct_08() {
     assert_display_snapshot!((compile(r###"
     from employees
     group department (sort salary | take 4..4)
@@ -1637,7 +1653,10 @@ fn test_distinct() {
     WHERE
       _expr_0 = 4
     "###);
+}
 
+#[test]
+fn test_distinct_09() {
     assert_display_snapshot!(compile("
     from invoices
     select {billing_country, billing_city}
@@ -3243,7 +3262,7 @@ fn test_basic_agg() {
 }
 
 #[test]
-fn test_exclude_columns() {
+fn test_exclude_columns_01() {
     assert_display_snapshot!(compile(r#"
     from tracks
     select {track_id, title, composer, bytes}
@@ -3257,7 +3276,10 @@ fn test_exclude_columns() {
       tracks
     "###
     );
+}
 
+#[test]
+fn test_exclude_columns_02() {
     assert_display_snapshot!(compile(r#"
     from tracks
     select {track_id, title, composer, bytes}
@@ -3275,7 +3297,10 @@ fn test_exclude_columns() {
       bytes
     "###
     );
+}
 
+#[test]
+fn test_exclude_columns_03() {
     assert_display_snapshot!(compile(r#"
     from artists
     derive nick = name
@@ -3288,7 +3313,10 @@ fn test_exclude_columns() {
       artists
     "###
     );
+}
 
+#[test]
+fn test_exclude_columns_04() {
     assert_display_snapshot!(compile(r#"
     prql target:sql.bigquery
     from tracks
@@ -3303,7 +3331,10 @@ fn test_exclude_columns() {
       tracks
     "###
     );
+}
 
+#[test]
+fn test_exclude_columns_05() {
     assert_display_snapshot!(compile(r#"
     prql target:sql.snowflake
     from tracks
@@ -3316,7 +3347,10 @@ fn test_exclude_columns() {
       tracks
     "###
     );
+}
 
+#[test]
+fn test_exclude_columns_06() {
     assert_display_snapshot!(compile(r#"
     prql target:sql.duckdb
     from tracks
@@ -3329,7 +3363,10 @@ fn test_exclude_columns() {
       tracks
     "###
     );
+}
 
+#[test]
+fn test_exclude_columns_07() {
     assert_display_snapshot!(compile(r#"
     prql target:sql.duckdb
     from s"SELECT * FROM foo"

--- a/prqlc/prqlc-ast/src/types.rs
+++ b/prqlc/prqlc-ast/src/types.rs
@@ -97,6 +97,10 @@ impl Ty {
         Ty::new(TyKind::Array(Box::new(tuple)))
     }
 
+    pub fn never() -> Self {
+        Ty::new(TyKind::Union(Vec::new()))
+    }
+
     pub fn as_relation(&self) -> Option<&Vec<TupleField>> {
         self.kind.as_array()?.kind.as_tuple()
     }


### PR DESCRIPTION
Improve type inference, mainly for transforms. This is a step toward joining Lineage and Ty, but not quite there yet.

I don't think this has any behavioral effects, so it is not really a "feature", but it is not just a refactor either. Only changes that might be observable by users are new types errors where we didn't detect them previously.