### PR TITLE
feat(Lezer grammar): Highlight properties

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -12,6 +12,7 @@ export const prqlHighlight = styleTags({
   Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,
+  PropertyName: t.propertyName,
   TypeTerm: t.typeName,
   Escape: t.escape,
   String: t.string,

--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -12,7 +12,7 @@ export const prqlHighlight = styleTags({
   Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,
-  PropertyName: t.propertyName,
+  DeclarationItem: t.propertyName,
   TypeTerm: t.typeName,
   Escape: t.escape,
   String: t.string,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -28,17 +28,17 @@ pipe { "|" | ~ambigNewline newline }
 
 TupleExpression { "{" newline* tupleItem (("," newline*) tupleItem)* ","? newline* "}" }
 
-tupleItem { AssignTupleItem | expression | CallExpression | CaseBranch }
+tupleItem { DeclarationTuple | expression | CallExpression | CaseBranch }
 
 // Ideally we would force a space after `Identifier` to prevent an invalid s-string
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we
 // can't seem to force a space because it's in our skip, and I can't see
 // a way of changing the skip expression to only specialize on a single item
-CallExpression { Identifier ArgList { (NamedArg | Parameter | test)+ } }
+CallExpression { Identifier ArgList { (NamedArg | Declaration | test)+ } }
 
 NamedArg { ArgumentName { identPart } ":" expression }
-Parameter { ParameterName { identPart } "=" expression }
-AssignTupleItem { PropertyName { identPart } "=" expression }
+Declaration { DeclarationItem { identPart } "=" expression }
+DeclarationTuple { DeclarationItem { identPart } "=" expression }
 CaseBranch { expression "=>" expression }
 // Possibly we could only accept case branches inside the TupleExpression?
 CaseExpression { @specialize<identPart, "case"> TupleExpression }

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -28,7 +28,7 @@ pipe { "|" | ~ambigNewline newline }
 
 TupleExpression { "{" newline* tupleItem (("," newline*) tupleItem)* ","? newline* "}" }
 
-tupleItem { Property | expression | CallExpression | CaseBranch }
+tupleItem { AssignTupleItem | expression | CallExpression | CaseBranch }
 
 // Ideally we would force a space after `Identifier` to prevent an invalid s-string
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we
@@ -38,7 +38,7 @@ CallExpression { Identifier ArgList { (NamedArg | Assign | test)+ } }
 
 NamedArg { identPart ":" expression }
 Assign { identPart "=" expression }
-Property { PropertyName { identPart } "=" expression }
+AssignTupleItem { PropertyName { identPart } "=" expression }
 CaseBranch { expression "=>" expression }
 // Possibly we could only accept case branches inside the TupleExpression?
 CaseExpression { @specialize<identPart, "case"> TupleExpression }

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -28,7 +28,7 @@ pipe { "|" | ~ambigNewline newline }
 
 TupleExpression { "{" newline* tupleItem (("," newline*) tupleItem)* ","? newline* "}" }
 
-tupleItem { AssignCall | expression | CallExpression | CaseBranch }
+tupleItem { Property | expression | CallExpression | CaseBranch }
 
 // Ideally we would force a space after `Identifier` to prevent an invalid s-string
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we
@@ -38,7 +38,7 @@ CallExpression { Identifier ArgList { (NamedArg | Assign | test)+ } }
 
 NamedArg { identPart ":" expression }
 Assign { identPart "=" expression }
-AssignCall { identPart "=" expression }
+Property { PropertyName { identPart } "=" expression }
 CaseBranch { expression "=>" expression }
 // Possibly we could only accept case branches inside the TupleExpression?
 CaseExpression { @specialize<identPart, "case"> TupleExpression }

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -34,10 +34,10 @@ tupleItem { AssignTupleItem | expression | CallExpression | CaseBranch }
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we
 // can't seem to force a space because it's in our skip, and I can't see
 // a way of changing the skip expression to only specialize on a single item
-CallExpression { Identifier ArgList { (NamedArg | Assign | test)+ } }
+CallExpression { Identifier ArgList { (NamedArg | Parameter | test)+ } }
 
-NamedArg { identPart ":" expression }
-Assign { identPart "=" expression }
+NamedArg { ArgumentName { identPart } ":" expression }
+Parameter { ParameterName { identPart } "=" expression }
 AssignTupleItem { PropertyName { identPart } "=" expression }
 CaseBranch { expression "=>" expression }
 // Possibly we could only accept case branches inside the TupleExpression?

--- a/grammars/prql-lezer/test/full_queries.txt
+++ b/grammars/prql-lezer/test/full_queries.txt
@@ -10,4 +10,4 @@ filter income > 1
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,DateTime))),CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Float),Property(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier))))),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Integer)))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,DateTime))),CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Float),AssignTupleItem(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier))))),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Integer)))))

--- a/grammars/prql-lezer/test/full_queries.txt
+++ b/grammars/prql-lezer/test/full_queries.txt
@@ -10,4 +10,4 @@ filter income > 1
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,DateTime))),CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Float),AssignTupleItem(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier))))),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Integer)))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,DateTime))),CallExpression(Identifier,ArgList(TupleExpression(DeclarationTuple(DeclarationItem,Equals,Float),DeclarationTuple(DeclarationItem,Equals,BinaryExpression(Identifier,ArithOp,Identifier))))),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Integer)))))

--- a/grammars/prql-lezer/test/full_queries.txt
+++ b/grammars/prql-lezer/test/full_queries.txt
@@ -10,4 +10,4 @@ filter income > 1
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,DateTime))),CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier))))),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Integer)))))
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,DateTime))),CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Float),Property(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier))))),CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Integer)))))

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -121,7 +121,7 @@ derive {
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Float),AssignCall(Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Float),Property(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))
 
 # Nested pipeline
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -121,7 +121,7 @@ derive {
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Float),AssignTupleItem(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(DeclarationTuple(DeclarationItem,Equals,Float),DeclarationTuple(DeclarationItem,Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))
 
 # Nested pipeline
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -121,7 +121,7 @@ derive {
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Float),Property(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Float),AssignTupleItem(PropertyName,Equals,BinaryExpression(Identifier,ArithOp,Identifier)))))))
 
 # Nested pipeline
 

--- a/grammars/prql-lezer/test/tuples.txt
+++ b/grammars/prql-lezer/test/tuples.txt
@@ -40,7 +40,7 @@ test {foo=bar}
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Identifier))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Identifier))))))
 
 # Tuple with keys and values
 
@@ -50,4 +50,4 @@ string    =    "string"
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Identifier),Property(PropertyName,Equals,Integer),Property(PropertyName,Equals,Float),Property(PropertyName,Equals,String))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Identifier),AssignTupleItem(PropertyName,Equals,Integer),AssignTupleItem(PropertyName,Equals,Float),AssignTupleItem(PropertyName,Equals,String))))))

--- a/grammars/prql-lezer/test/tuples.txt
+++ b/grammars/prql-lezer/test/tuples.txt
@@ -40,7 +40,7 @@ test {foo=bar}
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Identifier))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(DeclarationTuple(DeclarationItem,Equals,Identifier))))))
 
 # Tuple with keys and values
 
@@ -50,4 +50,4 @@ string    =    "string"
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignTupleItem(PropertyName,Equals,Identifier),AssignTupleItem(PropertyName,Equals,Integer),AssignTupleItem(PropertyName,Equals,Float),AssignTupleItem(PropertyName,Equals,String))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(DeclarationTuple(DeclarationItem,Equals,Identifier),DeclarationTuple(DeclarationItem,Equals,Integer),DeclarationTuple(DeclarationItem,Equals,Float),DeclarationTuple(DeclarationItem,Equals,String))))))

--- a/grammars/prql-lezer/test/tuples.txt
+++ b/grammars/prql-lezer/test/tuples.txt
@@ -40,7 +40,7 @@ test {foo=bar}
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Identifier))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Identifier))))))
 
 # Tuple with keys and values
 
@@ -50,4 +50,4 @@ string    =    "string"
 
 ==>
 
-Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(AssignCall(Equals,Identifier),AssignCall(Equals,Integer),AssignCall(Equals,Float),AssignCall(Equals,String))))))
+Query(Pipeline(CallExpression(Identifier,ArgList(TupleExpression(Property(PropertyName,Equals,Identifier),Property(PropertyName,Equals,Integer),Property(PropertyName,Equals,Float),Property(PropertyName,Equals,String))))))


### PR DESCRIPTION
This renames the `AssignCall` token to `Property` which seems more common in upstream tokens, albeit there it is inconsistently named and sometimes named `Property` (JSON) and `PropertyDeclaration` (JavaScript), etc.

This also adds a token with the name `PropertyName` which we map to the Lezer highlighting tag [`propertyName`](https://lezer.codemirror.net/docs/ref/#highlight.tags.propertyName).