### PR TITLE
refactor: wildcard resolution and pl::Expr::target_ids

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,12 +30,12 @@ prqlc-lint:
 # Test prqlc
 packages := '--package=prqlc-ast --package=prqlc-parser --package=prql-compiler --package=prqlc'
 prqlc-test-fast:
-    cargo clippy --all-targets {{packages}} -- -D warnings
-
     # cargo insta test, but allowing multiple --package arguments
     INSTA_FORCE_PASS=1 cargo test --locked {{packages}}
 
     cargo insta review
+
+    cargo clippy --all-targets {{packages}} -- -D warnings
 
 prqlc-test:
     cargo clippy --all-targets {{packages}} -- -D warnings

--- a/prqlc/prql-compiler/src/ir/pl/expr.rs
+++ b/prqlc/prql-compiler/src/ir/pl/expr.rs
@@ -36,10 +36,6 @@ pub struct Expr {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_id: Option<usize>,
 
-    /// For [ExprKind::All], these are ids of included nodes
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub target_ids: Vec<usize>,
-
     /// Type of expression this node represents.
     /// [None] means that type should be inferred.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -176,9 +172,6 @@ impl std::fmt::Debug for Expr {
         }
         if let Some(x) = &self.target_id {
             ds.field("target_id", x);
-        }
-        if !self.target_ids.is_empty() {
-            ds.field("target_ids", &self.target_ids);
         }
         if self.needs_window {
             ds.field("needs_window", &self.needs_window);

--- a/prqlc/prql-compiler/src/ir/pl/extra/expr.rs
+++ b/prqlc/prql-compiler/src/ir/pl/extra/expr.rs
@@ -124,7 +124,6 @@ impl Expr {
             kind: kind.into(),
             span: None,
             target_id: None,
-            target_ids: Vec::new(),
             ty: None,
             lineage: None,
             needs_window: false,

--- a/prqlc/prql-compiler/src/semantic/ast_expand.rs
+++ b/prqlc/prql-compiler/src/semantic/ast_expand.rs
@@ -77,7 +77,6 @@ pub fn expand_expr(expr: Expr) -> Result<pl::Expr> {
         alias: expr.alias,
         id: None,
         target_id: None,
-        target_ids: Vec::new(),
         ty: None,
         lineage: None,
         needs_window: false,

--- a/prqlc/prql-compiler/src/semantic/module.rs
+++ b/prqlc/prql-compiler/src/semantic/module.rs
@@ -220,6 +220,9 @@ impl Module {
                         namespace.redirects.push(Ident::from_name(input_name));
 
                         let input = lineage.find_input_by_name(input_name).unwrap();
+                        let order = lineage.inputs.iter().position(|i| i.id == input.id);
+                        let order = order.unwrap();
+
                         let mut sub_ns = Module::default();
 
                         let self_ty = lin_ty.clone().kind.into_tuple().unwrap();
@@ -241,6 +244,7 @@ impl Module {
 
                         let sub_ns = Decl {
                             declared_at: Some(input.id),
+                            order,
                             kind: DeclKind::Module(sub_ns),
                             ..Default::default()
                         };

--- a/prqlc/prql-compiler/src/semantic/resolver/functions.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/functions.rs
@@ -89,7 +89,7 @@ impl Resolver<'_> {
                     })
                 }
             } else {
-                let expr = self.resolve_special_func(closure)?;
+                let expr = self.resolve_special_func(closure, needs_window)?;
                 self.fold_expr(expr)?
             }
         } else {

--- a/prqlc/prql-compiler/src/semantic/resolver/mod.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/mod.rs
@@ -61,7 +61,6 @@ pub(super) mod test {
             expr.kind = self.fold_expr_kind(expr.kind)?;
             expr.id = None;
             expr.target_id = None;
-            expr.target_ids.clear();
             Ok(expr)
         }
     }

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__frames_and_names-3.snap
@@ -18,7 +18,7 @@ columns:
   - Single:
       name:
         - emp_salary
-      target_id: 110
+      target_id: 114
       target_name: ~
 inputs:
   - id: 89

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
@@ -308,7 +308,7 @@ lineage:
         target_name: ~
     - Single:
         name: ~
-        target_id: 100
+        target_id: 102
         target_name: ~
   inputs:
     - id: 85

--- a/prqlc/prql-compiler/src/semantic/std.prql
+++ b/prqlc/prql-compiler/src/semantic/std.prql
@@ -162,7 +162,7 @@ let concat_array = column <array> -> <text> internal std.concat_array
 
 # Counts number of items in the column.
 # Note that the count will include null values.
-let count = column<array> -> <int> internal std.count
+let count = column<array> -> <int> internal count
 
 # Deprecated in favour of filterning input to the [std.count] function (not yet implemented).
 @{deprecated}
@@ -175,7 +175,7 @@ let first      = column <array> -> internal std.first
 let last       = column <array> -> internal std.last
 let rank       = column <array> -> internal std.rank
 let rank_dense = column <array> -> internal std.rank_dense
-let row_number = column <array> -> internal std.row_number
+let row_number = column <array> -> internal row_number
 
 ## Misc functions
 let round = n_digits column -> <scalar> internal std.round

--- a/prqlc/prql-compiler/tests/sql/ast_code_matches.rs
+++ b/prqlc/prql-compiler/tests/sql/ast_code_matches.rs
@@ -37,12 +37,12 @@ fn test_expr_ast_code_matches() {
     -    pub op: UnOp,
     -    pub expr: Box<Expr>,
     @@ .. @@
-    -}
-    -
     -/// A value and a series of functions that are to be applied to that value one after another.
     -#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
     -pub struct Pipeline {
     -    pub exprs: Vec<Expr>,
+    -}
+    -
     "###
     );
 }

--- a/prqlc/prql-compiler/tests/sql/sql.rs
+++ b/prqlc/prql-compiler/tests/sql/sql.rs
@@ -601,8 +601,6 @@ fn test_rn_ids_are_unique() {
         _expr_1 <= 2
     )
     SELECT
-      x_id,
-      y_id,
       *
     FROM
       table_0
@@ -762,6 +760,7 @@ fn test_sorts_02() {
       "index"
     "###);
 
+    // TODO: this is invalid SQL: a._expr_0 does not exist
     assert_display_snapshot!((compile(r#"
     from a
     join side:left b (==col)
@@ -1223,7 +1222,6 @@ fn test_window_functions_13() {
     )
     SELECT
       milliseconds - _expr_0 AS grp,
-      album_id,
       *,
       ROW_NUMBER() OVER (PARTITION BY milliseconds - _expr_0) AS count
     FROM
@@ -2156,9 +2154,9 @@ take 20
       SELECT
         title,
         country,
-        salary,
         salary + payroll_tax + benefits_cost AS _expr_0,
-        salary + payroll_tax AS _expr_1
+        salary + payroll_tax AS _expr_1,
+        salary
       FROM
         employees
       WHERE
@@ -3014,16 +3012,11 @@ fn test_direct_table_references() {
     select x
     "###,
     )
-    .unwrap_err(), @r###"
-    Error:
-       ╭─[:3:12]
-       │
-     3 │     select x
-       │            ┬
-       │            ╰── table instance cannot be referenced directly
-       │
-       │ Help: did you forget to specify the column name?
-    ───╯
+    .unwrap(), @r###"
+    SELECT
+      *
+    FROM
+      x
     "###);
 }
 

--- a/prqlc/prqlc-ast/src/types.rs
+++ b/prqlc/prqlc-ast/src/types.rs
@@ -6,7 +6,7 @@ use crate::{Ident, Span};
 
 use super::Literal;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ty {
     pub kind: TyKind,
 
@@ -155,5 +155,11 @@ impl From<TyFunc> for TyKind {
 impl From<Literal> for TyKind {
     fn from(value: Literal) -> Self {
         TyKind::Singleton(value)
+    }
+}
+
+impl std::fmt::Debug for Ty {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR has partially been cherry-picked from an old branch of mine and partially rewritten anew. I've worked on this for a few weeks now, so I forgot the initial motivation of why I wanted to change this :D

It does simplify:
- the wildcard resolution (this opinion might be biased since I spent so much time debugging it and I know how it works in depth now)
- `Expr::target_id` and `Expr::target_ids`, which are now a single number.

I *think* I wanted this because it made lineage inference independent of the declarations in root module: https://github.com/PRQL/prql/pull/3863/files#diff-d2aed3357385f80cd4517d8ca5492ad503c33c13b8afbd9e219666f57f947459L264

As an additional upside, I changed functions implemented specifically for lineage into functions that manipulate the AST, which means that I don't have to duplicate this behavior in type inference. 