### PR TITLE
fix(Playground): Handle compiler crashing

### DIFF
--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -74,7 +74,8 @@ class Workbench extends React.Component {
     } catch (e) {
       if (e instanceof WebAssembly.RuntimeError) {
         this.setState({
-          prqlError: "A compiler bug encountered. Please report this to https://github.com/PRQL/prql/issues/new/choose",
+          prqlError:
+            "A compiler bug encountered. Please report this to https://github.com/PRQL/prql/issues/new/choose",
         });
         return;
       }

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -74,7 +74,7 @@ class Workbench extends React.Component {
     } catch (e) {
       if (e instanceof WebAssembly.RuntimeError) {
         this.setState({
-          prqlError: "The compiler crashed! Report this as a bug!",
+          prqlError: "A compiler bug encountered. Please report this to https://github.com/PRQL/prql/issues/new/choose",
         });
         return;
       }

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -72,6 +72,11 @@ class Workbench extends React.Component {
       this.setState({ prqlError: null });
       this.monaco.editor.setModelMarkers(this.editor.getModel(), "prql", []);
     } catch (e) {
+      if (e instanceof WebAssembly.RuntimeError) {
+        this.setState({ prqlError: "The compiler crashed! Report this as a bug!" });
+        return;
+      }
+
       const errors = JSON.parse(e.message).inner;
       this.setState({ prqlError: errors[0].display });
 

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -73,7 +73,9 @@ class Workbench extends React.Component {
       this.monaco.editor.setModelMarkers(this.editor.getModel(), "prql", []);
     } catch (e) {
       if (e instanceof WebAssembly.RuntimeError) {
-        this.setState({ prqlError: "The compiler crashed! Report this as a bug!" });
+        this.setState({
+          prqlError: "The compiler crashed! Report this as a bug!",
+        });
         return;
       }
 


### PR DESCRIPTION
The playground just caught any exception then called `JSON.parse` to deserialize the `inner` property. That was a problem since sometimes we get a `Error` thrown (when the compiler returns an error), and sometimes a `RuntimeError` thrown (when the compiler crashes).

So now we check if the exception is an `RuntimeError` and then we know the compiler crashed and there is nothing to JSON deserialize.

Fixes #3848