### PR TITLE
tweak: Remove unused items

### DIFF
--- a/prqlc/prql-compiler/src/ir/pl/expr.rs
+++ b/prqlc/prql-compiler/src/ir/pl/expr.rs
@@ -7,8 +7,6 @@ use serde::{Deserialize, Serialize};
 use prqlc_ast::expr::generic;
 use prqlc_ast::{Ident, Literal, Span, Ty};
 
-pub use prqlc_ast::expr::{BinOp, UnOp};
-
 use crate::codegen::write_ty;
 
 use super::{Lineage, TransformCall};


### PR DESCRIPTION
I think this is showing warnings in the nightly compiler, so shows up on PRs when `check-unused-dependences` is run
