### PR TITLE
refactor: have fixed number of args for `RqOperator`

### DIFF
--- a/prqlc/prql-compiler/src/ir/rq/expr.rs
+++ b/prqlc/prql-compiler/src/ir/rq/expr.rs
@@ -38,6 +38,8 @@ pub enum ExprKind {
 
     /// Placeholder for expressions provided after compilation.
     Param(String),
+
+    Array(Vec<Expr>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/prqlc/prql-compiler/src/ir/rq/fold.rs
+++ b/prqlc/prql-compiler/src/ir/rq/fold.rs
@@ -230,6 +230,9 @@ pub fn fold_expr_kind<F: ?Sized + RqFold>(fold: &mut F, kind: ExprKind) -> Resul
         ExprKind::Param(id) => ExprKind::Param(id),
 
         ExprKind::Literal(_) => kind,
+        ExprKind::Array(exprs) => {
+            ExprKind::Array(exprs.into_iter().map(|e| fold.fold_expr(e)).try_collect()?)
+        }
     })
 }
 

--- a/prqlc/prql-compiler/src/semantic/lowering.rs
+++ b/prqlc/prql-compiler/src/semantic/lowering.rs
@@ -882,10 +882,14 @@ impl Lowerer {
                 );
             }
 
-            pl::ExprKind::FuncCall(_)
-            | pl::ExprKind::Array(_)
-            | pl::ExprKind::Func(_)
-            | pl::ExprKind::TransformCall(_) => {
+            pl::ExprKind::Array(exprs) => rq::ExprKind::Array(
+                exprs
+                    .into_iter()
+                    .map(|x| self.lower_expr(x))
+                    .try_collect()?,
+            ),
+
+            pl::ExprKind::FuncCall(_) | pl::ExprKind::Func(_) | pl::ExprKind::TransformCall(_) => {
                 log::debug!("cannot lower {expr:?}");
                 return Err(Error::new(Reason::Unexpected {
                     found: format!("`{}`", write_pl(expr.clone())),

--- a/prqlc/prql-compiler/src/semantic/resolver/transforms.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/transforms.rs
@@ -238,14 +238,10 @@ impl Resolver<'_> {
 
                 let [pattern, value] = unpack::<2>(func.args);
 
-                // TODO: instead of unpacking the array, compile it to rq::ExprKind::Array
                 if let ExprKind::Array(in_values) = pattern.kind {
-                    let mut col_and_values: Vec<Expr> = Vec::with_capacity(in_values.len() + 1);
-                    col_and_values.push(value);
-                    col_and_values.extend(in_values);
                     return Ok(Expr::new(ExprKind::RqOperator {
                         name: "std.array_in".to_string(),
-                        args: col_and_values,
+                        args: vec![value, Expr::new(ExprKind::Array(in_values))],
                     }));
                 }
 

--- a/prqlc/prql-compiler/src/sql/gen_expr.rs
+++ b/prqlc/prql-compiler/src/sql/gen_expr.rs
@@ -14,7 +14,7 @@ use crate::ir::pl::{self, Ident, Literal};
 use crate::ir::rq::*;
 use crate::sql::srq::context::ColumnDecl;
 use crate::utils::{OrMap, VALID_IDENT};
-use crate::{Error, Span, WithErrorInfo};
+use crate::{Error, Reason, Span, WithErrorInfo};
 use prqlc_ast::expr::generic::{InterpolateItem, Range};
 
 use super::gen_projection::try_into_exprs;
@@ -117,7 +117,13 @@ pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<ExprOrSour
             }
             super::operators::translate_operator_expr(expr, ctx)?
         }
-        ExprKind::Array(_) => panic!("unsupported expr kind: array"),
+        ExprKind::Array(_) => {
+            return Err(Error::new(Reason::Unexpected {
+                found: "array of values (not supported here)".to_string(),
+            })
+            .with_span(expr.span)
+            .into());
+        }
     })
 }
 

--- a/prqlc/prql-compiler/src/sql/srq/anchor.rs
+++ b/prqlc/prql-compiler/src/sql/srq/anchor.rs
@@ -566,8 +566,8 @@ pub fn infer_complexity_expr(expr: &Expr) -> Complexity {
         rq::ExprKind::ColumnRef(_)
         | rq::ExprKind::Literal(_)
         | rq::ExprKind::SString(_)
-        | rq::ExprKind::Param(_) => Complexity::Plain,
-        rq::ExprKind::Array(_) => panic!("unsupported expr kind: array"),
+        | rq::ExprKind::Param(_)
+        | rq::ExprKind::Array(_) => Complexity::Plain,
     }
 }
 

--- a/prqlc/prql-compiler/src/sql/srq/anchor.rs
+++ b/prqlc/prql-compiler/src/sql/srq/anchor.rs
@@ -567,6 +567,7 @@ pub fn infer_complexity_expr(expr: &Expr) -> Complexity {
         | rq::ExprKind::Literal(_)
         | rq::ExprKind::SString(_)
         | rq::ExprKind::Param(_) => Complexity::Plain,
+        rq::ExprKind::Array(_) => panic!("unsupported expr kind: array"),
     }
 }
 

--- a/prqlc/prql-compiler/src/sql/srq/anchor.rs
+++ b/prqlc/prql-compiler/src/sql/srq/anchor.rs
@@ -566,8 +566,8 @@ pub fn infer_complexity_expr(expr: &Expr) -> Complexity {
         rq::ExprKind::ColumnRef(_)
         | rq::ExprKind::Literal(_)
         | rq::ExprKind::SString(_)
-        | rq::ExprKind::Param(_)
-        | rq::ExprKind::Array(_) => Complexity::Plain,
+        | rq::ExprKind::Param(_) => Complexity::Plain,
+        rq::ExprKind::Array(_) => Complexity::highest(),
     }
 }
 

--- a/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
+++ b/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
@@ -78,24 +78,6 @@ fn test_bad_error_messages() {
 }
 
 #[test]
-fn array_instead_of_tuple() {
-    // Particularly given this used to be our syntax, this could be clearer
-    // (though we do say so in the message, which is friendly!)
-    assert_display_snapshot!(compile(r###"
-    from e=employees
-    select [e.first_name, e.last_name]
-    "###).unwrap_err(), @r###"
-    Error:
-       ╭─[:3:12]
-       │
-     3 │     select [e.first_name, e.last_name]
-       │            ─────────────┬─────────────
-       │                         ╰─────────────── unexpected array of values (not supported here)
-    ───╯
-    "###);
-}
-
-#[test]
 fn empty_interpolations() {
     assert_display_snapshot!(compile(r#"
     from x

--- a/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
+++ b/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
@@ -90,9 +90,7 @@ fn array_instead_of_tuple() {
        │
      3 │     select [e.first_name, e.last_name]
        │            ─────────────┬─────────────
-       │                         ╰─────────────── unexpected `[this.e.first_name, this.e.last_name]`
-       │
-       │ Help: this is probably a 'bad type' error (we are working on that)
+       │                         ╰─────────────── unexpected array of values (not supported here)
     ───╯
     "###);
 }

--- a/prqlc/prql-compiler/tests/integration/error_messages.rs
+++ b/prqlc/prql-compiler/tests/integration/error_messages.rs
@@ -103,8 +103,6 @@ fn test_errors() {
 
 #[test]
 fn array_instead_of_tuple() {
-    // Particularly given this used to be our syntax, this could be clearer
-    // (though we do say so in the message, which is friendly!)
     assert_display_snapshot!(compile(r###"
     from e=employees
     select [e.first_name, e.last_name]

--- a/prqlc/prql-compiler/tests/integration/error_messages.rs
+++ b/prqlc/prql-compiler/tests/integration/error_messages.rs
@@ -102,6 +102,24 @@ fn test_errors() {
 }
 
 #[test]
+fn array_instead_of_tuple() {
+    // Particularly given this used to be our syntax, this could be clearer
+    // (though we do say so in the message, which is friendly!)
+    assert_display_snapshot!(compile(r###"
+    from e=employees
+    select [e.first_name, e.last_name]
+    "###).unwrap_err(), @r###"
+    Error:
+       ╭─[:3:12]
+       │
+     3 │     select [e.first_name, e.last_name]
+       │            ─────────────┬─────────────
+       │                         ╰─────────────── unexpected array of values (not supported here)
+    ───╯
+    "###);
+}
+
+#[test]
 fn test_union_all_sqlite() {
     // TODO: `SQLiteDialect` would be better as `sql.sqlite` or `sqlite`.
     assert_display_snapshot!(compile(r###"


### PR DESCRIPTION
following @aljazerzen advice in [#3883](https://github.com/PRQL/prql/pull/3883#discussion_r1413535136) here is the follow up PR

> make the number of arguments fixed. This is hard to do, since we want arrays to have a variable number of arguments and because we don't have array in the RQ. Here I would suggest:
>        
>        * to add `rq::ExprKind::Array`, https://github.com/prql/PRQL/blob/main/prqlc/prql-compiler/src/ir/rq/expr.rs#L20,
>        * lower `pl::ExprKind::Array` into `rq::ExprKind::Array` here: https://github.com/prql/PRQL/blob/main/prqlc/prql-compiler/src/semantic/lowering.rs#L886
>        * unpack the `rq::ExprKind::Array` in the `process_in_values` function,
>        * in any other place in SQL backend, reject the `rq::ExprKind::Array` saying "unsupported feature"
>        
>        This is a bit of work, so I'm fine with merging this PR with a comment saying "TODO: instead of unpacking the array, compile it to rq::ExprKind::Array".



2 questions:
1) is it the right approach?
2) if yes what should I do with the failing test? Should I change `infer_complexity_expr` to return a `Result` in order to propagate a clean `Err(Error::new(Reason::Unexpected ...))` upstream?

This test now fails
```rs
#[test]
fn array_instead_of_tuple() {
    // Particularly given this used to be our syntax, this could be clearer
    // (though we do say so in the message, which is friendly!)
    assert_display_snapshot!(compile(r###"
    from e=employees
    select [e.first_name, e.last_name]
    "###).unwrap_err(), @r###"
    Error:
       ╭─[:3:12]
       │
     3 │     select [e.first_name, e.last_name]
       │            ─────────────┬─────────────
       │                         ╰─────────────── unexpected `[this.e.first_name, this.e.last_name]`
       │
       │ Help: this is probably a 'bad type' error (we are working on that)
    ───╯
    "###);
}
```
since we now `panic!`

```console
---- bad_error_messages::array_instead_of_tuple stdout ----
thread 'bad_error_messages::array_instead_of_tuple' panicked at 'unsupported expr kind: array', prqlc/prql-compiler/src/sql/srq/anchor.rs:570:35
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```