### PR TITLE
docs: Fix syntax in example

### DIFF
--- a/web/website/content/posts/2022-05-19-examples.md
+++ b/web/website/content/posts/2022-05-19-examples.md
@@ -55,23 +55,23 @@ Here's the same query with PRQL:
 ```prql
 from employees                                # Each line transforms the previous result.
 filter start_date > @2021-01-01               # Clear date syntax.
-derive [                                      # `derive` adds columns / variables.
+derive {                                      # `derive` adds columns / variables.
   gross_salary = salary + payroll_tax,
   gross_cost = gross_salary + benefits_cost   # Variables can use other variables.
-]
+}
 filter gross_cost > 0
-group [title, country] (                      # `group` runs a pipeline over each group.
-  aggregate [                                 # `aggregate` reduces a column to a row.
+group {title, country} (                      # `group` runs a pipeline over each group.
+  aggregate {                                 # `aggregate` reduces a column to a row.
     average salary,
     sum     salary,
     average gross_salary,
     sum     gross_salary,
     average gross_cost,
     sum_gross_cost = sum gross_cost,          # `=` sets a column name.
-    ct = count,
-  ]
+    ct = count this,
+  }
 )
-sort [sum_gross_cost, -country]               # `-country` means descending order.
+sort {sum_gross_cost, -country}               # `-country` means descending order.
 filter ct > 2_000
 take 20
 ```


### PR DESCRIPTION
Since release 0.9.0, tuples are enclosed in braces, not brackets. This commit adapts the example to be valid PRQL with the latest version again.
Additionally, since 0.9.0 `count` requires and argument which is also added to the example.