### PR TITLE
feat(Lezer grammar): Highlight DateTime

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -12,6 +12,7 @@ export const prqlHighlight = styleTags({
   Boolean: t.bool,
   Integer: t.integer,
   Float: t.float,
+  DateTime: t.color,
   DeclarationItem: t.propertyName,
   TypeTerm: t.typeName,
   Escape: t.escape,


### PR DESCRIPTION
This maps the `DateTime` token to the Lezer highlighting tag [`color`](https://lezer.codemirror.net/docs/ref/#highlight.tags.color). Lezer doesn't have any highlighting tag for dates or times, but we definitely do want to somehow highlight the `DateTime` token so we'll just pick an relatively arbitrary one. The `color` tag belongs to the set of literal tags. In the real world the end result is an improvement.