### PR TITLE
refactor(Lezer grammar): Rename TypeTerm

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -14,7 +14,7 @@ export const prqlHighlight = styleTags({
   Float: t.float,
   DateTime: t.color,
   DeclarationItem: t.propertyName,
-  TypeTerm: t.typeName,
+  TypeName: t.typeName,
   Escape: t.escape,
   String: t.string,
   FString: t.special(t.string),

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -103,8 +103,8 @@ kw<term> { @specialize[@name={term}]<identPart, term> }
 VariableDeclaration { kw<"let"> VariableName "=" (NestedPipeline (newline+ | end) | Lambda) }
 
 Lambda { LambdaParam* "->" expression (newline+ | end) }
-TypeDefinition { "<" TypeTerm ("|" TypeTerm)* ">" }
-TypeTerm { identPart TypeDefinition? }
+TypeDefinition { "<" TypeName ("|" TypeName)* ">" }
+TypeName { identPart TypeDefinition? }
 LambdaParam { identPart TypeDefinition? (":" expression)? }
 
 @skip {} {

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -102,7 +102,7 @@ let my_func = arg1<int32> -> arg1
 
 ==>
 
-Query(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam(TypeDefinition(TypeTerm)),Identifier)))
+Query(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam(TypeDefinition(TypeName)),Identifier)))
 
 # Simple pipeline
 


### PR DESCRIPTION
This PR renames the `TypeTerm` token to `TypeName` to align with upstream grammars.

Upstream JavaScript and Java grammars names it `TypeName` while the Rust and C++ grammars names it `TypeIdentifier`.

`TypeName` is nice because it maps nicely to the Lezer highlighting tag named [`typeName`](https://lezer.codemirror.net/docs/ref/#highlight.tags.typeName).