### PR TITLE
feat(Lezer grammar): Add parameters

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -25,6 +25,7 @@ export const prqlHighlight = styleTags({
   CompareOp: t.compareOperator,
   LogicOp: t.logicOperator,
   Equals: t.definitionOperator,
+  Parameter: t.processingInstruction,
   VariableName: t.variableName,
   "( )": t.paren,
   "[ ]": t.squareBracket,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -72,6 +72,7 @@ expression[@isGroup=Expression] {
   NestedPipeline |
   CaseExpression |
   DateTime |
+  Parameter |
   RangeExpression |
   Identifier |
   boolean |
@@ -145,6 +146,8 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   Escape {
     "\\" ("x" hex hex | "u" "{" hex+ "}" | $[bfnrt])
   }
+
+  Parameter { "$" (@digit+ | identPart) }
 
   stringContentSingle { ![\\']+ }
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -104,6 +104,14 @@ let my_func = arg1<int32> -> arg1
 
 Query(VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam(TypeDefinition(TypeTerm)),Identifier)))
 
+# Parameter
+
+filter id == $1
+
+==>
+
+Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Parameter)))))
+
 # Simple pipeline
 
 from foo | select bar


### PR DESCRIPTION
This PR adds support for parameters, i.e. `$1` through a new token named `Parameter`. I am unsure whether it should be mapped as the Lezer highlighting tag [`processingInstruction`](https://lezer.codemirror.net/docs/ref/#highlight.tags.processingInstruction) or `t.special(t.variable)` or even something else, I guess it doesn't matter that much. Either way it improves the grammar as it fills a gap.