### PR TITLE
feat(Lezer grammar): Parenthesized expressions

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -73,6 +73,7 @@ expression[@isGroup=Expression] {
   CaseExpression |
   DateTime |
   Parameter |
+  ParenthesizedExpression |
   RangeExpression |
   Identifier |
   boolean |
@@ -89,6 +90,8 @@ BinaryExpression {
   expression !plus ArithOp<"+" | "-"> expression |
   expression !times ArithOp<"*" | "/" | "%" | "//"> expression
 }
+
+ParenthesizedExpression { "(" expression ")" }
 
 UnaryExpression { !prefix ArithOp<"+" | "-"> expression }
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -112,6 +112,14 @@ filter id == $1
 
 Query(Pipeline(CallExpression(Identifier,ArgList(BinaryExpression(Identifier,CompareOp,Parameter)))))
 
+# Parenthesized expression
+
+filter (1)
+
+==>
+
+Query(Pipeline(CallExpression(Identifier,ArgList(ParenthesizedExpression(Integer)))))
+
 # Simple pipeline
 
 from foo | select bar


### PR DESCRIPTION
This PR adds support for parenthesized expressions, e.g. `derive x = 5 + (1)`.