### PR TITLE
feat(Lezer grammar): Add annotations

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -5,6 +5,7 @@ export const prqlHighlight = styleTags({
   let: t.definitionKeyword,
   case: t.controlKeyword,
   in: t.operatorKeyword,
+  Annotation: t.annotation,
   Comment: t.lineComment,
   Docblock: t.docString,
   "this that": t.self,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -16,7 +16,7 @@
 
 @skip { space | Comment | Docblock | wrappedLine }
 
-statements { newline* QueryDefinition? VariableDeclaration* pipelineStatement? end }
+statements { newline* QueryDefinition? Annotation? VariableDeclaration* pipelineStatement? end }
 
 QueryDefinition { @specialize<identPart, "prql"> NamedArg+ newline+ }
 
@@ -29,6 +29,8 @@ pipe { "|" | ~ambigNewline newline }
 TupleExpression { "{" newline* tupleItem (("," newline*) tupleItem)* ","? newline* "}" }
 
 tupleItem { DeclarationTuple | expression | CallExpression | CaseBranch }
+
+Annotation { "@{" commaSep<Declaration>? "}" }
 
 // Ideally we would force a space after `Identifier` to prevent an invalid s-string
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -30,7 +30,7 @@ TupleExpression { "{" newline* tupleItem (("," newline*) tupleItem)* ","? newlin
 
 tupleItem { DeclarationTuple | expression | CallExpression | CaseBranch }
 
-Annotation { "@{" commaSep<Declaration>? "}" }
+Annotation { "@{" commaSep<Declaration>? "}" newline }
 
 // Ideally we would force a space after `Identifier` to prevent an invalid s-string
 // being parsed as a CallExpression, e.g. `s"{a"` -> `s` & `"{a"'. But we

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -38,6 +38,14 @@ filter that
 
 Query(Pipeline(CallExpression(Identifier,ArgList(that))))
 
+# Annotation
+
+@{binding_strength=1}
+
+==>
+
+Query(Annotation(Declaration(DeclarationItem,Equals,Integer)))
+
 # Range: 10..20
 
 filter 10..20

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -41,10 +41,11 @@ Query(Pipeline(CallExpression(Identifier,ArgList(that))))
 # Annotation
 
 @{binding_strength=1}
+let x = y -> z
 
 ==>
 
-Query(Annotation(Declaration(DeclarationItem,Equals,Integer)))
+Query(Annotation(Declaration(DeclarationItem,Equals,Integer)),VariableDeclaration(let,VariableName,Equals,Lambda(LambdaParam,Identifier)))
 
 # Range: 10..20
 


### PR DESCRIPTION
This PR adds support for annotations, e.g. `@{binding_strength=1}`.