### PR TITLE
fix(Lezer grammar): Comment between pipelines

### DIFF
--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -24,7 +24,7 @@ pipelineStatement { Pipeline (~ambigNewline newline+ | end)}
 
 Pipeline { CallExpression (pipe CallExpression)* }
 
-pipe { "|" | ~ambigNewline newline }
+pipe { "|" | ~ambigNewline newline+ }
 
 TupleExpression { "{" newline* tupleItem (("," newline*) tupleItem)* ","? newline* "}" }
 

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -72,7 +72,7 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))),Comment)
 
 Query(Comment,Comment)
 
-# Comment beween pipes
+# Comment between pipes
 
 from foo
 # filter...

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -72,6 +72,16 @@ Query(Pipeline(CallExpression(Identifier,ArgList(Integer))),Comment)
 
 Query(Comment,Comment)
 
+# Comment beween pipes
+
+from foo
+# filter...
+select bar
+
+==>
+
+Query(Pipeline(CallExpression(Identifier,ArgList(Identifier)),Comment,CallExpression(Identifier,ArgList(Identifier))))
+
 # Docblock
 
 #! Hello


### PR DESCRIPTION
This PR allows comments and blank lines between pipelines, example:
```elm
from foo
# filter x == y
select bar
```
and
```elm
from foo

select bar
```