### PR TITLE
chore: improve integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,8 +10,8 @@ slow-timeout = { period = "2s", terminate-after = 4 }
 
 [test-groups.test-dbs]
 # test-dbs runs database setup when the connection is established,
-# and becuase nextest runs test in separate processes, this happens on every test.
-# To prevent mutliple setups running at once, we set max-threads to 1.
+# and because nextest runs test in separate processes, this happens on every test.
+# To prevent multiple setups running at once, we set max-threads to 1.
 # Ideally, we could run tests in parallel and they would use a locking mechanism to see if
 # the database has already been setup. For now, we can use cargo test instead.
 max-threads = 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -36,7 +36,7 @@ checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.2.9",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -313,18 +313,6 @@ dependencies = [
  "num",
  "regex",
  "regex-syntax",
-]
-
-[[package]]
-name = "async-native-tls"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
-dependencies = [
- "futures-util",
- "native-tls",
- "thiserror",
- "url",
 ]
 
 [[package]]
@@ -898,7 +886,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom",
  "once_cell",
  "proc-macro-hack",
  "tiny-keccak",
@@ -1575,24 +1563,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2143,12 +2120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
-
-[[package]]
 name = "mdbook"
 version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,7 +2249,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -2349,7 +2320,7 @@ dependencies = [
  "mysql-common-derive",
  "num-bigint",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rust_decimal",
  "saturating",
@@ -2797,7 +2768,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "stringprep",
 ]
@@ -3166,36 +3137,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3205,16 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3223,16 +3162,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -3332,6 +3262,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,7 +3374,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -3489,6 +3448,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,6 +3527,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring 0.17.3",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "seahash"
@@ -3720,6 +3722,18 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlformat"
@@ -3968,7 +3982,6 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6e2bf3e4b5be181a2a2ceff4b9b12e2684010d436a6958bd564fbc8094d44d"
 dependencies = [
- "async-native-tls",
  "async-trait",
  "asynchronous-codec",
  "bigdecimal",
@@ -3982,13 +3995,15 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pretty-hex",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "thiserror",
  "time",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "uuid",
- "winauth",
 ]
 
 [[package]]
@@ -4100,11 +4115,22 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.8.5",
+ "rand",
  "socket2",
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -4216,7 +4242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -4302,6 +4328,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,12 +4395,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4472,6 +4504,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.3",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "whoami"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4511,19 +4553,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winauth"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f820cd208ce9c6b050812dc2d724ba98c6c1e9db5ce9b3f58d925ae5723a5e6"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "md5",
- "rand 0.7.3",
- "winapi",
-]
 
 [[package]]
 name = "windows"

--- a/prqlc/prql-compiler/Cargo.toml
+++ b/prqlc/prql-compiler/Cargo.toml
@@ -52,7 +52,7 @@ mysql = {version = "24", optional = true}
 pg_bigdecimal = {version = "0.1", optional = true}
 postgres = {version = "0.19", optional = true}
 rusqlite = {version = "0.29.0", optional = true, features = ["bundled", "csvtab"]}
-tiberius = {version = "0.12.2", optional = true, features = ["sql-browser-tokio", "bigdecimal", "time"]}
+tiberius = {version = "0.12.2", optional = true, default-features = false, features = ["sql-browser-tokio", "bigdecimal", "time", "rustls", "tds73"]}
 tokio = {version = "1", optional = true, features = ["full"]}
 tokio-util = {version = "0.7", optional = true, features = ["compat"]}
 

--- a/prqlc/prql-compiler/Cargo.toml
+++ b/prqlc/prql-compiler/Cargo.toml
@@ -43,8 +43,8 @@ strum_macros = "0.25.3"
 serde_yaml = {version = "0.9", optional = true}
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-# For integration tests. These are gated by the `test-dbs` feature, rather than
-# dev-dependencies, because dev-dependencies can't be optional.
+# For integration tests. These are gated by the `test-dbs` and `test-dbs-external` features,
+# rather than dev-dependencies, because dev-dependencies can't be optional.
 chrono = {version = "0.4", optional = true, features = [], default-features = false}
 duckdb = {version = "0.9.2", optional = true, features = ["bundled", "chrono"]}
 glob = {version = "0.3.1", optional = true}

--- a/prqlc/prql-compiler/tests/integration/dbs/README.md
+++ b/prqlc/prql-compiler/tests/integration/dbs/README.md
@@ -13,8 +13,8 @@ cargo test --features=test-dbs
 
 ## External DBs
 
-To run tests against external databases — currently Postgres, MySQL, SQL Server
-and ClickHouse are tested — we use `docker compose`:
+To run tests against external databases — currently Postgres, MySQL, SQL Server,
+ClickHouse and GlareDB are tested — we use `docker compose`:
 
 1. Run `docker compose up` (may take a while on the first time):
 
@@ -26,14 +26,29 @@ and ClickHouse are tested — we use `docker compose`:
 2. Run the tests:
 
    ```sh
-   cargo test --features=test-dbs-external
+   cargo test --features=test-dbs-external --no-capture
    ```
+
+   The `--no-capture` option is definitely not required but is practical to see
+   all the dialects tested per query.
 
 3. After you're done, stop the containers and remove local images and volumes:
 
    ```sh
    docker compose down -v --rmi local
    ```
+
+Note: if you're on an M1 and your MSSQL docker container doesn't run, refer to
+[this comment](https://github.com/microsoft/mssql-docker/issues/668#issuecomment-1436802153)
+
+## Tested databases
+
+Tests are by default run on all the DBs with `SupportLevel::Supported`.
+
+If you also want to test on a DB that is not yet at this support level like
+`MSSQL`, simply add `# mssql:test` on top of your query.\
+If you want to ignore one of the supported DBs like `sqlite`, simply add `# sqlite:skip`
+on top of your query.
 
 ## Data
 

--- a/prqlc/prql-compiler/tests/integration/queries.rs
+++ b/prqlc/prql-compiler/tests/integration/queries.rs
@@ -162,6 +162,7 @@ mod results {
 
             let dialect = con.cfg.dialect;
 
+            println!("Executing {test_name} for {dialect}");
             let rows = con
                 .run_query(&prql)
                 .context(format!("Executing {test_name} for {dialect}"))


### PR DESCRIPTION
## Feedbacks on integration tests

When I first started to work on integration tests, I didn't know there was the great
`prqlc/prql-compiler/tests/integration/dbs/README.md` file that explains clearly how to run those tests.
I first had an issue by running
```shell
cargo nextest run --all-targets -F "test-dbs,test-dbs-external
```
and got bitten by the "it doesn't handle multiple processes"
Fortunately I saw the message
```
# test-dbs runs database setup when the connection is established,
# and because nextest runs test in separate processes, this happens on every test.
# To prevent mutliple setups running at once, we set max-threads to 1.
```
in `nextest.toml` and managed to run them properly

I also had issues with just starting the `mssql` container but this is due to my M1 and I found this issue that was already
linked in the docker-compose (https://github.com/microsoft/mssql-docker/issues/668#issuecomment-1436802153)
Thank you for that!

Once MSSQL was up and running, I thought everything would work. I was wrong 😬

The first time I run the test I got a timeout on the MSSQL server

```shell
test queries::results::aggregation has been running for over 60 seconds
.test queries::results::aggregation ... FAILED

failures:

---- queries::results::aggregation stdout ----
thread 'queries::results::aggregation' panicked at 'called `Result::unwrap()` on an `Err` value: Tls("connection closed via error")', prqlc/prql-compiler/tests/integration/dbs/protocol/mssql.rs:32:18
```

I also got once the error
```shell
thread 'queries::results::aggregation' panicked at 'Failed to insert row: no such table: albums.my

Caused by:
    Error code 1: SQL error or missing database
```

I don't remember if I stopped a test during execution or whatever but I had to dig a bit in the code
that it's just a side effect of the MySQL test that copies the csv files into `xyz.my.csv`.
And since they are git ignored, you don't see anything in a `git status`.
Anyway easy fix:

```shell
find . -type f -name '*.my.csv' -delete
```

### So how do we fix the MSSQL timeout error?

It appears there is an issue with the TLS handshake on M1 (see https://github.com/prisma/tiberius/issues/65)
I propose the switch to `rustls` since it doesn't require headers or runtime libraries.
(it conflicts with `async_native_tls` and is in the default features henece the need to deactive
those: see https://github.com/prisma/tiberius/issues/317)

And when I went with this approach the handshake was done! Great so it works finally!!!
OR NOT

```
error[E0277]: the trait bound `BigDecimal: tiberius::FromSql<'_>` is not satisfied
   --> prqlc/prql-compiler/tests/integration/dbs/protocol/mssql.rs:64:48
    |
64  | ...                   .get::<BigDecimal, usize>(i)
    |                                          ^^^^^ the trait `tiberius::FromSql<'_>` is not implemented for `BigDecimal`
    |
    = help: the following other types implement trait `tiberius::FromSql<'a>`:
              bool
              i16
              i32
              i64
              u8
              f32
              f64
              Uuid
            and 5 others
note: required by a bound in `tiberius::Row::get`
   --> /Users/ericjolibois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tiberius-0.12.2/src/row.rs:375:12
    |
373 |     pub fn get<'a, R, I>(&'a self, idx: I) -> Option<R>
    |            --- required by a bound in this associated function
374 |     where
375 |         R: FromSql<'a>,
    |            ^^^^^^^^^^^ required by this bound in `Row::get`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `prql-compiler` (test "integration") due to previous error
```

Ahhhh right! By setting `default-features = false`, I forgot to add `tds73` which is also enabled by default
Annnnnnd TADA!

### Improvements

When you run a test and see
```console
test queries::compile::math ... ok
```
you don't know which dialects have been tested
And with a little `dbg!()` macro you see that `MSSQL` is not tested by default!

```console
[prqlc/prql-compiler/tests/integration/queries.rs:164] test_name = "math"
[prqlc/prql-compiler/tests/integration/queries.rs:164] dialect = DuckDb
[prqlc/prql-compiler/tests/integration/queries.rs:164] test_name = "math"
[prqlc/prql-compiler/tests/integration/queries.rs:164] dialect = Postgres
[prqlc/prql-compiler/tests/integration/queries.rs:164] test_name = "math"
[prqlc/prql-compiler/tests/integration/queries.rs:164] dialect = MySql
[prqlc/prql-compiler/tests/integration/queries.rs:164] test_name = "math"
[prqlc/prql-compiler/tests/integration/queries.rs:164] dialect = ClickHouse
[prqlc/prql-compiler/tests/integration/queries.rs:164] test_name = "math"
[prqlc/prql-compiler/tests/integration/queries.rs:164] dialect = GlareDb
```
So you NEED to add `# mssql:test` on top of the file to run it. That's weird compared to the others...
But then I looked at the code and saw that level is "UNSUPPORTED". So makes sense but again you need to know to know ;)

And the second point is just to improve/update a bit the documentation

-----------------------------------------------------------------------------------

So I would go with those changes in this PR if you're ok with it

- [x] make integration tests pass on M1 (for that I would like to know if it doesn't break anything for tests on Linux)
- [x] improve documentation