### PR TITLE
test: Run in-process DB tests with `test-dbs-external`

### DIFF
--- a/prqlc/prql-compiler/tests/integration/dbs/mod.rs
+++ b/prqlc/prql-compiler/tests/integration/dbs/mod.rs
@@ -41,10 +41,8 @@ pub struct ConnectionCfg {
 impl DbConnection {
     pub fn new(cfg: ConnectionCfg) -> Option<DbConnection> {
         let protocol = match &cfg.protocol {
-            #[cfg(feature = "test-dbs")]
             DbProtocol::DuckDb => protocol::duckdb::init(),
 
-            #[cfg(feature = "test-dbs")]
             DbProtocol::SQLite => protocol::sqlite::init(),
 
             #[cfg(feature = "test-dbs-external")]

--- a/prqlc/prql-compiler/tests/integration/dbs/protocol/mod.rs
+++ b/prqlc/prql-compiler/tests/integration/dbs/protocol/mod.rs
@@ -1,4 +1,5 @@
-#[cfg(feature = "test-dbs")]
+#![cfg(any(feature = "test-dbs", feature = "test-dbs-external"))]
+
 pub mod duckdb;
 
 #[cfg(feature = "test-dbs-external")]
@@ -10,7 +11,6 @@ pub mod mysql;
 #[cfg(feature = "test-dbs-external")]
 pub mod postgres;
 
-#[cfg(feature = "test-dbs")]
 pub mod sqlite;
 
 use anyhow::Result;


### PR DESCRIPTION
I think this might be causing the issues at https://github.com/PRQL/prql/pull/3951 — we're not running the in-process tests at the moment, because we're only enabling the `test-dbs-external` feature.

This PR allows runs all db tests with the `test-dbs-external` feature.