### PR TITLE
fix: ensure parentheses are set for sub expr

### DIFF
--- a/prqlc/prql-compiler/src/sql/operators.rs
+++ b/prqlc/prql-compiler/src/sql/operators.rs
@@ -89,7 +89,10 @@ pub(super) fn translate_operator(
                 let arg = translate_operand(
                     arg,
                     false,
-                    required_strength,
+                    // for recursive calls, we increase the binding strength of sub-expressions
+                    // so that a / (b / c), translated as Expr { Expr a, /, Expr { Expr b, /, Expr c } }
+                    // is translated as a / (b / c) instead of a / b / c
+                    required_strength + 1,
                     super::gen_expr::Associativity::Both,
                     ctx,
                 )?;

--- a/prqlc/prql-compiler/tests/integration/queries/basic_operations.prql
+++ b/prqlc/prql-compiler/tests/integration/queries/basic_operations.prql
@@ -1,0 +1,12 @@
+# mssql:test
+# sqlite:skip
+# mysql:skip
+from [{
+  x=0
+}]
+derive {
+  a = 10 - (10 - 2),
+  b = 10 - (10 + 2),
+  c = 10 / (10 / 2),
+  d = 10 / (10 * 2),
+}

--- a/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__compile__basic_operations.snap
+++ b/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__compile__basic_operations.snap
@@ -1,0 +1,18 @@
+---
+source: prqlc/prql-compiler/tests/integration/queries.rs
+expression: "# mssql:test\nfrom [{\n  x=0\n}]\nderive {\n  a = 10 - (10 - 2),\n  b = 10 - (10 + 2),\n  c = 10 / (10 / 2),\n  d = 10 / (10 * 2),\n}\n"
+input_file: prqlc/prql-compiler/tests/integration/queries/basic_operations.prql
+---
+WITH table_0 AS (
+  SELECT
+    0 AS x
+)
+SELECT
+  x,
+  10 - (10 - 2) AS a,
+  10 - (10 + 2) AS b,
+  10 / (10 / 2) AS c,
+  10 / (10 * 2) AS d
+FROM
+  table_0
+

--- a/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__compile__pipelines.snap
+++ b/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__compile__pipelines.snap
@@ -12,7 +12,7 @@ WITH table_0 AS (
     tracks
   WHERE
     REGEXP(name, 'Love')
-    AND milliseconds / 1000 / 60 BETWEEN 3 AND 4
+    AND (milliseconds / 1000) / 60 BETWEEN 3 AND 4
   ORDER BY
     track_id
   LIMIT

--- a/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__fmt__basic_operations.snap
+++ b/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__fmt__basic_operations.snap
@@ -1,0 +1,13 @@
+---
+source: prqlc/prql-compiler/tests/integration/queries.rs
+expression: "# mssql:test\nfrom [{\n  x=0\n}]\nderive {\n  a = 10 - (10 - 2),\n  b = 10 - (10 + 2),\n  c = 10 / (10 / 2),\n  d = 10 / (10 * 2),\n}\n"
+input_file: prqlc/prql-compiler/tests/integration/queries/basic_operations.prql
+---
+from [{x = 0}]
+derive {
+  a = 10 - (10 - 2),
+  b = 10 - (10 + 2),
+  c = 10 / (10 / 2),
+  d = 10 / (10 * 2),
+}
+

--- a/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__results__basic_operations.snap
+++ b/prqlc/prql-compiler/tests/integration/snapshots/integration__queries__results__basic_operations.snap
@@ -1,0 +1,6 @@
+---
+source: prqlc/prql-compiler/tests/integration/queries.rs
+expression: "# mssql:skip\n# sqlite:skip\n# glaredb:skip\n# clickhouse:skip\n# mysql:skip\n# postgres:skip\nfrom [{\n  x=0\n}]\nderive {\n  a = 10 - (10 - 2),\n  b = 10 - (10 + 2),\n  c = 10 / (10 / 2),\n  d = 10 / (10 * 2),\n}\n"
+input_file: prqlc/prql-compiler/tests/integration/queries/basic_operations.prql
+---
+0,2,-2,2,0.5

--- a/prqlc/prql-compiler/tests/integration/sql.rs
+++ b/prqlc/prql-compiler/tests/integration/sql.rs
@@ -276,7 +276,7 @@ fn test_precedence() {
     SELECT
       *,
       (temp_f - 32) / 1.8 AS temp_c,
-      (temp_f - 32) / 1.8 * 9 / 5 AS temp_f,
+      ((temp_f - 32) / 1.8 * 9) / 5 AS temp_f,
       temp_x + 9 - 5 AS temp_z
     FROM
       x
@@ -319,7 +319,7 @@ fn test_precedence() {
       a > 0 AS gtz,
       NOT a > 0 AS ltz,
       NOT a > 0
-      AND NOT NOT a > 0 AS zero,
+      AND NOT (NOT a > 0) AS zero,
       NOT a = b AS is_not_equal,
       NOT a > b AS is_not_gt,
       (NOT a) IS NULL AS negated_is_null_1,
@@ -356,7 +356,7 @@ fn test_precedence() {
       c + a - b,
       c - d - (a - b),
       c + d + a - b,
-      a / b * c,
+      a / (b * c),
       y - z AS x,
       -(y - z)
     FROM
@@ -1028,6 +1028,27 @@ fn test_numbers() {
       5.0 AS z
     FROM
       numbers
+    "###);
+}
+
+#[test]
+fn test_parentheses() {
+    assert_display_snapshot!((compile(r#"
+    from foo
+    derive {
+      a = 10 - (10 - 2),
+      b = 10 - (10 + 2),
+      c = 10 / (10 / 2),
+      d = 10 / (10 * 2),
+    }"#).unwrap()), @r###"
+    SELECT
+      *,
+      10 - (10 - 2) AS a,
+      10 - (10 + 2) AS b,
+      10 / (10 / 2) AS c,
+      10 / (10 * 2) AS d
+    FROM
+      foo
     "###);
 }
 

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__wrapping-lines__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__wrapping-lines__1.snap
@@ -1,11 +1,19 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from tracks\n# This would be a really long line without being able to split it:\nselect listening_time_years = (spotify_plays + apple_music_plays + pandora_plays)\n# * length_seconds\n# Actually it's `length_s` I think:\n\\ * length_s\n#   min  hour day  year\n\\ / 60 / 60 / 24 / 365\n"
+expression: "from tracks\n# This would be a really long line without being able to split it:\nselect listening_time_years = (spotify_plays + apple_music_plays + pandora_plays)\n# We can toggle between lines when developing:\n# \\ * length_seconds\n\\ * length_s\n#   min  hour day  year\n\\ / 60 / 60 / 24 / 365\n"
 ---
 SELECT
   (
-    spotify_plays + apple_music_plays + pandora_plays
-  ) * length_s / 60 / 60 / 24 / 365 AS listening_time_years
+    (
+      (
+        (
+          (
+            spotify_plays + apple_music_plays + pandora_plays
+          ) * length_s
+        ) / 60
+      ) / 60
+    ) / 24
+  ) / 365 AS listening_time_years
 FROM
   tracks
 

--- a/web/website/data/examples/expressions.yaml
+++ b/web/website/data/examples/expressions.yaml
@@ -12,7 +12,7 @@ sql: |
     *,
     started + unfinished AS finished,
     (started + unfinished) / started AS fin_share,
-    (started + unfinished) / started / (1 - (started + unfinished) / started)
+    ((started + unfinished) / started) / (1 - (started + unfinished) / started)
      AS fin_ratio
   FROM
     track_plays

--- a/web/website/data/examples/functions.yaml
+++ b/web/website/data/examples/functions.yaml
@@ -6,6 +6,6 @@ prql: |
   select temp_f = (fahrenheit_from_celsius temp_c)
 sql: |
   SELECT
-    temp_c * 9 / 5 + 32 AS temp_f
+    (temp_c * 9) / 5 + 32 AS temp_f
   FROM
     weather


### PR DESCRIPTION
Proposal for #3963
I don't know if this is the right fix, there is maybe a better way.
I understand that it may add some unneeded parentheses but honestly I feel like it's way more important to have the right result than the cleanest query possible.
+ sometimes some extra parentheses make stuff more explicit (for example when you choose a column that is already an operation that you divide)