### PR TITLE
docs: Fix confusion: "celsius_to_fahrenhent" is more clear ...

### DIFF
--- a/web/website/data/examples/functions.yaml
+++ b/web/website/data/examples/functions.yaml
@@ -1,9 +1,9 @@
 label: Functions
 prql: |
-  let fahrenheit_from_celsius = temp -> temp * 9/5 + 32
+  let celsius_to_fahrenheit = temp -> temp * 9/5 + 32
 
   from weather
-  select temp_f = (fahrenheit_from_celsius temp_c)
+  select temp_f = (celsius_to_fahrenheit temp_c)
 sql: |
   SELECT
     temp_c * 9 / 5 + 32 AS temp_f


### PR DESCRIPTION
I was massively confused because the documentation has two similarly-named functions that do the opposite things. Their names were:

* `fahrenheit_to_celsius` and
* `fahrenheit_from_celsius`

My poor brain was struggling to understand why the formulas were different. Renaming the latter (using F -> C) makes more sense.