### PR TITLE
feat: infer array to be of type of union of items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 **Features**:
 
+- Infer the type of array literals to be the union of types of its items.
+  (@aljazerzen, #3989)
+
 **Fixes**:
 
 - Do not compile to `DISTINCT ON` when `take n` is used with `group` for the

--- a/prqlc/prql-compiler/src/semantic/resolver/expr.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/expr.rs
@@ -197,27 +197,6 @@ impl PlFold for Resolver<'_> {
                 }
             }
 
-            ExprKind::Array(exprs) => {
-                let mut exprs = self.fold_exprs(exprs)?;
-
-                // validate that all elements have the same type
-                let mut expected_ty: Option<&Ty> = None;
-                for expr in &mut exprs {
-                    if expr.ty.is_some() {
-                        if expected_ty.is_some() {
-                            let who = || Some("array".to_string());
-                            self.validate_expr_type(expr, expected_ty, &who)?;
-                        }
-                        expected_ty = expr.ty.as_ref();
-                    }
-                }
-
-                Expr {
-                    kind: ExprKind::Array(exprs),
-                    ..node
-                }
-            }
-
             item => Expr {
                 kind: fold_expr_kind(self, item)?,
                 ..node

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline-2.snap
@@ -36,14 +36,14 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
                     - - ~
                       - kind:
                           Primitive: Int
-                        span: "2:4160-4163"
+                        span: "2:4128-4131"
                         name: ~
                     - - ~
                       - kind:
                           Primitive: Float
-                        span: "2:4167-4172"
+                        span: "2:4135-4140"
                         name: ~
-                span: "2:4160-4172"
+                span: "2:4128-4140"
                 name: ~
             - Literal:
                 Integer: 1

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__test__functions_pipeline.snap
@@ -24,13 +24,13 @@ expression: "resolve_derive(r#\"\n            from a\n            derive one = (
         - - ~
           - kind:
               Primitive: Int
-            span: "2:4160-4163"
+            span: "2:4128-4131"
             name: ~
         - - ~
           - kind:
               Primitive: Float
-            span: "2:4167-4172"
+            span: "2:4135-4140"
             name: ~
-    span: "2:4160-4172"
+    span: "2:4128-4140"
     name: ~
 

--- a/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
+++ b/prqlc/prql-compiler/src/semantic/resolver/snapshots/prql_compiler__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
@@ -53,14 +53,14 @@ TransformCall:
                   - - ~
                     - kind:
                         Primitive: Float
-                      span: "2:4225-4230"
+                      span: "2:4193-4198"
                       name: ~
                   - - ~
                     - kind:
                         Singleton: "Null"
-                      span: "2:4234-4238"
+                      span: "2:4202-4206"
                       name: ~
-              span: "2:4225-4238"
+              span: "2:4193-4206"
               name: ~
         ty:
           kind:
@@ -72,14 +72,14 @@ TransformCall:
                         - - ~
                           - kind:
                               Primitive: Float
-                            span: "2:4225-4230"
+                            span: "2:4193-4198"
                             name: ~
                         - - ~
                           - kind:
                               Singleton: "Null"
-                            span: "2:4234-4238"
+                            span: "2:4202-4206"
                             name: ~
-                    span: "2:4225-4238"
+                    span: "2:4193-4206"
                     name: ~
           span: ~
           name: ~
@@ -146,7 +146,7 @@ TransformCall:
                           name: ~
                   span: "2:2042-2053"
                   name: tuple
-          span: "2:3052-3067"
+          span: "2:3020-3035"
           name: ~
     ty:
       kind:
@@ -209,7 +209,7 @@ TransformCall:
                                 name: ~
                         span: "2:2042-2053"
                         name: tuple
-                span: "2:3052-3067"
+                span: "2:3020-3035"
                 name: ~
       span: ~
       name: ~
@@ -276,7 +276,7 @@ ty:
                                 name: ~
                         span: "2:2042-2053"
                         name: tuple
-                span: "2:3052-3067"
+                span: "2:3020-3035"
                 name: ~
           - Single:
               - ~
@@ -285,14 +285,14 @@ ty:
                     - - ~
                       - kind:
                           Primitive: Float
-                        span: "2:4225-4230"
+                        span: "2:4193-4198"
                         name: ~
                     - - ~
                       - kind:
                           Singleton: "Null"
-                        span: "2:4234-4238"
+                        span: "2:4202-4206"
                         name: ~
-                span: "2:4225-4238"
+                span: "2:4193-4206"
                 name: ~
       span: ~
       name: ~

--- a/prqlc/prql-compiler/src/semantic/resolver/types.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/types.rs
@@ -71,22 +71,9 @@ impl Resolver<'_> {
                 let mut intersection = None;
                 for item in items {
                     let item_ty = Resolver::infer_type(item)?;
-
-                    if let Some(item_ty) = item_ty {
-                        if let Some(intersection) = &intersection {
-                            if intersection != &item_ty {
-                                // TODO: compute type intersection instead
-                                return Ok(None);
-                            }
-                        } else {
-                            intersection = Some(item_ty);
-                        }
-                    }
+                    intersection = maybe_type_intersection(intersection, item_ty);
                 }
-                let Some(items_ty) = intersection else {
-                    // TODO: return Array(Infer) instead of Infer
-                    return Ok(None);
-                };
+                let items_ty = intersection.unwrap_or_else(|| Ty::new(TyKind::Any));
                 TyKind::Array(Box::new(items_ty))
             }
 
@@ -638,11 +625,14 @@ where
     F: Fn() -> Option<String>,
 {
     fn display_ty(ty: &Ty) -> String {
-        if ty.name.is_none() && ty.kind.is_tuple() {
-            "a tuple".to_string()
-        } else {
-            format!("type `{}`", write_ty(ty))
+        if ty.name.is_none() {
+            if let TyKind::Tuple(fields) = &ty.kind {
+                if fields.len() == 1 && fields[0].is_wildcard() {
+                    return "a tuple".to_string();
+                }
+            }
         }
+        format!("type `{}`", write_ty(ty))
     }
 
     let who = who();
@@ -913,6 +903,7 @@ fn type_intersection_of_tuples(a: Vec<TupleField>, b: Vec<TupleField>) -> Ty {
             }
             (Some((a_name, a_ty)), Some((b_name, b_ty))) => {
                 let name = match (a_name, b_name) {
+                    (Some(a), Some(b)) if a == b => Some(a),
                     (None, None) | (Some(_), Some(_)) => None,
                     (None, Some(n)) | (Some(n), None) => Some(n),
                 };

--- a/prqlc/prql-compiler/src/semantic/resolver/types.rs
+++ b/prqlc/prql-compiler/src/semantic/resolver/types.rs
@@ -68,12 +68,15 @@ impl Resolver<'_> {
                 ty_tuple_kind(ty_fields)
             }
             ExprKind::Array(items) => {
-                let mut intersection = None;
+                let mut variants = Vec::with_capacity(items.len());
                 for item in items {
                     let item_ty = Resolver::infer_type(item)?;
-                    intersection = maybe_type_intersection(intersection, item_ty);
+                    if let Some(item_ty) = item_ty {
+                        variants.push((None, item_ty));
+                    }
                 }
-                let items_ty = intersection.unwrap_or_else(|| Ty::new(TyKind::Any));
+                let items_ty = Ty::new(TyKind::Union(variants));
+                let items_ty = normalize_type(items_ty);
                 TyKind::Array(Box::new(items_ty))
             }
 

--- a/prqlc/prql-compiler/src/semantic/std.prql
+++ b/prqlc/prql-compiler/src/semantic/std.prql
@@ -73,7 +73,7 @@ let from = func
   -> <relation> internal from
 
 let select = func
-  columns <scalar || tuple>
+  columns <anytype>
   tbl <relation>
   -> <relation> internal select
 
@@ -83,17 +83,17 @@ let filter = func
   -> <relation> internal filter
 
 let derive = func
-  columns <scalar || tuple>
+  columns <anytype>
   tbl <relation>
   -> <relation> internal derive
 
 let aggregate = func
-  columns <scalar || tuple>
+  columns <anytype>
   tbl <relation>
   -> <relation> internal aggregate
 
 let sort = func
-  by <scalar || tuple>
+  by <anytype>
   tbl <relation>
   -> <relation> internal sort
 

--- a/prqlc/prql-compiler/tests/integration/sql.rs
+++ b/prqlc/prql-compiler/tests/integration/sql.rs
@@ -4454,20 +4454,15 @@ fn test_into() {
 }
 
 #[test]
-fn test_array() {
-    assert_display_snapshot!(compile(r#"
+fn test_array_01() {
+    compile(
+        r#"
     let a = [1, 2, false]
-    "#).unwrap_err(),
-        @r###"
-    Error:
-       ╭─[:2:20]
-       │
-     2 │     let a = [1, 2, false]
-       │                    ──┬──
-       │                      ╰──── array expected type `int`, but found type `bool`
-    ───╯
-    "###
-    );
+
+    from x
+    "#,
+    )
+    .unwrap();
 
     assert_snapshot!(compile(r#"
     let my_relation = [
@@ -4504,6 +4499,30 @@ fn test_array() {
       b
     "###
     );
+}
+
+#[test]
+fn test_array_02() {
+    assert_snapshot!(compile(r#"
+    from [
+      {x = null},
+      {x = '1'},
+    ]
+    "#)
+    .unwrap(), @r###"
+    WITH table_0 AS (
+      SELECT
+        NULL AS x
+      UNION
+      ALL
+      SELECT
+        '1' AS x
+    )
+    SELECT
+      x
+    FROM
+      table_0
+    "###);
 }
 
 #[test]

--- a/prqlc/prqlc-ast/src/types.rs
+++ b/prqlc/prqlc-ast/src/types.rs
@@ -6,7 +6,7 @@ use crate::{Ident, Span};
 
 use super::Literal;
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ty {
     pub kind: TyKind,
 
@@ -154,11 +154,5 @@ impl From<TyFunc> for TyKind {
 impl From<Literal> for TyKind {
     fn from(value: Literal) -> Self {
         TyKind::Singleton(value)
-    }
-}
-
-impl std::fmt::Debug for Ty {
-    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Ok(())
     }
 }


### PR DESCRIPTION
Closes #2822

Behavior before this commit:
```
['hello', null] -> array of text, type error at second element
[false, 'hello'] -> array of bool, type error at second element
```

Behavior after:
```
['hello', null] -> array of text || null
[false, 'hello'] -> array of bool || text
```