### PR TITLE
feat: type difference

### DIFF
--- a/prqlc/prql-compiler/src/codegen/types.rs
+++ b/prqlc/prql-compiler/src/codegen/types.rs
@@ -68,6 +68,11 @@ impl WriteSource for TyKind {
                 Some(r)
             }
             Any => Some("anytype".to_string()),
+            Difference { base, exclude } => {
+                let base = base.write(opt.clone())?;
+                let exclude = exclude.write(opt.clone())?;
+                Some(format!("{base} - {exclude}"))
+            }
         }
     }
 }

--- a/prqlc/prql-compiler/src/ir/pl/fold.rs
+++ b/prqlc/prql-compiler/src/ir/pl/fold.rs
@@ -346,6 +346,10 @@ pub fn fold_type<T: ?Sized + PlFold>(fold: &mut T, ty: Ty) -> Result<Ty> {
                 })
                 .transpose()?,
             ),
+            TyKind::Difference { base, exclude } => TyKind::Difference {
+                base: Box::new(fold.fold_type(*base)?),
+                exclude: Box::new(fold.fold_type(*exclude)?),
+            },
             TyKind::Any | TyKind::Ident(_) | TyKind::Primitive(_) | TyKind::Singleton(_) => ty.kind,
         },
         span: ty.span,

--- a/prqlc/prqlc-ast/src/types.rs
+++ b/prqlc/prqlc-ast/src/types.rs
@@ -42,6 +42,9 @@ pub enum TyKind {
     /// Type of every possible value. Super type of all other types.
     /// The breaker of chains. Mother of types.
     Any,
+
+    /// Type that is the largest subtype of `base` while not a subtype of `exclude`.
+    Difference { base: Box<Ty>, exclude: Box<Ty> },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, EnumAsInner)]
@@ -99,6 +102,10 @@ impl Ty {
 
     pub fn never() -> Self {
         Ty::new(TyKind::Union(Vec::new()))
+    }
+
+    pub fn is_never(&self) -> bool {
+        self.kind.as_union().map_or(false, |x| x.is_empty())
     }
 
     pub fn as_relation(&self) -> Option<&Vec<TupleField>> {

--- a/web/book/src/reference/spec/type-system.md
+++ b/web/book/src/reference/spec/type-system.md
@@ -236,7 +236,7 @@ A & B = (), where:
  - A and B are primitive, singleton, tuple or array
  - and A != B
 
-A - (A | B) = (), where
+A - (A | B) = ()
 
 A | () = A
 ```

--- a/web/book/src/reference/spec/type-system.md
+++ b/web/book/src/reference/spec/type-system.md
@@ -225,9 +225,9 @@ select [1.4, false, "foo"]
 
 ### Normalization
 
-Say we have a type expression E, composed of possibly many operators.
-To minimize this expression, we employ process of normalization,
-which is meant to take advantage of the following equalities:
+Say we have a type expression E, composed of possibly many operators. To
+minimize this expression, we employ process of normalization, which is meant to
+take advantage of the following equalities:
 
 ```
 A & A = A
@@ -242,8 +242,8 @@ A | () = A
 ```
 
 We can see that intersection and difference are the main simplifying operations,
-which is why the normalization 'sinks them into the expression',
-to maximize the number of their interactions.
+which is why the normalization 'sinks them into the expression', to maximize the
+number of their interactions.
 
 Rules for normalization during intersection:
 

--- a/web/book/src/reference/spec/type-system.md
+++ b/web/book/src/reference/spec/type-system.md
@@ -223,6 +223,62 @@ of entries, which can be of different types. Thus, it is a tuple.
 select [1.4, false, "foo"]
 ```
 
+### Normalization
+
+Say we have a type expression E, composed of possibly many operators.
+To minimize this expression, we employ process of normalization,
+which is meant to take advantage of the following equalities:
+
+```
+A & A = A
+
+A & B = (), where:
+ - A and B are primitive, singleton, tuple or array
+ - and A != B
+
+A - (A | B) = (), where
+
+A | () = A
+```
+
+We can see that intersection and difference are the main simplifying operations,
+which is why the normalization 'sinks them into the expression',
+to maximize the number of their interactions.
+
+Rules for normalization during intersection:
+
+```
+(A | B)      & C            = (A & C) | (B & C)
+A            & (B | C)      = (A & B) | (A & C)
+
+(A - B)      & C            = (A & C) - B
+A            & (B - C)      = (A & B) - C
+
+{A, B}       & {C, D}       = {A & C, B & D}
+[A]          & [B]          = [A & B]
+
+A            & A            = A
+A            & B            = never
+```
+
+Rules for normalization during difference:
+
+```
+(A | B)      - C            = (A - C) | (B - C)
+(A - B)      - C            = A - (B | C)
+
+{A, B}       - {C, D}       = {A - C, B - D}
+{A, B}       - C            = {A, B}
+A            - {B, C}       = A
+
+[A]          - [B]          = [A - B]
+[A]          - B            = [A]
+A            - [B]          = A
+
+A            - (B - C)      = A & not (B & not C) = A & (not B | C) = (A & not B) | (A & C) = (A - B) | (A & C)
+A            - (A | B)      = ()
+```
+
 ## Physical layout
 
 _Logical type_ is user-facing the notion of a type that is the building block of


### PR DESCRIPTION
For now this in an internal change without language changes.

It implements ability to express type `T - U` which contains all values of `T` that are not also in `U`.

This is needed to replace behavior provided by current lineage implementation with the type system.

Idea is that for a relation that we don't have knowledge of, we'll introduce a generic type argument:
```
from x
```
will infer:
```
module default_db {
  let x: [T]
}
```

In the case where we exclude a column from a relation, we will have to infer:
```
from x
select !{a}
```
... to have the type of `[T - {a = U}]`.
