### PR TITLE
ci: bump actions/upload-artifact and actions/download-artifact from 3 to 4

### DIFF
--- a/.github/actions/build-prql-python/action.yaml
+++ b/.github/actions/build-prql-python/action.yaml
@@ -36,7 +36,7 @@ runs:
           --release -o target/python --universal2 -m
           prqlc/bindings/python/Cargo.toml
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ runner.os }}-${{ inputs.target }}
         path: target/python

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -89,7 +89,7 @@ runs:
         7z a "../../../${ARTIFACT_NAME}" prqlc.exe ../../../LICENSE README.md
 
     - name: Upload prqlc
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: prqlc-${{ inputs.target }}
         path: ${{ env.ARTIFACT_NAME }}

--- a/.github/actions/time-compilation/action.yaml
+++ b/.github/actions/time-compilation/action.yaml
@@ -29,7 +29,7 @@ runs:
       with:
         command: build
         args: --timings --all-targets
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: cargo-timing.html
         path: target/cargo-timings/cargo-timing-*.html

--- a/.github/workflows/lint-megalinter.yaml
+++ b/.github/workflows/lint-megalinter.yaml
@@ -41,7 +41,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MegaLinter reports
           path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
       contents: write
     steps:
       - name: Download a Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: prqlc-${{ matrix.target }}
       - name: Copy files into .deb package
@@ -126,9 +126,9 @@ jobs:
 
             PRQL is a modern language for transforming data — a simple,
             powerful, pipelined SQL replacement.
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: artifact-deb
+          name: prqlc-deb-${{ matrix.target }}
           path: |
             ./*.deb
       - name: Release
@@ -150,7 +150,7 @@ jobs:
       contents: write
     steps:
       - name: Download a Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: prqlc-${{ matrix.target }}
       - name: Copy files into .rpm package
@@ -185,9 +185,9 @@ jobs:
             PRQL is a modern language for transforming data — a simple,
             powerful, pipelined SQL replacement.
           license: Apache-2.0
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: artifact-rpm
+          name: prqlc-rpm-${{ matrix.target }}
           path: |
             ./*.rpm
             !./*-debuginfo-*.rpm
@@ -244,9 +244,10 @@ jobs:
     needs: [build-python-wheels]
     if: github.event_name == 'release'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          name: wheels-*
+          merge-multiple: true
       - name: Publish to PyPI
         uses: messense/maturin-action@v1
         env:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -25,10 +25,11 @@ jobs:
         uses: ./.github/actions/build-prql-python
         with:
           target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64' || '' }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          name: wheels-*
           path: target/python
+          merge-multiple: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.7"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -419,7 +419,7 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
       - name: Upload code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: cobertura.xml


### PR DESCRIPTION
Sorry, but at this point it seems we can't fix this: the test workflow can be called multiple times with one trigger, and then the uploaded artifact name will be duplicated, resulting in an error.