### PR TITLE
feat(Lezer grammar): Add module

### DIFF
--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -2,6 +2,7 @@ import { styleTags, tags as t } from "@lezer/highlight";
 
 export const prqlHighlight = styleTags({
   "CallExpression/Identifier": t.function(t.variableName),
+  "module": t.moduleKeyword,
   let: t.definitionKeyword,
   case: t.controlKeyword,
   in: t.operatorKeyword,

--- a/grammars/prql-lezer/src/highlight.js
+++ b/grammars/prql-lezer/src/highlight.js
@@ -2,7 +2,7 @@ import { styleTags, tags as t } from "@lezer/highlight";
 
 export const prqlHighlight = styleTags({
   "CallExpression/Identifier": t.function(t.variableName),
-  "module": t.moduleKeyword,
+  module: t.moduleKeyword,
   let: t.definitionKeyword,
   case: t.controlKeyword,
   in: t.operatorKeyword,

--- a/grammars/prql-lezer/src/prql.grammar
+++ b/grammars/prql-lezer/src/prql.grammar
@@ -16,9 +16,11 @@
 
 @skip { space | Comment | Docblock | wrappedLine }
 
-statements { newline* QueryDefinition? Annotation? VariableDeclaration* pipelineStatement? end }
+statements { newline* QueryDefinition? Module? Annotation? VariableDeclaration* pipelineStatement? end? }
 
 QueryDefinition { @specialize<identPart, "prql"> NamedArg+ newline+ }
+
+Module { kw<"module"> Identifier "{" statements "}" }
 
 pipelineStatement { Pipeline (~ambigNewline newline+ | end)}
 
@@ -165,8 +167,6 @@ LambdaParam { identPart TypeDefinition? (":" expression)? }
   Comment { "#" ![\n]* }
   @precedence { Docblock, Comment }
 
-  //op_bin_only { "*" | "/" | "//" | "%" | "!=" | ">=" | "<=" | "~=" | ">" | "<" | "??" | "&&" | "||" }
-  //op_unary { "-" | "+" | "==" }
   end { @eof }
   lineWrap { "\\" }
   wrappedLine { newline+ (Comment newline+)* lineWrap }

--- a/grammars/prql-lezer/test/misc.txt
+++ b/grammars/prql-lezer/test/misc.txt
@@ -177,3 +177,13 @@ let		foo		=		(foo 1)
 ==>
 
 Query(VariableDeclaration(let,VariableName,Equals,NestedPipeline(Pipeline(CallExpression(Identifier,ArgList(Integer))))))
+
+# Module
+
+module foo {
+  let x = -> s"foo()"
+}
+
+==>
+
+Query(Module(module,Identifier,VariableDeclaration(let,VariableName,Equals,Lambda(SString))))


### PR DESCRIPTION
This PR adds support for modules and highlights the `module` keyword using the [`moduleKeyword`](https://lezer.codemirror.net/docs/ref/#highlight.tags.moduleKeyword) Lezer highlighting tag.