### PR TITLE
chore: Update playground `package-lock.json`

### DIFF
--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -33,7 +33,7 @@
       "version": "0.11.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "chai": "^4.3.6",
+        "chai": "^5.0.0",
         "cross-env": "^7.0.3",
         "mocha": "^10.0.0"
       }


### PR DESCRIPTION
I think because the dev dependency of `prql-js` updated, this updates from 'task build-all`
