### PR TITLE
fix: Don't panic on nested `group`

### DIFF
--- a/prqlc/prql-compiler/src/semantic/lowering.rs
+++ b/prqlc/prql-compiler/src/semantic/lowering.rs
@@ -943,11 +943,11 @@ impl Lowerer {
                 if let Some((cid, _)) = input_columns.get(&name) {
                     *cid
                 } else {
-                    return Err(Error::new(Reason::Bug).into());
+                    panic!("cannot find cid by id={id} and name={name:?}");
                 }
             }
             None => {
-                return Err(Error::new(Reason::Bug).into());
+                return Err(Error::new(Reason::Bug { issue: Some(3870) }))?;
             }
         };
 

--- a/prqlc/prql-compiler/src/semantic/lowering.rs
+++ b/prqlc/prql-compiler/src/semantic/lowering.rs
@@ -943,10 +943,12 @@ impl Lowerer {
                 if let Some((cid, _)) = input_columns.get(&name) {
                     *cid
                 } else {
-                    panic!("cannot find cid by id={id} and name={name:?}");
+                    return Err(Error::new(Reason::Bug).into());
                 }
             }
-            None => panic!("cannot find cid by id={id}"),
+            None => {
+                return Err(Error::new(Reason::Bug).into());
+            }
         };
 
         Ok(cid)

--- a/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
+++ b/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
@@ -175,3 +175,23 @@ fn test_relation_literal_contains_literals() {
     ───╯
     "###)
 }
+
+#[test]
+fn nested_groups() {
+    // Nested `group` gives a very abstract & internally-focused error message
+    assert_display_snapshot!(compile(r###"
+    from inv=invoices
+    join item=invoice_items (==invoice_id)
+
+    group { inv.billing_city } (
+
+      group { item.name } (
+        aggregate {
+          ct1 = count inv.name,
+        }
+      )
+    )
+    "###).unwrap_err(), @r###"
+    Error: Internal compiler error. If we don't track this in a GitHub issue yet, please report it!
+    "###);
+}

--- a/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
+++ b/prqlc/prql-compiler/tests/integration/bad_error_messages.rs
@@ -192,6 +192,6 @@ fn nested_groups() {
       )
     )
     "###).unwrap_err(), @r###"
-    Error: Internal compiler error. If we don't track this in a GitHub issue yet, please report it!
+    Error: internal compiler error; tracked at https://github.com/PRQL/prql/issues/3870
     "###);
 }

--- a/prqlc/prqlc-ast/src/error.rs
+++ b/prqlc/prqlc-ast/src/error.rs
@@ -42,6 +42,7 @@ pub enum Reason {
         name: String,
         namespace: String,
     },
+    Bug,
 }
 
 impl Error {
@@ -76,6 +77,7 @@ impl std::fmt::Display for Reason {
             }
             Reason::Unexpected { found } => write!(f, "unexpected {found}"),
             Reason::NotFound { name, namespace } => write!(f, "{namespace} `{name}` not found"),
+            Reason::Bug => f.write_str("Internal compiler error. If we don't track this in a GitHub issue yet, please report it!"),
         }
     }
 }

--- a/prqlc/prqlc-ast/src/error.rs
+++ b/prqlc/prqlc-ast/src/error.rs
@@ -42,7 +42,9 @@ pub enum Reason {
         name: String,
         namespace: String,
     },
-    Bug,
+    Bug {
+        issue: Option<i32>,
+    },
 }
 
 impl Error {
@@ -77,7 +79,14 @@ impl std::fmt::Display for Reason {
             }
             Reason::Unexpected { found } => write!(f, "unexpected {found}"),
             Reason::NotFound { name, namespace } => write!(f, "{namespace} `{name}` not found"),
-            Reason::Bug => f.write_str("Internal compiler error. If we don't track this in a GitHub issue yet, please report it!"),
+            Reason::Bug { issue } => match issue {
+                Some(issue) => write!(
+                    f,
+                    "internal compiler error; tracked at https://github.com/PRQL/prql/issues/{}",
+                    issue
+                ),
+                None => write!(f, "internal compiler error"),
+            },
         }
     }
 }


### PR DESCRIPTION
A small change to avoid the panic. Still a bad error message.

I haven't thought about whether this should work. Assuming it shouldn't, we can close #3870, now it's replaced with the bad error message test
