### PR TITLE
feat: named unions

### DIFF
--- a/prqlc/Taskfile.yaml
+++ b/prqlc/Taskfile.yaml
@@ -17,7 +17,7 @@ tasks:
     cmds:
       - cmd: |
           # remove trailing whitespace
-          rg '\s+$' --files-with-matches --glob '!*.rs' . \
+          rg '\s+$' --files-with-matches --glob '!*.{rs,snap}' . \
           | xargs -I _ sh -c "echo Removing trailing whitespace from _ && sd '[\t ]+$' '' _"
 
       - cmd: |

--- a/prqlc/prql-compiler/src/codegen/types.rs
+++ b/prqlc/prql-compiler/src/codegen/types.rs
@@ -38,14 +38,24 @@ impl WriteSource for TyKind {
             Ident(ident) => ident.write(opt),
             Primitive(prim) => Some(prim.to_string()),
             Union(variants) => {
-                let variants: Vec<_> = variants.iter().map(|x| &x.1).collect();
+                let parenthesize = 
+                    // never must be parenthesized
+                    variants.is_empty() ||
+                    // named union must be parenthesized
+                    variants.iter().any(|(n, _)| n.is_some());
 
-                SeparatedExprs {
+                let variants: Vec<_> = variants.iter().map(|(n, t)| UnionVariant(n, t)).collect();
+                let sep_exprs = SeparatedExprs {
                     exprs: &variants,
                     inline: " || ",
                     line_end: " ||",
+                };
+
+                if parenthesize {
+                    sep_exprs.write_between("(", ")", opt)
+                } else {
+                    sep_exprs.write(opt)
                 }
-                .write(opt)
             }
             Singleton(lit) => Some(lit.to_string()),
             Tuple(elements) => SeparatedExprs {
@@ -99,5 +109,20 @@ impl WriteSource for TupleField {
                 Some(r)
             }
         }
+    }
+}
+
+struct UnionVariant<'a>(&'a Option<String>, &'a Ty);
+
+impl WriteSource for UnionVariant<'_> {
+    fn write(&self, mut opt: WriteOpt) -> Option<String> {
+        let mut r = String::new();
+        if let Some(name) = &self.0 {
+            r += name;
+            r += " = ";
+        }
+        opt.consume_width(r.len() as u16);
+        r += &self.1.write(opt)?;
+        Some(r)
     }
 }

--- a/prqlc/prql-compiler/src/codegen/types.rs
+++ b/prqlc/prql-compiler/src/codegen/types.rs
@@ -38,7 +38,7 @@ impl WriteSource for TyKind {
             Ident(ident) => ident.write(opt),
             Primitive(prim) => Some(prim.to_string()),
             Union(variants) => {
-                let parenthesize = 
+                let parenthesize =
                     // never must be parenthesized
                     variants.is_empty() ||
                     // named union must be parenthesized

--- a/prqlc/prql-compiler/src/sql/gen_expr.rs
+++ b/prqlc/prql-compiler/src/sql/gen_expr.rs
@@ -813,8 +813,8 @@ pub(super) fn translate_operand(
 ///    parentheses are not required. Some examples of when parentheses are not required:
 ///    - `(a - b) - c` & `(a + b) - c` — as opposed to `a - (b - c)`
 ///    - `a + (b - c)` & `a + (b + c)` — as opposed to `a - (b + c)` & `a - (b - c)`
-///         
-///       
+///
+///
 //
 // If it were possible to evaluate this with less context that would be
 // preferable, but it's not clear how to do that. (For example, even if we

--- a/prqlc/prql-compiler/tests/integration/error_messages.rs
+++ b/prqlc/prql-compiler/tests/integration/error_messages.rs
@@ -324,7 +324,7 @@ fn date_to_text_with_column_format() {
 fn date_to_text_unsupported_chrono_item() {
     assert_display_snapshot!(compile(r#"
     prql target:sql.duckdb
-  
+
     from [{d = @2021-01-01}]
     derive {
       d_str = d | date.to_text "%_j"

--- a/prqlc/prql-compiler/tests/integration/resolving.rs
+++ b/prqlc/prql-compiler/tests/integration/resolving.rs
@@ -46,12 +46,11 @@ fn resolve_types_01() {
 }
 
 #[test]
-#[ignore]
 fn resolve_types_02() {
     assert_snapshot!(resolve(r#"
-    type A = A || ()
+    type A = int || ()
     "#).unwrap(), @r###"
-    type A = A
+    type A = int
     "###)
 }
 
@@ -62,4 +61,24 @@ fn resolve_types_03() {
     "#).unwrap(), @r###"
     type A = {a = int, bool, b = text, float}
     "###)
+}
+
+#[test]
+fn resolve_types_04() {
+    assert_snapshot!(resolve(
+        r#"
+    type Status = (
+        Paid = () ||
+        Unpaid = float ||
+        Canceled = {reason = text, cancelled_at = timestamp} ||
+    )
+    "#,
+    )
+    .unwrap(), @r###"
+    type Status = (
+      Paid = () ||
+      Unpaid = float ||
+      {reason = text, cancelled_at = timestamp} ||
+    )
+    "###);
 }

--- a/prqlc/prql-compiler/tests/integration/snapshots/integration__resolving__resolve_types_04.snap
+++ b/prqlc/prql-compiler/tests/integration/snapshots/integration__resolving__resolve_types_04.snap
@@ -1,0 +1,9 @@
+---
+source: prqlc/prql-compiler/tests/integration/resolving.rs
+expression: "resolve(r#\"\n    type Status = (\n        Paid = () ||\n        Unpaid = float ||\n        Canceled = {reason = text, cancelled_at = timestamp} ||\n    )\n    \"#).unwrap()"
+---
+type Status = 
+  float ||
+  {reason = text, cancelled_at = timestamp} ||
+
+

--- a/prqlc/prql-compiler/tests/integration/snapshots/integration__resolving__resolve_types_04.snap
+++ b/prqlc/prql-compiler/tests/integration/snapshots/integration__resolving__resolve_types_04.snap
@@ -1,9 +1,0 @@
----
-source: prqlc/prql-compiler/tests/integration/resolving.rs
-expression: "resolve(r#\"\n    type Status = (\n        Paid = () ||\n        Unpaid = float ||\n        Canceled = {reason = text, cancelled_at = timestamp} ||\n    )\n    \"#).unwrap()"
----
-type Status = 
-  float ||
-  {reason = text, cancelled_at = timestamp} ||
-
-

--- a/prqlc/prql-compiler/tests/integration/sql.rs
+++ b/prqlc/prql-compiler/tests/integration/sql.rs
@@ -318,7 +318,7 @@ fn test_precedence() {
     assert_display_snapshot!((compile(r###"
     from numbers
     derive {
-      sum_1 = a + b, 
+      sum_1 = a + b,
       sum_2 = add a b,
       g = -a
     }

--- a/prqlc/prqlc-parser/src/interpolation.rs
+++ b/prqlc/prqlc-parser/src/interpolation.rs
@@ -27,7 +27,7 @@ fn parse_interpolate() {
     let span_base = ParserSpan::new(0, 0..0);
 
     assert_debug_snapshot!(
-        parse("concat({a})".to_string(), span_base).unwrap(), 
+        parse("concat({a})".to_string(), span_base).unwrap(),
     @r###"
     [
         String(
@@ -55,7 +55,7 @@ fn parse_interpolate() {
     "###);
 
     assert_debug_snapshot!(
-        parse("print('{{hello}}')".to_string(), span_base).unwrap(), 
+        parse("print('{{hello}}')".to_string(), span_base).unwrap(),
     @r###"
     [
         String(
@@ -65,7 +65,7 @@ fn parse_interpolate() {
     "###);
 
     assert_debug_snapshot!(
-        parse("concat('{{', a, '}}')".to_string(), span_base).unwrap(), 
+        parse("concat('{{', a, '}}')".to_string(), span_base).unwrap(),
     @r###"
     [
         String(
@@ -75,7 +75,7 @@ fn parse_interpolate() {
     "###);
 
     assert_debug_snapshot!(
-        parse("concat('{{', {a}, '}}')".to_string(), span_base).unwrap(), 
+        parse("concat('{{', {a}, '}}')".to_string(), span_base).unwrap(),
     @r###"
     [
         String(

--- a/prqlc/prqlc/tests/snapshots/test__debug.snap
+++ b/prqlc/prqlc/tests/snapshots/test__debug.snap
@@ -7,10 +7,10 @@ info:
     - debug
     - resolve
   env:
-    RUST_BACKTRACE: ""
     CLICOLOR_FORCE: ""
-    NO_COLOR: "1"
+    RUST_BACKTRACE: ""
     RUST_LOG: ""
+    NO_COLOR: "1"
   stdin: from tracks
 ---
 success: true


### PR DESCRIPTION
Support for parsing and codegen of:

```elm
    type Status = (
      Paid = () ||
      Unpaid = float ||
      {reason = text, cancelled_at = timestamp} ||
    )
```

As we don't have any code for interaction with this, this does not change the behavior in any way, so I'm not adding a changelog.