### PR TITLE
docs(changelog): Add sloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
 **Integrations**:
 
 - Add syntax highlight file for CotEditor. (@vanillajonathan)
-- [sloc](https://github.com/flosse/sloc), a source lines of code counter
-  now has support for `.prql` files. (@vanillajonathan)
+- [sloc](https://github.com/flosse/sloc), a source lines of code counter now has
+  support for `.prql` files. (@vanillajonathan)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 **Integrations**:
 
 - Add syntax highlight file for CotEditor. (@vanillajonathan)
+- [sloc](https://github.com/flosse/sloc), a source lines of code counter
+  now has support for `.prql` files. (@vanillajonathan)
 
 **Internal changes**:
 


### PR DESCRIPTION
[sloc](https://github.com/flosse/sloc) now has support for `.prql` files since PR https://github.com/flosse/sloc/pull/138.