### PR TITLE
ci: Pin Zig compiler version

### DIFF
--- a/.github/workflows/test-clib.yaml
+++ b/.github/workflows/test-clib.yaml
@@ -34,7 +34,8 @@ jobs:
         uses: goto-bus-stop/setup-zig@v2
         with:
           cache: false
-      # TODO: Broken so disabling — https://github.com/PRQL/prql/issues/4050
-      # - name: Run example minimal-zig
-      #   working-directory: prqlc/bindings/clib/examples/minimal-zig
-      #   run: make run test
+          # Pinned version — https://github.com/PRQL/prql/issues/4050
+          version: 0.11.0
+      - name: Run example minimal-zig
+        working-directory: prqlc/bindings/clib/examples/minimal-zig
+        run: make run test


### PR DESCRIPTION
Pin the Zig compiler version so the GitHub Action doesn't use the nightly version which has breaking changes.

This PR is related to issue #4050.