### PR TITLE
refactor: Move `WithErrorInfo` to `prqlc-ast`, use in `prqlc-parser`

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -31,7 +31,7 @@ runs:
         save-if:
           ${{ (github.ref == 'refs/heads/main') && contains(inputs.target,
           'musl') }}
-        shared-key: rust-${{ inputs.target }}-${{ inputs.features }}
+        shared-key: rust-${{ inputs.target }}
         prefix-key: ${{ env.version }}
 
     - if: runner.os == 'Linux'

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -52,7 +52,7 @@ jobs:
         id: cache
         with:
           prefix-key: ${{ env.version }}
-          shared-key: rust-${{ inputs.target }}-${{ inputs.features }}
+          shared-key: rust-${{ inputs.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
         # We split up the test compilation as recommended in
         # https://matklad.github.io/2021/09/04/fast-rust-builds.html

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -169,7 +169,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            features: test-dbs-external
+            features: default,test-dbs-external
           # Only run wasm on ubuntu, given it's the same rust target. (There is a
           # possibility of having a failure on just one platform, but it's quite
           # unlikely. If we do observe this, we can expand, or introduce a
@@ -177,7 +177,7 @@ jobs:
           # using runners & cache space)
           - target: wasm32-unknown-unknown
             os: ubuntu-latest
-            features: ""
+            features: default
     with:
       os: ubuntu-latest
       target: ${{ matrix.target }}
@@ -410,7 +410,7 @@ jobs:
           #
           # cargo llvm-cov --codecov --output-path=codecov.json --features=test-dbs
           cargo llvm-cov --cobertura --output-path=cobertura.xml
-          --features=test-dbs
+          --features=default,test-dbs
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
@@ -598,7 +598,7 @@ jobs:
           # Match the features with the available caches from tests
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            features: ""
+            features: default
           # TODO: Until we have tests for these, we don't have a cache for them.
           # If we can add tests, then re-enable them. They run on `release.yaml`
           # regardless.
@@ -609,10 +609,10 @@ jobs:
           #   target: aarch64-apple-darwin
           - os: macos-latest
             target: x86_64-apple-darwin
-            features: test-dbs
+            features: default,test-dbs
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            features: ""
+            features: default
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ dependencies = [
 name = "prqlc-ast"
 version = "0.11.2"
 dependencies = [
+ "anyhow",
  "enum-as-inner",
  "insta",
  "semver",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -296,7 +296,8 @@ tasks:
     #   - "**/*.lock"
     #   - "**/*.snap"
     cmds:
-      - cargo insta test --accept --features=test-dbs --unreferenced=auto
+      - cargo insta test --accept --features=default,test-dbs
+        --unreferenced=auto
 
   test-rust-fast:
     desc: Test prql-compiler's unit tests.
@@ -330,7 +331,8 @@ tasks:
       # Use a different target dir so we don't poison the cache
       CARGO_TARGET_DIR: "./target-cov"
     cmds:
-      - cargo llvm-cov  --lcov --output-path lcov.info --features=test-dbs
+      - cargo llvm-cov  --lcov --output-path lcov.info
+        --features=default,test-dbs
 
   build-web:
     desc:

--- a/bacon.toml
+++ b/bacon.toml
@@ -4,10 +4,10 @@ default_job = "clippy"
 
 # PRQL additions
 [jobs.test]
-command = ['cargo', 'insta', 'test', "--color=always", "--features=test-dbs", "--unreferenced=auto"]
+command = ['cargo', 'insta', 'test', "--color=always", "--features=default,test-dbs", "--unreferenced=auto"]
 
 [jobs.test-accept]
-command = ['cargo', 'insta', 'test', '--accept', "--color=always", "--features=test-dbs", "--unreferenced=auto"]
+command = ['cargo', 'insta', 'test', '--accept', "--color=always", "--features=default,test-dbs", "--unreferenced=auto"]
 watch = ["*"]
 
 [jobs.test-accept-fast]
@@ -43,8 +43,8 @@ need_stdout = false
 # If the doc compiles, then it opens in your browser and bacon switches
 # to the previous job
 [jobs.doc-open]
-command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
-need_stdout = false
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"] 
+need_stdout = false 
 on_success = "back" # so that we don't open the browser at each change
 
 # You may define here keybindings that would be specific to

--- a/bacon.toml
+++ b/bacon.toml
@@ -43,8 +43,8 @@ need_stdout = false
 # If the doc compiles, then it opens in your browser and bacon switches
 # to the previous job
 [jobs.doc-open]
-command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"] 
-need_stdout = false 
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
 # You may define here keybindings that would be specific to

--- a/prqlc/Taskfile.yaml
+++ b/prqlc/Taskfile.yaml
@@ -58,7 +58,7 @@ tasks:
           {{.packages_bindings}} -- -D warnings
 
       - cmd:
-          cargo test --package prql-compiler --features=test-dbs
+          cargo test --package prql-compiler --features=default,test-dbs
           --test=integration -- queries::results
 
   pull-request:

--- a/prqlc/prqlc-ast/Cargo.toml
+++ b/prqlc/prqlc-ast/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
+anyhow = {version = "1.0", optional = true}
 enum-as-inner = "0.6.0"
 semver = {version = "1.0.20", features = ["serde"]}
 serde = {version = "1.0.193", features = ["derive"]}
@@ -21,3 +22,6 @@ strum = {version = "0.25.0", features = ["std", "derive"]}
 [dev-dependencies]
 insta = "1.34"
 serde_json = "1.0"
+
+[features]
+default = ["anyhow"]

--- a/prqlc/prqlc-ast/Cargo.toml
+++ b/prqlc/prqlc-ast/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 anyhow = {version = "1.0", optional = true}

--- a/prqlc/prqlc-ast/src/error.rs
+++ b/prqlc/prqlc-ast/src/error.rs
@@ -239,21 +239,26 @@ mod tests {
 
     #[test]
     fn test_anyhow_error_integration() {
-        let err: anyhow::Error = Error::new_simple("An anyhow error")
+        use anyhow::Error as AnyhowError;
+
+        let err = AnyhowError::new(Error::new_simple("simple message"))
             .push_hint("Hint for anyhow")
-            .into();
+            .with_code("E001")
+            .with_span(None);
 
         assert_debug_snapshot!(err, @r###"
         Error {
             kind: Error,
             span: None,
             reason: Simple(
-                "An anyhow error",
+                "simple message",
             ),
             hints: [
                 "Hint for anyhow",
             ],
-            code: None,
+            code: Some(
+                "E001",
+            ),
         }
         "###);
     }

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -14,6 +14,9 @@ metadata.msrv = "1.70.0"
 [[bin]]
 name = "prqlc"
 
+[features]
+default = []
+
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 anstream = {version = "0.6.5", features = ["auto"]}
 anyhow = {version = "1.0.78"}

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -354,7 +354,7 @@ inconsistent in watchexec. Let's revert back if it gets solved.
   ```sh
   task test-rust
   # or
-  cargo insta test --accept --features=test-dbs
+  cargo insta test --accept --features=default,test-dbs
   ```
 
   More details on running with external databases are in the


### PR DESCRIPTION
A small refactor while working on other parts of the codebase this weekend

This led to some yak-shaving with coverage, and then the `anyhow` implementation, and then a default feature. Think it's probably better than not having it, even if it wasn't _that_ productive
