### PR TITLE
devops: Add dependabot for `prql-python`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,14 @@ updates:
     package-ecosystem: "github-actions"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: pip
+    directory: "prqlc/bindings/python"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore: "
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch


### PR DESCRIPTION
I was getting warnings about the maturin version, hopefully this will upgrade it automatically
