### PR TITLE
ci: Build `prqlc-clib` as artifacts

### DIFF
--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -69,8 +69,8 @@ runs:
         export ARTIFACT_NAME="prqlc-clib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
-        cp ../../../prqlc/prqlc-clib/README.md .
-        tar czf "../../../${ARTIFACT_NAME}" prqlc-clib ../../../LICENSE README.md
+        # cp ../../../prqlc/prqlc-clib/README.md .
+        tar czf "../../../${ARTIFACT_NAME}" prqlc-clib ../../../LICENSE # README.md
 
     - name: Create artifact for Windows
       shell: bash
@@ -79,8 +79,8 @@ runs:
         export ARTIFACT_NAME="prqlc-clib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
-        cp ../../../prqlc/prqlc-clib/README.md .
-        7z a "../../../${ARTIFACT_NAME}" prqlc-clib.exe ../../../LICENSE README.md
+        # cp ../../../prqlc/prqlc-clib/README.md .
+        7z a "../../../${ARTIFACT_NAME}" prqlc-clib.exe ../../../LICENSE # README.md
 
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -1,6 +1,10 @@
-name: build-prqlc
+name: build-prqlc-clib
 description: >
-  Build prqlc
+  A version of `build-prqlc` for the C bindings.
+
+  Note that this is quite open to change, including names and which files we
+  package. Contributions and/or suggestions are welcome.
+
 inputs:
   target:
     description: Build target
@@ -70,7 +74,7 @@ runs:
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         ls -al
-        tar czf "../../../${ARTIFACT_NAME}" libprqlc_lib*
+        tar czf "../../../${ARTIFACT_NAME}" *prqlc_lib*
 
     - name: Create artifact for Windows
       shell: bash
@@ -80,7 +84,7 @@ runs:
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         ls -al
-        7z a "../../../${ARTIFACT_NAME}" libprqlc_lib*
+        7z a "../../../${ARTIFACT_NAME}" *prqlc_lib*
 
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -1,0 +1,93 @@
+name: build-prqlc
+description: >
+  Build prqlc
+inputs:
+  target:
+    description: Build target
+    required: true
+  profile:
+    description: Build profile option; `dev` or `release`.
+    required: true
+  features:
+    description: Features to enable
+    default: ""
+outputs:
+  artifact-name:
+    description: The name of the artifact
+    value: ${{ steps.echo-artifact-name.outputs.artifact-name }}
+
+runs:
+  using: composite
+  steps:
+    - run: rustup target add ${{ inputs.target }}
+      shell: bash
+
+    - run: ./.github/workflows/scripts/set_version.sh
+      shell: bash
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        # Share cache with `test-rust`, except for `musl` targets.
+        save-if:
+          ${{ (github.ref == 'refs/heads/main') && contains(inputs.target,
+          'musl') }}
+        shared-key: rust-${{ inputs.target }}
+        prefix-key: ${{ env.version }}
+
+    - if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools
+
+    - if: runner.os == 'Windows' && inputs.profile == 'release'
+      shell: bash
+      run: |
+        echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >>"$GITHUB_ENV"
+
+    - if: inputs.target == 'aarch64-unknown-linux-musl'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu
+        echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+        echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+
+    - name: cargo build
+      uses: richb-hanover/cargo@v1.1.0
+      with:
+        command: build
+        args:
+          --profile=${{ inputs.profile }} --locked --target=${{ inputs.target }}
+          --features=${{ inputs.features }} ${{ contains(inputs.target, 'musl')
+          && '--package=prqlc-clib' || '--all-targets' }}
+
+    - name: Create artifact for Linux and macOS
+      shell: bash
+      if: runner.os != 'Windows'
+      run: |
+        export ARTIFACT_NAME="prqlc-clib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
+        echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
+        cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
+        cp ../../../prqlc/prqlc-clib/README.md .
+        tar czf "../../../${ARTIFACT_NAME}" prqlc-clib ../../../LICENSE README.md
+
+    - name: Create artifact for Windows
+      shell: bash
+      if: runner.os == 'Windows'
+      run: |
+        export ARTIFACT_NAME="prqlc-clib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
+        echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
+        cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
+        cp ../../../prqlc/prqlc-clib/README.md .
+        7z a "../../../${ARTIFACT_NAME}" prqlc-clib.exe ../../../LICENSE README.md
+
+    - name: Upload prqlc-clib
+      uses: actions/upload-artifact@v3
+      with:
+        name: prqlc-${{ inputs.target }}
+        path: ${{ env.ARTIFACT_NAME }}
+
+    - id: echo-artifact-name
+      shell: bash
+      run: echo "artifact-name=${{ env.ARTIFACT_NAME }}" >>"$GITHUB_OUTPUT"

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -66,21 +66,21 @@ runs:
       shell: bash
       if: runner.os != 'Windows'
       run: |
-        export ARTIFACT_NAME="prqlc-clib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
+        export ARTIFACT_NAME="prqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         # cp ../../../prqlc/prqlc-clib/README.md .
-        tar czf "../../../${ARTIFACT_NAME}" prqlc-clib* ../../../LICENSE # README.md
+        tar czf "../../../${ARTIFACT_NAME}" prqlc_lib* ../../../LICENSE # README.md
 
     - name: Create artifact for Windows
       shell: bash
       if: runner.os == 'Windows'
       run: |
-        export ARTIFACT_NAME="prqlc-clib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
+        export ARTIFACT_NAME="prqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         # cp ../../../prqlc/prqlc-clib/README.md .
-        7z a "../../../${ARTIFACT_NAME}" prqlc-clib* ../../../LICENSE # README.md
+        7z a "../../../${ARTIFACT_NAME}" prqlc_lib* ../../../LICENSE # README.md
 
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -70,7 +70,7 @@ runs:
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         # cp ../../../prqlc/prqlc-clib/README.md .
-        tar czf "../../../${ARTIFACT_NAME}" prqlc-clib ../../../LICENSE # README.md
+        tar czf "../../../${ARTIFACT_NAME}" prqlc-clib* ../../../LICENSE # README.md
 
     - name: Create artifact for Windows
       shell: bash
@@ -80,7 +80,7 @@ runs:
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         # cp ../../../prqlc/prqlc-clib/README.md .
-        7z a "../../../${ARTIFACT_NAME}" prqlc-clib.exe ../../../LICENSE # README.md
+        7z a "../../../${ARTIFACT_NAME}" prqlc-clib* ../../../LICENSE # README.md
 
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -70,7 +70,7 @@ runs:
       shell: bash
       if: runner.os != 'Windows'
       run: |
-        export ARTIFACT_NAME="libprqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
+        export ARTIFACT_NAME="prqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         ls -al
@@ -80,7 +80,7 @@ runs:
       shell: bash
       if: runner.os == 'Windows'
       run: |
-        export ARTIFACT_NAME="libprqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
+        export ARTIFACT_NAME="prqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         ls -al
@@ -89,7 +89,7 @@ runs:
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3
       with:
-        name: libprqlc_lib-${{ inputs.target }}
+        name: prqlc_lib-${{ inputs.target }}
         path: ${{ env.ARTIFACT_NAME }}
 
     - id: echo-artifact-name

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -66,21 +66,21 @@ runs:
       shell: bash
       if: runner.os != 'Windows'
       run: |
-        export ARTIFACT_NAME="prqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
+        export ARTIFACT_NAME="libprqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         # cp ../../../prqlc/prqlc-clib/README.md .
-        tar czf "../../../${ARTIFACT_NAME}" prqlc_lib* ../../../LICENSE # README.md
+        tar czf "../../../${ARTIFACT_NAME}" libprqlc_lib* ../../../LICENSE # README.md
 
     - name: Create artifact for Windows
       shell: bash
       if: runner.os == 'Windows'
       run: |
-        export ARTIFACT_NAME="prqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
+        export ARTIFACT_NAME="libprqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
         # cp ../../../prqlc/prqlc-clib/README.md .
-        7z a "../../../${ARTIFACT_NAME}" prqlc_lib* ../../../LICENSE # README.md
+        7z a "../../../${ARTIFACT_NAME}" libprqlc_lib* ../../../LICENSE # README.md
 
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -85,7 +85,7 @@ runs:
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3
       with:
-        name: prqlc-${{ inputs.target }}
+        name: libprqlc_lib-${{ inputs.target }}
         path: ${{ env.ARTIFACT_NAME }}
 
     - id: echo-artifact-name

--- a/.github/actions/build-prqlc-clib/action.yaml
+++ b/.github/actions/build-prqlc-clib/action.yaml
@@ -69,8 +69,8 @@ runs:
         export ARTIFACT_NAME="libprqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
-        # cp ../../../prqlc/prqlc-clib/README.md .
-        tar czf "../../../${ARTIFACT_NAME}" libprqlc_lib* ../../../LICENSE # README.md
+        ls -al
+        tar czf "../../../${ARTIFACT_NAME}" libprqlc_lib*
 
     - name: Create artifact for Windows
       shell: bash
@@ -79,8 +79,8 @@ runs:
         export ARTIFACT_NAME="libprqlc_lib-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
         cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
-        # cp ../../../prqlc/prqlc-clib/README.md .
-        7z a "../../../${ARTIFACT_NAME}" libprqlc_lib* ../../../LICENSE # README.md
+        ls -al
+        7z a "../../../${ARTIFACT_NAME}" libprqlc_lib*
 
     - name: Upload prqlc-clib
       uses: actions/upload-artifact@v3

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -1,6 +1,9 @@
 name: build-prqlc
 description: >
   Build prqlc
+
+  Note that much of this is copy/pasted into build-prqlc-clib, so changes here
+  should generally be copied into that file.
 inputs:
   target:
     description: Build target

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,40 @@ jobs:
           append_body: true
           files: ${{ steps.build-artifact.outputs.artifact-name }}
 
+  build-prqlc_lib:
+    # Currently a copy/paste of `build-prqlc`.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    permissions:
+      contents: write
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-prqlc-clib
+        id: build-artifact
+        with:
+          target: ${{ matrix.target }}
+          profile: release
+      - name: Upload release artifact
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          append_body: true
+          files: ${{ steps.build-artifact.outputs.artifact-name }}
+
   winget-release:
     runs-on: ubuntu-latest
     needs: build-prqlc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -638,6 +638,40 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
       RUSTDOCFLAGS: "-Dwarnings"
 
+  build-prqlc-clib:
+    runs-on: ${{ matrix.os }}
+    needs: rules
+    if: needs.rules.outputs.rust == 'true' || needs.rules.outputs.main == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Match the features with the available caches from tests
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            features: default
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            features: default,test-dbs
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            features: default
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-prqlc-clib
+        with:
+          target: ${{ matrix.target }}
+          profile: dev
+          features: ${{ matrix.features }}
+    # These are the same env variables as in `test-rust.yaml`. Custom actions
+    # don't allow setting env variables for the whole job, so we do it here.
+    env:
+      CARGO_TERM_COLOR: always
+      CLICOLOR_FORCE: 1
+      RUSTFLAGS: "-C debuginfo=0"
+      RUSTDOCFLAGS: "-Dwarnings"
+
   create-issue-on-nightly-failure:
     runs-on: ubuntu-latest
     needs:

--- a/prqlc/bindings/clib/Cargo.toml
+++ b/prqlc/bindings/clib/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+# This means we can build with `--features=default`, which can make builds more generic
+[features]
+default = []
+
 [lib]
 crate_type = ["staticlib", "cdylib"]
 doctest = false

--- a/prqlc/bindings/clib/Cargo.toml
+++ b/prqlc/bindings/clib/Cargo.toml
@@ -13,8 +13,10 @@ version.workspace = true
 default = []
 
 [lib]
+# We produce both of these at the moment, but could consider refining this. ref
+# https://github.com/rust-lang/cargo/issues/8607 &
+# https://github.com/rust-lang/rust/issues/59302
 crate_type = ["staticlib", "cdylib"]
-# crate_type = ["cdylib"]
 doctest = false
 name = "prqlc_lib"
 test = false

--- a/prqlc/bindings/clib/Cargo.toml
+++ b/prqlc/bindings/clib/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 
 [lib]
 crate_type = ["staticlib", "cdylib"]
+# crate_type = ["cdylib"]
 doctest = false
 name = "prqlc_lib"
 test = false


### PR DESCRIPTION
Closes https://github.com/PRQL/prql/issues/3953

Notes are inline about the exact names and structure being very open to change.

It's mostly a copy-paste from `build-prqlc` — though it's also different enough that I wouldn't suggest trying to make a generic action atm.

We had a discussion on crate naming on Discord, which might make names change: https://discord.com/channels/936728116712316989/1195504018882035752/1195513591302983731