### PR TITLE
ci: Don't build prqlc-c on every commit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -641,7 +641,7 @@ jobs:
   build-prqlc-clib:
     runs-on: ${{ matrix.os }}
     needs: rules
-    if: needs.rules.outputs.rust == 'true' || needs.rules.outputs.main == 'true'
+    if: needs.rules.outputs.main == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Running on merges is fine I think...
