### PR TITLE
devops: Run on newer prettier version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,12 +7,12 @@
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/eitsupi/devcontainer-features/go-task:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {
-      "yqVersion": "latest"
+      "yqVersion": "latest",
     },
     "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-      "packages": "cmake,sqlite3"
-    }
+      "packages": "cmake,sqlite3",
+    },
   },
   "customizations": {
     "vscode": {
@@ -22,27 +22,27 @@
         "rust-lang.rust-analyzer",
         "mitsuhiko.insta",
         "esbenp.prettier-vscode",
-        "budparr.language-hugo-vscode"
-      ]
-    }
+        "budparr.language-hugo-vscode",
+      ],
+    },
   },
   "mounts": [
     {
       "source": "devcontainer-cargo-cache-${devcontainerId}",
       "target": "/usr/local/cargo/registry",
-      "type": "volume"
+      "type": "volume",
     },
     {
       "source": "devcontainer-cargo-target-${devcontainerId}",
       "target": "${containerWorkspaceFolder}/target",
-      "type": "volume"
-    }
+      "type": "volume",
+    },
   ],
   "postCreateCommand": {
     "set-ownership": "sudo chown vscode target",
     "install-python-deps": "task install-maturin",
     // Disabling because of the issues in #3709
     // "install-python-deps": "task install-maturin && task install-pre-commit && pre-commit install-hooks",
-    "install-npm-dependencies": "task install-npm-dependencies"
-  }
+    "install-npm-dependencies": "task install-npm-dependencies",
+  },
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,8 @@ repos:
           # TODO: This doesn't seem to work, would be great to fix.
           # https://github.com/PRQL/prql/issues/3078
           - prettier-plugin-go-template
+        # Undo this on the next version of prettier; ref https://github.com/PRQL/prql/pull/4101
+        stages: [manual]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.13
     hooks:
@@ -98,5 +100,5 @@ repos:
 
 ci:
   # Currently network access isn't supported in the CI product.
-  skip: [fmt, markdown-link-check]
+  skip: [fmt, markdown-link-check, prettier]
   autoupdate_commit_msg: "chore: pre-commit autoupdate"

--- a/web/prql-codemirror-demo/tsconfig.json
+++ b/web/prql-codemirror-demo/tsconfig.json
@@ -17,7 +17,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
   },
-  "include": ["src"]
+  "include": ["src"],
 }


### PR DESCRIPTION
Despite not changing the pre-commit tag, the version of prettier that's running has changed, causing https://github.com/PRQL/prql/issues/4099.

~Not sure whether this will passed the `pre-commit.ci` test given that's likely cached~

It didn't pass, so disabling. When the next tag comes out, we can re-enable
