### PR TITLE
perf: reduce amount of stack memory usage

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -202,23 +202,23 @@ impl PlFold for Resolver<'_> {
                 ..node
             },
         };
-        self.finish_expr_resolve(Box::new(r), id, alias, span)
+        self.finish_expr_resolve(r, id, *alias, *span)
     }
 }
 
 impl Resolver<'_> {
     fn finish_expr_resolve(
         &mut self,
-        expr: Box<Expr>,
+        expr: Expr,
         id: usize,
-        alias: Box<Option<String>>,
-        span: Box<Option<Span>>,
+        alias: Option<String>,
+        span: Option<Span>,
     ) -> Result<Expr> {
-        let mut r = Box::new(self.static_eval(*expr)?);
+        let mut r = Box::new(self.static_eval(expr)?);
 
         r.id = r.id.or(Some(id));
-        r.alias = r.alias.or(*alias);
-        r.span = r.span.or(*span);
+        r.alias = r.alias.or(alias);
+        r.span = r.span.or(span);
 
         if r.ty.is_none() {
             r.ty = Resolver::infer_type(&r)?;

--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -108,9 +108,9 @@ impl PlFold for Resolver<'_> {
 
                     DeclKind::Expr(expr) => match &expr.kind {
                         ExprKind::Func(closure) => {
-                            let closure = self.fold_function_types(*closure.clone())?;
+                            let closure = self.fold_function_types(closure.clone())?;
 
-                            let expr = Expr::new(ExprKind::Func(Box::new(closure)));
+                            let expr = Expr::new(ExprKind::Func(closure));
 
                             if self.in_func_call_name {
                                 expr
@@ -170,14 +170,14 @@ impl PlFold for Resolver<'_> {
                 let name = self.fold_expr(*name)?;
                 self.in_func_call_name = old;
 
-                let func = *name.try_cast(|n| n.into_func(), None, "a function")?;
+                let func = name.try_cast(|n| n.into_func(), None, "a function")?;
 
                 // fold function
                 let func = self.apply_args_to_closure(func, args, named_args)?;
                 self.fold_function(func, span)?
             }
 
-            ExprKind::Func(closure) => self.fold_function(*closure, span)?,
+            ExprKind::Func(closure) => self.fold_function(closure, span)?,
 
             ExprKind::Tuple(exprs) => {
                 let exprs = self.fold_exprs(exprs)?;

--- a/prqlc/prqlc/src/semantic/resolver/functions.rs
+++ b/prqlc/prqlc/src/semantic/resolver/functions.rs
@@ -15,7 +15,7 @@ use crate::{Error, Span, WithErrorInfo};
 use super::Resolver;
 
 impl Resolver<'_> {
-    pub fn fold_function(&mut self, closure: Func, span: Option<Span>) -> Result<Expr> {
+    pub fn fold_function(&mut self, closure: Box<Func>, span: Option<Span>) -> Result<Expr> {
         let closure = self.fold_function_types(closure)?;
 
         log::debug!(
@@ -36,7 +36,7 @@ impl Resolver<'_> {
 
         let enough_args = closure.args.len() == closure.params.len();
         if !enough_args {
-            return Ok(expr_of_func(closure, span));
+            return Ok(*expr_of_func(closure, span));
         }
 
         // make sure named args are pushed into params
@@ -49,10 +49,10 @@ impl Resolver<'_> {
         // push the env
         let closure_env = Module::from_exprs(closure.env);
         self.root_mod.module.stack_push(NS_PARAM, closure_env);
-        let closure = Func {
+        let closure = Box::new(Func {
             env: HashMap::new(),
-            ..closure
-        };
+            ..*closure
+        });
 
         if log::log_enabled!(log::Level::Debug) {
             let name = closure
@@ -66,7 +66,7 @@ impl Resolver<'_> {
         let closure = match res {
             Ok(func) => func,
             Err(func) => {
-                return Ok(expr_of_func(func, span));
+                return Ok(*expr_of_func(func, span));
             }
         };
 
@@ -137,7 +137,7 @@ impl Resolver<'_> {
         Ok(Expr { span, ..res })
     }
 
-    pub fn fold_function_types(&mut self, mut closure: Func) -> Result<Func> {
+    pub fn fold_function_types(&mut self, mut closure: Box<Func>) -> Result<Box<Func>> {
         closure.params = closure
             .params
             .into_iter()
@@ -154,10 +154,10 @@ impl Resolver<'_> {
 
     pub fn apply_args_to_closure(
         &mut self,
-        mut closure: Func,
+        mut closure: Box<Func>,
         args: Vec<Expr>,
         mut named_args: HashMap<String, Expr>,
-    ) -> Result<Func> {
+    ) -> Result<Box<Func>> {
         // named arguments are consumed only by the first function
 
         // named
@@ -184,11 +184,14 @@ impl Resolver<'_> {
     }
 
     /// Resolves function arguments. Will return `Err(func)` is partial application is required.
-    fn resolve_function_args(&mut self, to_resolve: Func) -> Result<Result<Func, Func>> {
-        let mut closure = Func {
+    fn resolve_function_args(
+        &mut self,
+        to_resolve: Box<Func>,
+    ) -> Result<Result<Box<Func>, Box<Func>>> {
+        let mut closure = Box::new(Func {
             args: vec![Expr::new(Literal::Null); to_resolve.args.len()],
-            ..to_resolve
-        };
+            ..*to_resolve
+        });
         let mut partial_application_position = None;
 
         let func_name = &closure.name_hint;
@@ -342,7 +345,7 @@ impl Resolver<'_> {
     }
 }
 
-fn extract_partial_application(mut func: Func, position: usize) -> Func {
+fn extract_partial_application(mut func: Box<Func>, position: usize) -> Box<Func> {
     // Input:
     // Func {
     //     params: [x, y, z],
@@ -393,10 +396,10 @@ fn extract_partial_application(mut func: Func, position: usize) -> Func {
     arg_func.args.push(substitute_arg);
 
     // set the arg func body to the parent func
-    Func {
+    Box::new(Func {
         name_hint: None,
         return_ty: None,
-        body: Box::new(Expr::new(func)),
+        body: Box::new(Expr::new(ExprKind::Func(func))),
         params: vec![FuncParam {
             name: param_name,
             ty: None,
@@ -405,10 +408,10 @@ fn extract_partial_application(mut func: Func, position: usize) -> Func {
         named_params: Default::default(),
         args: Default::default(),
         env: Default::default(),
-    }
+    })
 }
 
-fn env_of_closure(closure: Func) -> (Module, Expr) {
+fn env_of_closure(closure: Box<Func>) -> (Module, Expr) {
     let mut func_env = Module::default();
 
     for (param, arg) in zip(closure.params, closure.args) {
@@ -424,7 +427,7 @@ fn env_of_closure(closure: Func) -> (Module, Expr) {
     (func_env, *closure.body)
 }
 
-pub fn expr_of_func(func: Func, span: Option<Span>) -> Expr {
+pub fn expr_of_func(func: Box<Func>, span: Option<Span>) -> Box<Expr> {
     let ty = TyFunc {
         args: func
             .params
@@ -436,9 +439,9 @@ pub fn expr_of_func(func: Func, span: Option<Span>) -> Expr {
         name_hint: func.name_hint.clone(),
     };
 
-    Expr {
+    Box::new(Expr {
         ty: Some(Ty::new(ty)),
         span,
-        ..Expr::new(ExprKind::Func(Box::new(func)))
-    }
+        ..Expr::new(ExprKind::Func(func))
+    })
 }

--- a/prqlc/prqlc/src/semantic/resolver/functions.rs
+++ b/prqlc/prqlc/src/semantic/resolver/functions.rs
@@ -103,10 +103,11 @@ impl Resolver<'_> {
         Ok(Expr { span, ..res })
     }
 
+    #[allow(clippy::boxed_local)]
     fn materialize_function(&mut self, closure: Box<Func>) -> Result<Expr> {
         log::debug!("stack_push for {}", closure.as_debug_name());
 
-        let (func_env, body) = env_of_closure(closure);
+        let (func_env, body) = env_of_closure(*closure);
 
         self.root_mod.module.stack_push(NS_PARAM, func_env);
 
@@ -190,7 +191,7 @@ impl Resolver<'_> {
     /// Resolves function arguments. Will return `Err(func)` is partial application is required.
     fn resolve_function_args(
         &mut self,
-        to_resolve: Box<Func>,
+        #[allow(clippy::boxed_local)] to_resolve: Box<Func>,
     ) -> Result<Result<Box<Func>, Box<Func>>> {
         let mut closure = Box::new(Func {
             args: vec![Expr::new(Literal::Null); to_resolve.args.len()],
@@ -415,7 +416,7 @@ fn extract_partial_application(mut func: Box<Func>, position: usize) -> Box<Func
     })
 }
 
-fn env_of_closure(closure: Box<Func>) -> (Module, Expr) {
+fn env_of_closure(closure: Func) -> (Module, Expr) {
     let mut func_env = Module::default();
 
     for (param, arg) in zip(closure.params, closure.args) {

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -23,7 +23,7 @@ use super::Resolver;
 
 impl Resolver<'_> {
     /// try to convert function call with enough args into transform
-    pub fn resolve_special_func(&mut self, func: Func, needs_window: bool) -> Result<Expr> {
+    pub fn resolve_special_func(&mut self, func: Box<Func>, needs_window: bool) -> Result<Expr> {
         let internal_name = func.body.kind.into_internal().unwrap();
 
         let (kind, input) = match internal_name.as_str() {
@@ -623,7 +623,7 @@ impl Resolver<'_> {
         })?;
 
         // construct the function back
-        let func = Func {
+        let func = Box::new(Func {
             name_hint: None,
             body: Box::new(pipeline),
             return_ty: None,
@@ -637,8 +637,8 @@ impl Resolver<'_> {
             named_params: vec![],
 
             env: Default::default(),
-        };
-        Ok(expr_of_func(func, span))
+        });
+        Ok(*expr_of_func(func, span))
     }
 }
 

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -23,6 +23,7 @@ use super::Resolver;
 
 impl Resolver<'_> {
     /// try to convert function call with enough args into transform
+    #[allow(clippy::boxed_local)]
     pub fn resolve_special_func(&mut self, func: Box<Func>, needs_window: bool) -> Result<Expr> {
         let internal_name = func.body.kind.into_internal().unwrap();
 

--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -128,7 +128,6 @@ fn compile_help() {
     "###);
 }
 
-#[cfg(not(windows))] // This is back to causing a SO on Windows since https://github.com/PRQL/prql/pull/3786
 #[test]
 fn long_query() {
     assert_cmd_snapshot!(prqlc_command()


### PR DESCRIPTION
Followup for https://github.com/PRQL/prql/issues/2857#issuecomment-1897218686

Refactor a few functions to use heap memory instead of stack memory, to reduce stack memory usage in the case where we recurse into function calls (which happens in long pipelines).

Ideally, stack size of the compile would not grow linearly with PRQL source call nesting depth, but that would be much harder to pull-off than just optimizing our code a bit.

---

For future reference: my debugging process
- put the offending query into `_a.prql`,
- run LLDB, it should stop when the panic is detected,
- run `thread backtrace` to get the list of all frames, enumerated. The name of the game is to refactor code such that number of frames in memory goes up, which means that the average size of a frame goes down.
- to see frame sizes:
  - `settings set frame-format '${frame.index} ${frame.sp} ${line.file.basename}\n'`
  - `thread backtrace`
  - copy-paste output to lo calc
  - to convert hex SP into memory offset: `=HEX2DEC(RIGHT(C12,9))` (RIGHT is needed because hex2dec cannot parse more than 10 digits)
  - `=E11-E12` to get the frame size
  - frame sizes are offset by 1, because that's how stack pointers and frame layouts work
  - when I started, frame sizes were: 1520, 4320, 14864, 19744, 26688
  - somewhere in-between, frame sizes were: 1520, 4320, 13744, 13712, 22144
