### PR TITLE
test: Demo of printing the stack

### DIFF
--- a/prqlc/prqlc/src/lib.rs
+++ b/prqlc/prqlc/src/lib.rs
@@ -82,7 +82,7 @@
 //! [profile.release.package.prqlc]
 //! strip = "debuginfo"
 //! ```
-
+#![feature(backtrace_frames)]
 #![forbid(unsafe_code)]
 // Our error type is 128 bytes, because it contains 5 strings & an Enum, which
 // is exactly the default warning level. Given we're not that performance
@@ -485,5 +485,52 @@ mod tests {
             .into_iter()
             .map(|name| Target::from_str(&name))
             .collect();
+    }
+
+    #[test]
+    fn long_query_inline() {
+        env_logger::builder().format_timestamp(None).init();
+        compile(
+            r#"
+let long_query = (
+  from employees
+  filter gross_cost > 0
+  group {title} (
+      aggregate {
+          ct = count this,
+      }
+  )
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+  sort ct
+  filter ct > 200
+  take 20
+)
+from long_query
+  "#,
+        )
+        .unwrap();
     }
 }

--- a/prqlc/prqlc/src/semantic/module.rs
+++ b/prqlc/prqlc/src/semantic/module.rs
@@ -183,6 +183,14 @@ impl Module {
 
         log::trace!("lookup: {ident}");
 
+        use std::backtrace;
+        let bt = backtrace::Backtrace::capture();
+        let len = bt.frames().len();
+        log::trace!("{}", len);
+        if len >= 120 {
+            log::trace!("{:?}\n", bt);
+        }
+
         let mut res = HashSet::new();
 
         res.extend(lookup_in(self, ident.clone()));


### PR DESCRIPTION
A slicker version of https://github.com/PRQL/prql/issues/2857#issuecomment-1603190843 in case that's helpful.

Run with:

```
RUST_BACKTRACE=1 RUST_LOG=trace cargo +nightly test -p prqlc --lib -- long_query_inline --nocapture
```

...may want to redirect to a file since it prints a lot...
