### PR TITLE
internal: Add comments to the lexer

### DIFF
--- a/prqlc/prqlc-parser/src/lexer.rs
+++ b/prqlc/prqlc-parser/src/lexer.rs
@@ -621,13 +621,13 @@ mod test {
 
     #[test]
     fn test_single_line_comment() {
-        assert_display_snapshot!(Token::Comment("This is a single-line comment".to_string()), @r###"
-        #This is a single-line comment
+        assert_display_snapshot!(Token::Comment(" This is a single-line comment".to_string()), @r###"
+        # This is a single-line comment
         "###);
-        assert_display_snapshot!(Token::Comment("This is a\nmulti-line\ncomment".to_string()), @r###"
-        #This is a
-        #multi-line
-        #comment
+        assert_display_snapshot!(Token::Comment(" This is a\n multi-line\n comment".to_string()), @r###"
+        # This is a
+        # multi-line
+        # comment
         "###);
     }
 

--- a/prqlc/prqlc-parser/src/lexer.rs
+++ b/prqlc/prqlc-parser/src/lexer.rs
@@ -523,7 +523,7 @@ impl std::fmt::Display for Token {
             }
             Token::Comment(s) => {
                 for line in s.lines() {
-                    writeln!(f, "# {}", line)?
+                    writeln!(f, "#{}", line)?
                 }
                 Ok(())
             }
@@ -621,11 +621,13 @@ mod test {
 
     #[test]
     fn test_single_line_comment() {
-        assert_display_snapshot!(Token::Comment("This is a single-line comment".to_string()), @"# This is a single-line comment");
+        assert_display_snapshot!(Token::Comment("This is a single-line comment".to_string()), @r###"
+        #This is a single-line comment
+        "###);
         assert_display_snapshot!(Token::Comment("This is a\nmulti-line\ncomment".to_string()), @r###"
-        # This is a
-        # multi-line
-        # comment
+        #This is a
+        #multi-line
+        #comment
         "###);
     }
 

--- a/prqlc/prqlc-parser/src/lib.rs
+++ b/prqlc/prqlc-parser/src/lib.rs
@@ -124,7 +124,6 @@ mod common {
 
 fn prepare_stream(
     tokens: impl Iterator<Item = TokenSpan>,
-
     source: &str,
     source_id: u16,
 ) -> Stream<Token, ParserSpan, impl Iterator<Item = (Token, ParserSpan)> + Sized> {

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__aggregation.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__aggregation.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/aggregation.prql
+input_file: prqlc/prqlc/tests/integration/queries/aggregation.prql
 ---
 TokenVec (
+  0..101: Comment(" mssql:skip\n mysql:skip\n clickhouse:skip\n glaredb:skip (the string_agg function is not supported)"),
   101..102: NewLine,
   102..106: Ident("from"),
   107..113: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__arithmetic.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__arithmetic.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/arithmetic.prql
+input_file: prqlc/prqlc/tests/integration/queries/arithmetic.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..19: Control('['),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__cast.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__cast.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/cast.prql
+input_file: prqlc/prqlc/tests/integration/queries/cast.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..24: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__date_to_text.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__date_to_text.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/date_to_text.prql
+input_file: prqlc/prqlc/tests/integration/queries/date_to_text.prql
 ---
 TokenVec (
+  0..56: Comment(" generic:skip\n glaredb:skip\n sqlite:skip\n mssql:test"),
   56..57: NewLine,
   57..61: Ident("from"),
   62..70: Ident("invoices"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/distinct.prql
+input_file: prqlc/prqlc/tests/integration/queries/distinct.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..24: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct_on.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct_on.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/distinct_on.prql
+input_file: prqlc/prqlc/tests/integration/queries/distinct_on.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..24: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__genre_counts.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__genre_counts.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/genre_counts.prql
+input_file: prqlc/prqlc/tests/integration/queries/genre_counts.prql
 ---
 TokenVec (
+  0..116: Comment(" clickhouse:skip (ClickHouse prefers aliases to column names https://github.com/PRQL/prql/issues/2827)\n mssql:test"),
   116..117: NewLine,
   117..120: Keyword("let"),
   121..132: Ident("genre_count"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_all.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_all.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/group_all.prql
+input_file: prqlc/prqlc/tests/integration/queries/group_all.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..19: Ident("a"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/group_sort.prql
+input_file: prqlc/prqlc/tests/integration/queries/group_sort.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..24: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort_limit_take.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort_limit_take.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/group_sort_limit_take.prql
+input_file: prqlc/prqlc/tests/integration/queries/group_sort_limit_take.prql
 ---
 TokenVec (
+  0..75: Comment(" Compute the 3 longest songs for each genre and sort by genre\n mssql:test"),
   75..76: NewLine,
   76..80: Ident("from"),
   81..87: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__invoice_totals.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__invoice_totals.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/invoice_totals.prql
+input_file: prqlc/prqlc/tests/integration/queries/invoice_totals.prql
 ---
 TokenVec (
+  0..56: Comment(" clickhouse:skip (clickhouse doesn't have lag function)"),
   56..57: NewLine,
   57..61: Ident("from"),
   62..63: Ident("i"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__loop_01.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__loop_01.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/loop_01.prql
+input_file: prqlc/prqlc/tests/integration/queries/loop_01.prql
 ---
 TokenVec (
+  0..161: Comment(" clickhouse:skip (DB::Exception: Syntax error)\n glaredb:skip (DataFusion does not support recursive CTEs https://github.com/apache/arrow-datafusion/issues/462)"),
   161..162: NewLine,
   162..166: Ident("from"),
   167..168: Control('['),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__math_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__math_module.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/math_module.prql
+input_file: prqlc/prqlc/tests/integration/queries/math_module.prql
 ---
 TokenVec (
+  0..81: Comment(" mssql:test\n sqlite:skip (see https://github.com/rusqlite/rusqlite/issues/1211)"),
   81..82: NewLine,
   82..86: Ident("from"),
   87..95: Ident("invoices"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__pipelines.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__pipelines.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/pipelines.prql
+input_file: prqlc/prqlc/tests/integration/queries/pipelines.prql
 ---
 TokenVec (
+  0..164: Comment(" sqlite:skip (Only works on Sqlite implementations which have the extension\n installed\n https://stackoverflow.com/questions/24037982/how-to-use-regexp-in-sqlite)"),
   164..165: NewLine,
   165..166: NewLine,
   166..170: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__read_csv.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__read_csv.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/read_csv.prql
+input_file: prqlc/prqlc/tests/integration/queries/read_csv.prql
 ---
 TokenVec (
+  0..42: Comment(" sqlite:skip\n postgres:skip\n mysql:skip"),
   42..43: NewLine,
   43..47: Ident("from"),
   48..49: Control('('),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__set_ops_remove.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/set_ops_remove.prql
+input_file: prqlc/prqlc/tests/integration/queries/set_ops_remove.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..16: Keyword("let"),
   17..25: Ident("distinct"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__sort.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__sort.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/sort.prql
+input_file: prqlc/prqlc/tests/integration/queries/sort.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..19: Ident("e"),
@@ -23,6 +24,7 @@ TokenVec (
   89..90: Control('}'),
   90..91: NewLine,
   91..92: NewLine,
+  92..144: Comment(" joining may use HashMerge, which can undo ORDER BY"),
   144..145: NewLine,
   145..149: Ident("join"),
   150..157: Ident("manager"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__switch.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__switch.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/switch.prql
+input_file: prqlc/prqlc/tests/integration/queries/switch.prql
 ---
 TokenVec (
+  0..88: Comment(" glaredb:skip (May be a bag of String type conversion for Postgres Client)\n mssql:test"),
   88..89: NewLine,
   89..93: Ident("from"),
   94..100: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__take.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__take.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/take.prql
+input_file: prqlc/prqlc/tests/integration/queries/take.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..24: Ident("tracks"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__text_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__text_module.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/text_module.prql
+input_file: prqlc/prqlc/tests/integration/queries/text_module.prql
 ---
 TokenVec (
+  0..12: Comment(" mssql:test"),
   12..13: NewLine,
   13..17: Ident("from"),
   18..24: Ident("albums"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__window.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__window.snap
@@ -1,9 +1,10 @@
 ---
-source: prqlc/prql-compiler/tests/integration/queries.rs
+source: prqlc/prqlc/tests/integration/queries.rs
 expression: tokens
-input_file: prqlc/prql-compiler/tests/integration/queries/window.prql
+input_file: prqlc/prqlc/tests/integration/queries/window.prql
 ---
 TokenVec (
+  0..337: Comment(" mssql:skip Conversion(\"cannot interpret I64(Some(1)) as an i32 value\")', connection.rs:200:34\n duckdb:skip problems with DISTINCT ON (duckdb internal error: [with INPUT_TYPE = int; RESULT_TYPE = unsigned char]: Assertion `min_val <= input' failed.)\n clickhouse:skip problems with DISTINCT ON\n postgres:skip problems with DISTINCT ON"),
   337..338: NewLine,
   338..342: Ident("from"),
   343..349: Ident("tracks"),


### PR DESCRIPTION
This doesn't impact any external interfaces atm — it adds comments to the lexer and filters them out before they hit the parser.

While we're still iterating on how comments (+ other significant whitespace) will be part of the formatter, we'll need comments in the lexer.
