### PR TITLE
docs: Fix `cargo doc`

### DIFF
--- a/prqlc/prqlc-ast/src/span.rs
+++ b/prqlc/prqlc-ast/src/span.rs
@@ -8,7 +8,7 @@ pub struct Span {
     pub start: usize,
     pub end: usize,
 
-    /// A key representing the path of the source. Value is stored in [`crate::SourceTree::source_ids`].
+    /// A key representing the path of the source. Value is stored in prqlc's SourceTree::source_ids.
     pub source_id: u16,
 }
 


### PR DESCRIPTION
Had to remove this link since `prqlc` is not a dependency of `prqlc-ast`
