### PR TITLE
docs: Small changes to `Expr` docstring

### DIFF
--- a/prqlc/prqlc-ast/src/expr.rs
+++ b/prqlc/prqlc-ast/src/expr.rs
@@ -24,10 +24,10 @@ impl Expr {
     }
 }
 
-// The following code is tested by the tests_misc crate to match expr.rs in prql_compiler.
+// The following code is tested by the tests_misc crate to match expr.rs in prqlc.
 
 /// Expr is anything that has a value and thus a type.
-/// If it cannot contain nested Exprs, is should be under [ExprKind::Literal].
+/// Most of these can contain other [Expr] themselves; literals should be [ExprKind::Literal].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Expr {
     #[serde(flatten)]

--- a/prqlc/prqlc/src/ir/pl/expr.rs
+++ b/prqlc/prqlc/src/ir/pl/expr.rs
@@ -14,7 +14,7 @@ use super::{Lineage, TransformCall};
 // The following code is tested by the tests_misc crate to match expr.rs in prqlc_ast.
 
 /// Expr is anything that has a value and thus a type.
-/// If it cannot contain nested Exprs, is should be under [ExprKind::Literal].
+/// Most of these can contain other [Expr] themselves; literals should be [ExprKind::Literal].
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Expr {
     #[serde(flatten)]


### PR DESCRIPTION
It seems not exactly accurate atm; for example `Param` doesn't contain other `Expr`s.
