### PR TITLE
docs: Add documentation on PostgreSQL extension

### DIFF
--- a/web/book/src/SUMMARY.md
+++ b/web/book/src/SUMMARY.md
@@ -96,6 +96,7 @@
   - [VS Code](./project/integrations/vscode.md)
   - [Rill](./project/integrations/rill.md)
   - [Syntax highlighting](./project/integrations/syntax-highlighting.md)
+  - [PostgreSQL](./project/integrations/postgresql.md)
 
 - [Contributing to PRQL](./project/contributing/README.md)
 

--- a/web/book/src/project/integrations/README.md
+++ b/web/book/src/project/integrations/README.md
@@ -8,5 +8,6 @@ PRQL is building integrations with lots of external tools, including:
 - [Prefect](./prefect.md)
 - [VS Code](./vscode.md)
 - [Rill](./rill.md)
+- [PostgreSQL](./postgresql.md)
 
 We also have a CLI, [`prqlc`](./prqlc-cli.md)

--- a/web/book/src/project/integrations/postgresql.md
+++ b/web/book/src/project/integrations/postgresql.md
@@ -1,6 +1,6 @@
 # PostgreSQL
 
-PL/PRQL is a PostgreSQL extension that lets you write functions with PRQL. 
+PL/PRQL is a PostgreSQL extension that lets you write functions with PRQL.
 
 PL/PRQL functions serve as intermediaries, compiling the user's PRQL code into SQL statements that PostgreSQL executes. The extension is based on the [pgrx](https://github.com/pgcentralfoundation/pgrx) for developing PostgreSQL extensions in Rust. This framework manages the interaction with PostgreSQL's internal APIs, type conversions, and other function hooks necessary to integrate PRQL with PostgreSQL.
 
@@ -23,8 +23,8 @@ create function match_stats(int) returns table(player text, kd_ratio float) as $
 $$ language plprql;
 
 select * from match_stats(1001)
-    
- player  | kd_ratio 
+
+ player  | kd_ratio
 ---------+----------
  Player1 |    0.625
  Player2 |      1.6
@@ -32,13 +32,13 @@ select * from match_stats(1001)
 ```
 
 You can also run PRQL directly with the `prql` function which is useful for custom SQL in ORMs:
- 
+
 ```sql
 select prql('from matches | filter player == ''Player1''', 'player1_cursor');
 
 fetch 2 from player1_cursor;
 
- id | match_id | round | player  | kills | deaths 
+ id | match_id | round | player  | kills | deaths
 ----+----------+-------+---------+-------+--------
   1 |     1001 |     1 | Player1 |     4 |      1
   3 |     1001 |     2 | Player1 |     1 |      7

--- a/web/book/src/project/integrations/postgresql.md
+++ b/web/book/src/project/integrations/postgresql.md
@@ -21,9 +21,9 @@ $$ language plprql
 
 You can also pass PRQL code to the `prql` function. For example:
 
- ```
- select prql('from rounds | filter match_id == 1, 'rounds_cursor');
- ```
+```sql
+select prql('from rounds | filter match_id == 1, 'rounds_cursor');
+```
 
 For more information on the extension, see the [PL/PRQL repository](https://github.com/kaspermarstal/plprql).
 

--- a/web/book/src/project/integrations/postgresql.md
+++ b/web/book/src/project/integrations/postgresql.md
@@ -20,12 +20,12 @@ $$ language plprql
 ```
 
 You can also pass PRQL code to the `prql` function. For example:
- 
+
  ```
  select prql('from rounds | filter match_id == 1, 'rounds_cursor');
  ```
 
-For more information on the extension, see the [PL/PRQL repository](https://github.com/kaspermarstal/plprql). 
+For more information on the extension, see the [PL/PRQL repository](https://github.com/kaspermarstal/plprql).
 
 # Getting started
 On Ubuntu, follow these steps to install PL/PRQL from source:
@@ -36,13 +36,13 @@ On Ubuntu, follow these steps to install PL/PRQL from source:
     cargo install --locked --version=0.11.2 cargo-pgrx
     ```
 
-    The version of `cargo-pgrx` must match the version of `pgrx` in `Cargo.toml`. 
+    The version of `cargo-pgrx` must match the version of `pgrx` in `Cargo.toml`.
 
 2. Initialize `pgrx` for your system.
    ```cmd
    cargo pgrx init --pg16 <PG16>
    ```
-   where `<PG16>` is the path to your system installation's `pg_config` tool (typically `/usr/bin/pg_config`). Supported versions are PostgreSQL v12-16. You can also run `cargo pgrx init` and have `pgrx` download, install, and compile PostgreSQL v12-16. These installations are managed by `pgrx` and used for development and testing. Individual `pgrx` installations can be installed using e.g. `cargo pgrx init --pg16 download`. 
+   where `<PG16>` is the path to your system installation's `pg_config` tool (typically `/usr/bin/pg_config`). Supported versions are PostgreSQL v12-16. You can also run `cargo pgrx init` and have `pgrx` download, install, and compile PostgreSQL v12-16. These installations are managed by `pgrx` and used for development and testing. Individual `pgrx` installations can be installed using e.g. `cargo pgrx init --pg16 download`.
 
 3. Clone this repository and `cd` into root directory.
 
@@ -50,19 +50,19 @@ On Ubuntu, follow these steps to install PL/PRQL from source:
     git clone https://github.com/kaspermarstal/plprql
     cd plprql
     ```
-   
+
 4. Install the extension to the PostgreSQL specified by
    the `pg_config` currently on your `$PATH`.
    ```cmd
    cargo pgrx install --release
    ```
    You can target a specific PostgreSQL installation by providing the path of another `pg_config` using the `-c` flag.
-   
+
 5. Fire up PostgreSQL and start writing functions right away!
    ```cmd
    $ cargo pgrx run pg16
    psql> create extension plprql;
-   psql> create function match_stats(int) 
+   psql> create function match_stats(int)
          returns table(total_kills real, total_deaths real) as $$
            from rounds
            filter match_id == $1
@@ -74,7 +74,7 @@ On Ubuntu, follow these steps to install PL/PRQL from source:
    psql> select match_stats(1);
    ```
 
-## Running Tests 
+## Running Tests
 You can run tests using `cargo pgrx test`. To run tests for all supported versions of PostgreSQL, run
 
 ```cmd

--- a/web/book/src/project/integrations/postgresql.md
+++ b/web/book/src/project/integrations/postgresql.md
@@ -1,0 +1,86 @@
+# PostgreSQL
+
+PL/PRQL is a PostgreSQL extension that lets you write functions with PRQL. For example:
+
+```sql
+create function player_stats(int) returns table(player text, kd_ratio real) as $$
+  from rounds
+  filter match_id == $1
+  group player (
+    aggregate {
+      total_kills = sum kills,
+      total_deaths = sum deaths
+    }
+  )
+  filter total_deaths > 0
+  derive kd_ratio = total_kills / total_deaths
+  select { player, kd_ratio }
+$$ language plprql
+
+```
+
+You can also pass PRQL code to the `prql` function. For example:
+ 
+ ```
+ select prql('from rounds | filter match_id == 1, 'rounds_cursor');
+ ```
+
+For more information on the extension, see the [PL/PRQL repository](https://github.com/kaspermarstal/plprql). 
+
+# Getting started
+On Ubuntu, follow these steps to install PL/PRQL from source:
+
+1. Install `cargo-pgrx`.
+
+    ```cmd
+    cargo install --locked --version=0.11.2 cargo-pgrx
+    ```
+
+    The version of `cargo-pgrx` must match the version of `pgrx` in `Cargo.toml`. 
+
+2. Initialize `pgrx` for your system.
+   ```cmd
+   cargo pgrx init --pg16 <PG16>
+   ```
+   where `<PG16>` is the path to your system installation's `pg_config` tool (typically `/usr/bin/pg_config`). Supported versions are PostgreSQL v12-16. You can also run `cargo pgrx init` and have `pgrx` download, install, and compile PostgreSQL v12-16. These installations are managed by `pgrx` and used for development and testing. Individual `pgrx` installations can be installed using e.g. `cargo pgrx init --pg16 download`. 
+
+3. Clone this repository and `cd` into root directory.
+
+    ```cmd
+    git clone https://github.com/kaspermarstal/plprql
+    cd plprql
+    ```
+   
+4. Install the extension to the PostgreSQL specified by
+   the `pg_config` currently on your `$PATH`.
+   ```cmd
+   cargo pgrx install --release
+   ```
+   You can target a specific PostgreSQL installation by providing the path of another `pg_config` using the `-c` flag.
+   
+5. Fire up PostgreSQL and start writing functions right away!
+   ```cmd
+   $ cargo pgrx run pg16
+   psql> create extension plprql;
+   psql> create function match_stats(int) 
+         returns table(total_kills real, total_deaths real) as $$
+           from rounds
+           filter match_id == $1
+           aggregate {
+             total_kills = sum kills,
+             total_deaths = sum deaths
+           }
+         $$ language plprql
+   psql> select match_stats(1);
+   ```
+
+## Running Tests 
+You can run tests using `cargo pgrx test`. To run tests for all supported versions of PostgreSQL, run
+
+```cmd
+cargo pgrx test pg16
+cargo pgrx test pg15
+cargo pgrx test pg14
+cargo pgrx test pg13
+cargo pgrx test pg12
+```

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -194,6 +194,10 @@ integrations_section:
       link: https://github.com/ywelsch/duckdb-prql
       text: A DuckDB extension to execute PRQL
 
+    - label: "PostgreSQL"
+      link: https://github.com/kaspermarstal/plprql
+      text: Write PRQL functions in PostgreSQL
+
 bindings_section:
   enable: true
   title: "Bindings"


### PR DESCRIPTION
This PR adds documentation on the PL/PRQL PostgreSQL extension to

- The "Integrations" section on the front page of the website
- The "Integrations" section in the book

See also discussion in #725