### PR TITLE
feat: table declarations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
           cargo-release
           pkg-config
           openssl
+          cargo-llvm-cov
 
           # actions
           go-task

--- a/prqlc/Taskfile.yaml
+++ b/prqlc/Taskfile.yaml
@@ -46,19 +46,22 @@ tasks:
       - cmd: cargo clippy --all-targets {{.packages_core}}
 
   test:
-    desc: A full test of prqlc
+    desc: |
+      A full test of prqlc (excluding --test-dbs-external).
+      Generates coverage report.
+    env:
+      # Use a different target dir so we don't poison the cache
+      CARGO_LLVM_COV_TARGET_DIR: ../target-cov
     cmds:
-      - cmd:
-          cargo nextest run {{.packages_core}} {{.packages_addon}}
-          {{.packages_bindings}}
+      - cmd: |
+          cargo \
+            llvm-cov --lcov --output-path lcov.info \
+            nextest --features=test-dbs \
+            {{.packages_core}} {{.packages_addon}} {{.packages_bindings}}
 
       - cmd:
           cargo clippy --all-targets {{.packages_core}} {{.packages_addon}}
           {{.packages_bindings}} -- -D warnings
-
-      - cmd:
-          cargo test --package prqlc --features=default,test-dbs
-          --test=integration -- queries::results
 
   pull-request:
     desc: Most checks that run within GH actions for a pull request

--- a/prqlc/prqlc-ast/src/error.rs
+++ b/prqlc/prqlc-ast/src/error.rs
@@ -112,29 +112,15 @@ impl std::fmt::Display for Errors {
 }
 
 pub trait WithErrorInfo: Sized {
-    fn span(&self) -> Option<&Span>;
-
     fn push_hint<S: Into<String>>(self, hint: S) -> Self;
 
     fn with_hints<S: Into<String>, I: IntoIterator<Item = S>>(self, hints: I) -> Self;
 
     fn with_span(self, span: Option<Span>) -> Self;
     fn with_code(self, code: &'static str) -> Self;
-
-    fn with_span_if_not_exists(self, span: Option<Span>) -> Self {
-        if self.span().is_none() {
-            self.with_span(span)
-        } else {
-            self
-        }
-    }
 }
 
 impl WithErrorInfo for Error {
-    fn span(&self) -> Option<&Span> {
-        self.span.as_ref()
-    }
-
     fn with_hints<S: Into<String>, I: IntoIterator<Item = S>>(mut self, hints: I) -> Self {
         self.hints = hints.into_iter().map(|x| x.into()).collect();
         self
@@ -158,10 +144,6 @@ impl WithErrorInfo for Error {
 
 #[cfg(feature = "anyhow")]
 impl WithErrorInfo for anyhow::Error {
-    fn span(&self) -> Option<&Span> {
-        self.downcast_ref::<Error>().and_then(|e| e.span.as_ref())
-    }
-
     fn push_hint<S: Into<String>>(self, hint: S) -> Self {
         self.downcast_ref::<Error>()
             .map(|e| e.clone().push_hint(hint).into())
@@ -191,10 +173,6 @@ impl WithErrorInfo for anyhow::Error {
 }
 
 impl<T, E: WithErrorInfo> WithErrorInfo for Result<T, E> {
-    fn span(&self) -> Option<&Span> {
-        self.as_ref().err().and_then(|x| x.span())
-    }
-
     fn with_hints<S: Into<String>, I: IntoIterator<Item = S>>(self, hints: I) -> Self {
         self.map_err(|e| e.with_hints(hints))
     }

--- a/prqlc/prqlc-ast/src/expr/ident.rs
+++ b/prqlc/prqlc-ast/src/expr/ident.rs
@@ -67,10 +67,18 @@ impl Ident {
             .all(|(prefix_component, self_component)| prefix_component == self_component)
     }
 
+    pub fn starts_with_path<S: AsRef<str>>(&self, prefix: &[S]) -> bool {
+        if prefix.len() > self.path.len() + 1 {
+            return false;
+        }
+        prefix
+            .iter()
+            .zip(self.iter())
+            .all(|(prefix_component, self_component)| prefix_component.as_ref() == self_component)
+    }
+
     pub fn starts_with_part(&self, prefix: &str) -> bool {
-        self.iter()
-            .next()
-            .map_or(false, |self_component| self_component == prefix)
+        self.starts_with_path(&[prefix])
     }
 }
 

--- a/prqlc/prqlc-ast/src/expr/ident.rs
+++ b/prqlc/prqlc-ast/src/expr/ident.rs
@@ -27,6 +27,14 @@ impl Ident {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.path.len() + 1
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
     /// Remove last part of the ident.
     /// Result will generally refer to the parent of this ident.
     pub fn pop(self) -> Option<Self> {
@@ -58,7 +66,7 @@ impl Ident {
     }
 
     pub fn starts_with(&self, prefix: &Ident) -> bool {
-        if prefix.path.len() > self.path.len() {
+        if prefix.len() > self.len() {
             return false;
         }
         prefix
@@ -68,7 +76,8 @@ impl Ident {
     }
 
     pub fn starts_with_path<S: AsRef<str>>(&self, prefix: &[S]) -> bool {
-        if prefix.len() > self.path.len() + 1 {
+        // self is an I
+        if prefix.len() > self.len() {
             return false;
         }
         prefix
@@ -116,7 +125,7 @@ impl Serialize for Ident {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_seq(Some(self.path.len() + 1))?;
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
         for part in &self.path {
             seq.serialize_element(part)?;
         }

--- a/prqlc/prqlc-ast/src/stmt.rs
+++ b/prqlc/prqlc-ast/src/stmt.rs
@@ -45,7 +45,7 @@ pub enum StmtKind {
 pub struct VarDef {
     pub kind: VarDefKind,
     pub name: String,
-    pub value: Box<Expr>,
+    pub value: Option<Box<Expr>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ty: Option<Ty>,

--- a/prqlc/prqlc-parser/src/stmt.rs
+++ b/prqlc/prqlc-parser/src/stmt.rs
@@ -107,8 +107,7 @@ fn var_def() -> impl Parser<Token, StmtKind, Error = PError> {
     let let_ = keyword("let")
         .ignore_then(ident_part())
         .then(type_expr().delimited_by(ctrl('<'), ctrl('>')).or_not())
-        .then_ignore(ctrl('='))
-        .then(expr_call().map(Box::new))
+        .then(ctrl('=').ignore_then(expr_call()).map(Box::new).or_not())
         .map(|((name, ty), value)| {
             StmtKind::VarDef(VarDef {
                 name,
@@ -133,7 +132,7 @@ fn var_def() -> impl Parser<Token, StmtKind, Error = PError> {
             StmtKind::VarDef(VarDef {
                 name,
                 kind,
-                value,
+                value: Some(value),
                 ty: None,
             })
         })

--- a/prqlc/prqlc-parser/src/test.rs
+++ b/prqlc/prqlc-parser/src/test.rs
@@ -16,7 +16,7 @@ fn parse_expr(source: &str) -> Result<Expr, Vec<Error>> {
 
     let stmts = parse_single(&source)?;
     let stmt = stmts.into_iter().exactly_one().unwrap();
-    Ok(*stmt.kind.into_var_def().unwrap().value)
+    Ok(*stmt.kind.into_var_def().unwrap().value.unwrap())
 }
 
 #[test]

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -12,6 +12,7 @@ use clap::{CommandFactory, Parser, Subcommand, ValueHint};
 use clio::has_extension;
 use clio::Output;
 use itertools::Itertools;
+use prqlc::semantic::NS_DEFAULT_DB;
 use prqlc_ast::stmt::StmtKind;
 use std::collections::HashMap;
 use std::env;
@@ -376,7 +377,7 @@ impl Command {
                 semantic::load_std_lib(sources);
 
                 let ast = prql_to_pl_tree(sources)?;
-                let ir = pl_to_rq_tree(ast, &main_path)?;
+                let ir = pl_to_rq_tree(ast, &main_path, &[NS_DEFAULT_DB.to_string()])?;
 
                 match format {
                     Format::Json => serde_json::to_string_pretty(&ir)?.into_bytes(),
@@ -397,7 +398,7 @@ impl Command {
                     .with_format(*format);
 
                 prql_to_pl_tree(sources)
-                    .and_then(|pl| pl_to_rq_tree(pl, &main_path))
+                    .and_then(|pl| pl_to_rq_tree(pl, &main_path, &[NS_DEFAULT_DB.to_string()]))
                     .and_then(|rq| rq_to_sql(rq, &opts))
                     .map_err(|e| e.composed(sources))?
                     .as_bytes()
@@ -408,7 +409,7 @@ impl Command {
                 semantic::load_std_lib(sources);
 
                 let ast = prql_to_pl_tree(sources)?;
-                let rq = pl_to_rq_tree(ast, &main_path)?;
+                let rq = pl_to_rq_tree(ast, &main_path, &[NS_DEFAULT_DB.to_string()])?;
                 let srq = prqlc::sql::internal::preprocess(rq)?;
                 format!("{srq:#?}").as_bytes().to_vec()
             }
@@ -416,7 +417,7 @@ impl Command {
                 semantic::load_std_lib(sources);
 
                 let ast = prql_to_pl_tree(sources)?;
-                let rq = pl_to_rq_tree(ast, &main_path)?;
+                let rq = pl_to_rq_tree(ast, &main_path, &[NS_DEFAULT_DB.to_string()])?;
                 let srq = prqlc::sql::internal::anchor(rq)?;
 
                 let json = serde_json::to_string_pretty(&srq)?;

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -361,7 +361,7 @@ impl Command {
                         if let StmtKind::VarDef(def) = stmt.kind {
                             res += &format!("## {}\n", def.name);
 
-                            let val = semantic::eval(*def.value)
+                            let val = semantic::eval(*def.value.unwrap())
                                 .map_err(downcast)
                                 .map_err(|e| e.composed(sources))?;
                             res += &semantic::write_pl(val);

--- a/prqlc/prqlc/src/codegen/ast.rs
+++ b/prqlc/prqlc/src/codegen/ast.rs
@@ -379,6 +379,7 @@ impl WriteSource for Stmt {
                         }
                         _ => {
                             r += &val.write(opt)?;
+                            r += "\n";
                         }
                     }
 
@@ -525,6 +526,19 @@ mod test {
     }
 
     #[test]
+    fn test_binary() {
+        assert_is_formatted(r#"let a = 5 * (4 + 3) ?? (5 / 2) // 2 == 1 and true"#);
+
+        // TODO: associativity is not handled correctly
+        // assert_is_formatted(r#"let a = 5 / 2 / 2"#);
+    }
+
+    #[test]
+    fn test_func() {
+        assert_is_formatted(r#"let a = func x y:false -> x and y"#);
+    }
+
+    #[test]
     fn test_simple() {
         assert_is_formatted(
             r#"
@@ -553,15 +567,73 @@ group {title, country} (aggregate {
     fn test_range() {
         assert_is_formatted(
             r#"
-from foo
-is_negative = -100..0
+let negative = -100..0
 "#,
         );
 
         assert_is_formatted(
             r#"
-from foo
-is_negative = -(100..0)
+let negative = -(100..0)
+"#,
+        );
+
+        assert_is_formatted(
+            r#"
+let negative = -100..
+"#,
+        );
+
+        assert_is_formatted(
+            r#"
+let negative = ..-100
+"#,
+        );
+    }
+
+    #[test]
+    fn test_annotation() {
+        assert_is_formatted(
+            r#"
+@deprecated
+module hello {
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_var_def() {
+        assert_is_formatted(
+            r#"
+let a
+"#,
+        );
+
+        assert_is_formatted(
+            r#"
+let a <int>
+"#,
+        );
+
+        assert_is_formatted(
+            r#"
+let a = 5
+"#,
+        );
+
+        assert_is_formatted(
+            r#"
+5
+into a
+"#,
+        );
+    }
+
+    #[test]
+    fn test_query_def() {
+        assert_is_formatted(
+            r#"
+prql version:"^0.9" target:sql.sqlite
 "#,
         );
     }

--- a/prqlc/prqlc/src/ir/pl/fold.rs
+++ b/prqlc/prqlc/src/ir/pl/fold.rs
@@ -128,7 +128,7 @@ fn fold_module_def<F: ?Sized + PlFold>(fold: &mut F, module_def: ModuleDef) -> R
 pub fn fold_var_def<F: ?Sized + PlFold>(fold: &mut F, var_def: VarDef) -> Result<VarDef> {
     Ok(VarDef {
         name: var_def.name,
-        value: Box::new(fold.fold_expr(*var_def.value)?),
+        value: fold_optional_box(fold, var_def.value)?,
         ty: var_def.ty.map(|x| fold.fold_type(x)).transpose()?,
     })
 }

--- a/prqlc/prqlc/src/ir/pl/stmt.rs
+++ b/prqlc/prqlc/src/ir/pl/stmt.rs
@@ -33,7 +33,7 @@ pub enum StmtKind {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct VarDef {
     pub name: String,
-    pub value: Box<Expr>,
+    pub value: Option<Box<Expr>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ty: Option<Ty>,

--- a/prqlc/prqlc/src/semantic/eval.rs
+++ b/prqlc/prqlc/src/semantic/eval.rs
@@ -460,7 +460,7 @@ mod test {
 
     fn eval(source: &str) -> Result<String> {
         let stmts = crate::prql_to_pl(source)?.into_iter().exactly_one()?;
-        let expr = stmts.kind.into_var_def().unwrap().value;
+        let expr = stmts.kind.into_var_def().unwrap().value.unwrap();
 
         let value = super::eval(*expr)?;
 

--- a/prqlc/prqlc/src/semantic/lowering.rs
+++ b/prqlc/prqlc/src/semantic/lowering.rs
@@ -79,8 +79,8 @@ fn extern_ref_to_relation(
         let (_, remainder) = fq_ident.clone().pop_front();
         remainder.unwrap()
     } else {
-        // tables that are not from default_db
-        todo!()
+        // tables that are not from default_db: use full name
+        fq_ident.clone()
     };
 
     // put wildcards last

--- a/prqlc/prqlc/src/semantic/lowering.rs
+++ b/prqlc/prqlc/src/semantic/lowering.rs
@@ -19,15 +19,22 @@ use crate::COMPILER_VERSION;
 use crate::{Error, Reason, Span, WithErrorInfo};
 use prqlc_ast::expr::generic::{InterpolateItem, Range, SwitchCase};
 
-use super::NS_DEFAULT_DB;
-
-/// Convert AST into IR and make sure that:
+/// Convert a resolved expression at path `main_path` relative to `root_mod`
+/// into RQ and make sure that:
 /// - transforms are not nested,
 /// - transforms have correct partition, window and sort set,
 /// - make sure there are no unresolved expressions.
+///
+/// All table references must reside within module at `database_module_path`.
+/// They are compiled to table identifiers, using their path relative to the database module.
+/// For example, with `database_module_path=my_database`:
+/// - `my_database.my_table` will compile to `"my_table"`,
+/// - `my_database.my_schema.my_table` will compile to `"my_schema.my_table"`,
+/// - `my_table` will error out saying that this table does not reside in current database.
 pub fn lower_to_ir(
     root_mod: RootModule,
     main_path: &[String],
+    database_module_path: &[String],
 ) -> Result<(RelationalQuery, RootModule)> {
     // find main
     log::debug!("lookup for main pipeline in {main_path:?}");
@@ -50,12 +57,17 @@ pub fn lower_to_ir(
     let tables = toposort_tables(tables, &main_ident);
 
     // lower tables
-    let mut l = Lowerer::new(root_mod);
+    let mut l = Lowerer::new(root_mod, database_module_path);
     let mut main_relation = None;
-    for (fq_ident, table) in tables {
+    for (fq_ident, (table, declared_at)) in tables {
         let is_main = fq_ident == main_ident;
 
-        l.lower_table_decl(table, fq_ident)?;
+        let span = declared_at
+            .and_then(|id| l.root_mod.span_map.get(&id))
+            .cloned();
+
+        l.lower_table_decl(table, fq_ident)
+            .with_span_if_not_exists(span)?;
 
         if is_main {
             let main_table = l.table_buffer.pop().unwrap();
@@ -74,13 +86,24 @@ pub fn lower_to_ir(
 fn extern_ref_to_relation(
     mut columns: Vec<TupleField>,
     fq_ident: &Ident,
-) -> (rq::Relation, Option<String>) {
-    let extern_name = if fq_ident.starts_with_part(NS_DEFAULT_DB) {
-        let (_, remainder) = fq_ident.clone().pop_front();
-        remainder.unwrap()
+    database_module_path: &[String],
+) -> Result<(rq::Relation, Option<String>), Error> {
+    let extern_name = if fq_ident.starts_with_path(database_module_path) {
+        let relative_to_database: Vec<&String> =
+            fq_ident.iter().skip(database_module_path.len()).collect();
+        if relative_to_database.is_empty() {
+            None
+        } else {
+            Some(Ident::from_path(relative_to_database))
+        }
     } else {
-        // tables that are not from default_db: use full name
-        fq_ident.clone()
+        None
+    };
+
+    let Some(extern_name) = extern_name else {
+        let database_module = Ident::from_path(database_module_path.to_vec());
+        return Err(Error::new_simple("this table is not in the current database")
+            .push_hint(format!("If this is a table in the current database, move its declaration into module {database_module}")));
     };
 
     // put wildcards last
@@ -90,7 +113,7 @@ fn extern_ref_to_relation(
         kind: rq::RelationKind::ExternRef(extern_name),
         columns: tuple_fields_to_relation_columns(columns),
     };
-    (relation, None)
+    Ok((relation, None))
 }
 
 fn tuple_fields_to_relation_columns(columns: Vec<TupleField>) -> Vec<RelationColumn> {
@@ -118,6 +141,7 @@ struct Lowerer {
     tid: IdGenerator<TId>,
 
     root_mod: RootModule,
+    database_module_path: Vec<String>,
 
     /// describes what has certain id has been lowered to
     node_mapping: HashMap<usize, LoweredTarget>,
@@ -146,9 +170,10 @@ enum LoweredTarget {
 }
 
 impl Lowerer {
-    fn new(root_mod: RootModule) -> Self {
+    fn new(root_mod: RootModule, database_module_path: &[String]) -> Self {
         Lowerer {
             root_mod,
+            database_module_path: database_module_path.to_vec(),
 
             cid: IdGenerator::new(),
             tid: IdGenerator::new(),
@@ -173,7 +198,9 @@ impl Lowerer {
                 // a CTE
                 (self.lower_relation(*expr)?, Some(fq_ident.name.clone()))
             }
-            TableExpr::LocalTable => extern_ref_to_relation(columns, &fq_ident),
+            TableExpr::LocalTable => {
+                extern_ref_to_relation(columns, &fq_ident, &self.database_module_path)?
+            }
             TableExpr::Param(_) => unreachable!(),
             TableExpr::None => return Ok(()),
         };
@@ -1008,12 +1035,12 @@ fn validate_take_range(range: &Range<rq::Expr>, span: Option<Span>) -> Result<()
 struct TableExtractor {
     path: Vec<String>,
 
-    tables: Vec<(Ident, decl::TableDecl)>,
+    tables: Vec<(Ident, (decl::TableDecl, Option<usize>))>,
 }
 
 impl TableExtractor {
     /// Finds table declarations in a module, recursively.
-    fn extract(root_module: &Module) -> Vec<(Ident, decl::TableDecl)> {
+    fn extract(root_module: &Module) -> Vec<(Ident, (decl::TableDecl, Option<usize>))> {
         let mut te = TableExtractor::default();
         te.extract_from_module(root_module);
         te.tables
@@ -1030,7 +1057,8 @@ impl TableExtractor {
                 }
                 DeclKind::TableDecl(table) => {
                     let fq_ident = Ident::from_path(self.path.clone());
-                    self.tables.push((fq_ident, table.clone()));
+                    self.tables
+                        .push((fq_ident, (table.clone(), entry.declared_at)));
                 }
                 _ => {}
             }
@@ -1043,14 +1071,14 @@ impl TableExtractor {
 /// are not needed for the main pipeline. To do this, it needs to collect references
 /// between pipelines.
 fn toposort_tables(
-    tables: Vec<(Ident, decl::TableDecl)>,
+    tables: Vec<(Ident, (decl::TableDecl, Option<usize>))>,
     main_table: &Ident,
-) -> Vec<(Ident, decl::TableDecl)> {
+) -> Vec<(Ident, (decl::TableDecl, Option<usize>))> {
     let tables: HashMap<_, _, RandomState> = HashMap::from_iter(tables);
 
     let mut dependencies: Vec<(Ident, Vec<Ident>)> = Vec::new();
     for (ident, table) in &tables {
-        let deps = if let TableExpr::RelationVar(e) = &table.expr {
+        let deps = if let TableExpr::RelationVar(e) = &table.0.expr {
             TableDepsCollector::collect(*e.clone())
         } else {
             vec![]

--- a/prqlc/prqlc/src/semantic/mod.rs
+++ b/prqlc/prqlc/src/semantic/mod.rs
@@ -27,10 +27,13 @@ use crate::{Error, Reason, SourceTree};
 pub fn resolve_and_lower(
     file_tree: SourceTree<Vec<prqlc_ast::stmt::Stmt>>,
     main_path: &[String],
+    database_module_path: Option<&[String]>,
 ) -> Result<RelationalQuery> {
     let root_mod = resolve(file_tree, Default::default())?;
 
-    let (query, _) = lowering::lower_to_ir(root_mod, main_path)?;
+    let default_db = [NS_DEFAULT_DB.to_string()];
+    let database_module_path = database_module_path.unwrap_or(&default_db);
+    let (query, _) = lowering::lower_to_ir(root_mod, main_path, database_module_path)?;
     Ok(query)
 }
 
@@ -284,7 +287,7 @@ pub mod test {
 
     pub fn parse_resolve_and_lower(query: &str) -> Result<RelationalQuery> {
         let source_tree = query.into();
-        resolve_and_lower(parse(&source_tree)?, &[])
+        resolve_and_lower(parse(&source_tree)?, &[], None)
     }
 
     pub fn parse_and_resolve(query: &str) -> Result<RootModule> {

--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -44,10 +44,10 @@ impl PlFold for Resolver<'_> {
     }
 
     fn fold_var_def(&mut self, var_def: VarDef) -> Result<VarDef> {
-        let value = if matches!(var_def.value.kind, ExprKind::Func(_)) {
-            var_def.value
-        } else {
-            Box::new(flatten::Flattener::fold(self.fold_expr(*var_def.value)?))
+        let value = match var_def.value {
+            Some(value) if matches!(value.kind, ExprKind::Func(_)) => Some(value),
+            Some(value) => Some(Box::new(flatten::Flattener::fold(self.fold_expr(*value)?))),
+            None => None,
         };
 
         Ok(VarDef {

--- a/prqlc/prqlc/src/semantic/resolver/generic.rs
+++ b/prqlc/prqlc/src/semantic/resolver/generic.rs
@@ -1,0 +1,2 @@
+use prqlc_ast::Ty;
+

--- a/prqlc/prqlc/src/semantic/resolver/generic.rs
+++ b/prqlc/prqlc/src/semantic/resolver/generic.rs
@@ -1,2 +1,0 @@
-use prqlc_ast::Ty;
-

--- a/prqlc/prqlc/tests/integration/bad_error_messages.rs
+++ b/prqlc/prqlc/tests/integration/bad_error_messages.rs
@@ -192,6 +192,14 @@ fn nested_groups() {
       )
     )
     "###).unwrap_err(), @r###"
-    Error: internal compiler error; tracked at https://github.com/PRQL/prql/issues/3870
+    Error:
+        ╭─[:2:5]
+        │
+      2 │ ╭─▶     from inv=invoices
+        ┆ ┆
+     12 │ ├─▶     )
+        │ │
+        │ ╰─────────── internal compiler error; tracked at https://github.com/PRQL/prql/issues/3870
+    ────╯
     "###);
 }

--- a/prqlc/prqlc/tests/integration/resolving.rs
+++ b/prqlc/prqlc/tests/integration/resolving.rs
@@ -97,6 +97,19 @@ fn resolve_types_04() {
 }
 
 #[test]
+fn resolve_types_05() {
+    // TODO: this is very strange, it should only be allowed in std
+    assert_snapshot!(resolve(
+        r#"
+    type A
+    "#,
+    )
+    .unwrap(), @r###"
+    type A = null
+    "###);
+}
+
+#[test]
 fn resolve_generics_01() {
     assert_snapshot!(resolve(
         r#"

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -4959,3 +4959,22 @@ fn test_table_declarations() {
       10
     "###);
 }
+
+#[test]
+fn test_param_declarations() {
+    assert_display_snapshot!(compile(
+        r###"
+    let a <int>
+
+    from x | filter b == a
+        "###,
+    )
+    .unwrap(), @r###"
+    SELECT
+      *
+    FROM
+      x
+    WHERE
+      b = $a
+    "###);
+}

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -2273,7 +2273,7 @@ fn test_from_json() {
     prqlc::semantic::load_std_lib(&mut source_tree);
 
     let sql_from_prql = Ok(prqlc::prql_to_pl_tree(&source_tree).unwrap())
-        .and_then(|ast| prqlc::semantic::resolve_and_lower(ast, &[]))
+        .and_then(|ast| prqlc::semantic::resolve_and_lower(ast, &[], None))
         .and_then(|rq| sql::compile(rq, &Options::default()))
         .unwrap();
 
@@ -4935,13 +4935,15 @@ fn test_group_exclude() {
 fn test_table_declarations() {
     assert_display_snapshot!(compile(
         r###"
-    module my_schema {
-      let my_table <[{ id = int, a = text }]>
+    module default_db {
+      module my_schema {
+        let my_table <[{ id = int, a = text }]>
+      }
+
+      let another_table <[{ id = int, b = text }]>
     }
 
-    let another_table <[{ id = int, b = text }]>
-
-    my_schema.my_table | join another_table (==id) | take 10
+    from my_schema.my_table | join another_table (==id) | take 10
         "###,
     )
     .unwrap(), @r###"

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -4930,3 +4930,30 @@ fn test_group_exclude() {
     //   x
     // "###);
 }
+
+#[test]
+fn test_table_declarations() {
+    assert_display_snapshot!(compile(
+        r###"
+    module my_schema {
+      let my_table <[{ id = int, a = text }]>
+    }
+
+    let another_table <[{ id = int, b = text }]>
+
+    my_schema.my_table | join another_table (==id) | take 10
+        "###,
+    )
+    .unwrap(), @r###"
+    SELECT
+      my_table.id,
+      my_table.a,
+      another_table.id,
+      another_table.b
+    FROM
+      my_schema.my_table
+      JOIN another_table ON my_table.id = another_table.id
+    LIMIT
+      10
+    "###);
+}

--- a/prqlc/prqlc/tests/integration/static_eval.rs
+++ b/prqlc/prqlc/tests/integration/static_eval.rs
@@ -10,7 +10,7 @@ fn static_eval(prql_source: &str) -> ConstExpr {
     let stmts = stmts_tree.sources.values().next().unwrap();
     let stmt = stmts.iter().next().unwrap();
     let var_def: &VarDef = stmt.kind.as_var_def().unwrap();
-    let expr: Expr = var_def.value.as_ref().clone();
+    let expr: Expr = *var_def.value.as_ref().unwrap().clone();
 
     let expr = prqlc::semantic::ast_expand::expand_expr(expr).unwrap();
 


### PR DESCRIPTION
Closes #2646 with adding support for:

```elm
    module my_schema {
      let my_table <[{ id = int, a = text }]>
    }

    let another_table <[{ id = int, b = text }]>

    my_schema.my_table
    join another_table (==id)
    take 10
```

The rule is that any variable declaration with relational type and without an assigned value will be treated as a table in the database.

Fully qualified name is used to refer to that table. This will be changed soon.