### PR TITLE
feat: Add Sublime Text grammar to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Add syntax highlight file for GtkSourceView. (@vanillajonathan, #4062)
 - Add syntax highlight file for CotEditor. (@vanillajonathan)
+- Add syntax highlight file for Sublime Text. (@vanillajonathan, #4127)
 - [sloc](https://github.com/flosse/sloc), a source lines of code counter now has
   support for `.prql` files. (@vanillajonathan)
 

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -27,7 +27,9 @@ an index.
   - The website (outside of the book & playground):
     [`website/themes/prql-theme/static/plugins/highlight/prql.js`](https://github.com/PRQL/prql/blob/main/web/book/highlight-prql.js)
 
-- [Textmate](https://macromates.com/manual/en/language_grammars) — used by the
+- Sublime Text — It's in the [`sublime-prql`](https://github.com/PRQL/sublime-prql/) repository.
+
+- [TextMate](https://macromates.com/manual/en/language_grammars) — used by the
   VS Code extension. It's in the `prql-vscode` repo in
   [`prql-vscode/syntaxes/prql.tmLanguage.json`](https://github.com/PRQL/prql-vscode/blob/main/syntaxes/prql.tmLanguage.json).
 


### PR DESCRIPTION
I have created a syntax highlight file for the macOS text editor Sublime Text.

The grammar is also supported by the Rust library [syntect](https://github.com/trishume/syntect) which is used by software such as [bat](https://github.com/sharkdp/bat) (`bat` is like `cat` but with syntax highlighting) and some other software such as documentation generators, static site generators, markdown software, etc (see [Projects using Syntect](https://github.com/trishume/syntect#projects-using-syntect)).

To be able to have it on [packagecontrol.io](https://packagecontrol.io/) we need to put it in an own repository, for example `sublime-prql`.