### PR TITLE
docs: Add example for running prql code directly in PostgreSQL without cursor

### DIFF
--- a/web/book/src/project/integrations/postgresql.md
+++ b/web/book/src/project/integrations/postgresql.md
@@ -44,7 +44,7 @@ limit 2;
   3 |     1001 |     2 | Player1 |     1 |      7
 (2 rows)
 
--- Same as above, but returns cursor
+-- Same as above without the need for the static types, but returns cursor
 select prql('from matches | filter player == ''Player1''', 'player1_cursor');
 fetch 2 from player1_cursor;
 ```

--- a/web/book/src/project/integrations/postgresql.md
+++ b/web/book/src/project/integrations/postgresql.md
@@ -2,7 +2,7 @@
 
 PL/PRQL is a PostgreSQL extension that lets you write functions with PRQL.
 
-PL/PRQL functions serve as intermediaries, compiling the user's PRQL code into SQL statements that PostgreSQL executes. The extension is based on the [pgrx](https://github.com/pgcentralfoundation/pgrx) for developing PostgreSQL extensions in Rust. This framework manages the interaction with PostgreSQL's internal APIs, type conversions, and other function hooks necessary to integrate PRQL with PostgreSQL.
+PL/PRQL functions serve as intermediaries, compiling the user's PRQL code into SQL statements that PostgreSQL executes. The extension is based on the [pgrx](https://github.com/pgcentralfoundation/pgrx) framework for developing PostgreSQL extensions in Rust. This framework manages the interaction with PostgreSQL's internal APIs, type conversions, and other function hooks necessary to integrate PRQL with PostgreSQL.
 
 
 ## Examples
@@ -31,18 +31,22 @@ select * from match_stats(1001)
 (2 rows)
 ```
 
-You can also run PRQL directly with the `prql` function which is useful for custom SQL in ORMs:
+You can also run PRQL code directly with the `prql` function which is useful for custom SQL in ORMs:
 
 ```sql
-select prql('from matches | filter player == ''Player1''', 'player1_cursor');
+select prql('from matches | filter player == ''Player1''') 
+as (id int, match_id int, round int, player text, kills int, deaths int) 
+limit 2;
 
-fetch 2 from player1_cursor;
-
- id | match_id | round | player  | kills | deaths
+ id | match_id | round | player  | kills | deaths 
 ----+----------+-------+---------+-------+--------
   1 |     1001 |     1 | Player1 |     4 |      1
   3 |     1001 |     2 | Player1 |     1 |      7
 (2 rows)
+ 
+-- Same as above, but returns cursor
+select prql('from matches | filter player == ''Player1''', 'player1_cursor');
+fetch 2 from player1_cursor;
 ```
 
 ## Getting Started

--- a/web/book/src/project/integrations/postgresql.md
+++ b/web/book/src/project/integrations/postgresql.md
@@ -34,16 +34,16 @@ select * from match_stats(1001)
 You can also run PRQL code directly with the `prql` function which is useful for custom SQL in ORMs:
 
 ```sql
-select prql('from matches | filter player == ''Player1''') 
-as (id int, match_id int, round int, player text, kills int, deaths int) 
+select prql('from matches | filter player == ''Player1''')
+as (id int, match_id int, round int, player text, kills int, deaths int)
 limit 2;
 
- id | match_id | round | player  | kills | deaths 
+ id | match_id | round | player  | kills | deaths
 ----+----------+-------+---------+-------+--------
   1 |     1001 |     1 | Player1 |     4 |      1
   3 |     1001 |     2 | Player1 |     1 |      7
 (2 rows)
- 
+
 -- Same as above, but returns cursor
 select prql('from matches | filter player == ''Player1''', 'player1_cursor');
 fetch 2 from player1_cursor;


### PR DESCRIPTION
This PR adds an example to the PostgreSQL extension docs for running PRQL code directly without the use of curser. The new function in the extension returns `setof record`. We previously discussed this issue in #725. The solution was to declare the record's type using e.g. `as (name text, age int)`.