### PR TITLE
ci: Longer time-outs for link checks

### DIFF
--- a/.config/.markdown-link-check-local.json
+++ b/.config/.markdown-link-check-local.json
@@ -6,5 +6,9 @@
       "_comment_3": "So this excludes anything that's not a relative link to a file in our repo or a link to our file on the web.",
       "pattern": "^(?!https://github\\.com/(PRQL|prql)|https://prql-lang\\.org|https://raw\\.githubusercontent\\.com/(PRQL|prql)|[./]+|file://).*$"
     }
-  ]
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s"
 }


### PR DESCRIPTION
This may reduce the prevalence of broken nightly tests, such as #4170. I tested running `pre-commit run -a --hook-stage=manual` lots of time concurrently and it helped. If anyone has a view on a better approach / whether all these options are needed, please feel free to adjust...
