### PR TITLE
build(lutra): Resolve naming issues

### DIFF
--- a/lutra/bindings/python/Cargo.toml
+++ b/lutra/bindings/python/Cargo.toml
@@ -12,7 +12,6 @@ version.workspace = true
 [lib]
 crate-type = ["cdylib"]
 doc = false
-name = "lutra_python"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 arrow = {version = "49.0", features = ["pyarrow"], default-features = false}

--- a/lutra/bindings/python/Cargo.toml
+++ b/lutra/bindings/python/Cargo.toml
@@ -11,15 +11,15 @@ version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
-name = "lutra"
 doc = false
+name = "lutra_python"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-# we rename lutra to lutralib here, so we can define a function named lutra
-lutralib = { package = "lutra", path = "../../lutra", default-features = false }
-arrow = { version = "49.0", features = ["pyarrow"], default-features = false }
+arrow = {version = "49.0", features = ["pyarrow"], default-features = false}
 itertools = "0.12.0"
-pyo3 = { version = "0.20.2", features = ["abi3-py37", "anyhow"] }
+# we rename lutra to lutralib here, so we can define a function named lutra
+lutralib = {package = "lutra", path = "../../lutra", default-features = false}
+pyo3 = {version = "0.20.2", features = ["abi3-py37", "anyhow"]}
 
 [build-dependencies]
 pyo3-build-config = "0.20.2"
@@ -27,3 +27,9 @@ pyo3-build-config = "0.20.2"
 [package.metadata.release]
 tag-name = "{{version}}"
 tag-prefix = ""
+
+# We want the package to be named `lutra`, but the crate is named `lutra_python`
+# to avoid a conflict with other cargo artifacts. This option renames the
+# package to `lutra`.
+[package.metadata.maturin]
+name = "lutra"

--- a/lutra/bindings/python/pyproject.toml
+++ b/lutra/bindings/python/pyproject.toml
@@ -3,11 +3,11 @@ build-backend = "maturin"
 requires = ["maturin>=1.0,<2.0"]
 
 [project]
-name = "lutra"
-requires-python = ">=3.8"
 dependencies = [
   "pyarrow ~= 15.0.0",
 ]
+name = "lutra"
+requires-python = ">=3.8"
 
 [tool.maturin]
 # This is required because of https://github.com/PyO3/pyo3/pull/2135. Instead of
@@ -18,6 +18,9 @@ dependencies = [
 # When https://github.com/PyO3/pyo3/pull/2135 merges, we can remove this config.
 
 features = ["pyo3/extension-module"]
+
+# The module is named `lutra` rather than `lutra-python`.
+module-name = "lutra"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
This fixes the naming conflicts while letting us name the python module `lutra`.

It also renames the python package name for PyPI to `lutra`, from `lutra-python`
