### PR TITLE
chore: Release notes for 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,16 @@
 # PRQL Changelog
 
-## [unreleased]
+## 0.11.3 — 2023-02-10
 
-**Language**:
+0.11.3 is a very small release, mostly a rename of the python bindings.
 
-**Features**:
-
-**Fixes**:
-
-**Documentation**:
-
-**Web**:
-
-**Integrations**:
+This release has 13 commits from 4 contributors. Selected changes:
 
 **Internal changes**:
 
-**New Contributors**:
+- As part of making our names more consistent, the python bindings are renamed.
+  `prql-python` becomes a package published and importable as `prqlc`. The
+  internal rust crate is named `prqlc-python`.
 
 ## 0.11.2 — 2023-02-07
 

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -441,10 +441,10 @@ Currently we release in a semi-automated way:
    produce a draft version at <https://github.com/PRQL/prql/releases/new>,
    including "New Contributors".
 
-   Use this script to generate the first line:
+   Use this script to generate a line introducing the enumerated changes:
 
    ```sh
-   echo "This release has $(git rev-list --count $(git rev-list --tags --max-count=1)..) commits from $(git shortlog --summary $(git rev-list --tags --max-count=1).. | wc -l | tr -d '[:space:]') contributors. Selected changes:"
+   echo "It has $(git rev-list --count $(git rev-list --tags --max-count=1)..) commits from $(git shortlog --summary $(git rev-list --tags --max-count=1).. | wc -l | tr -d '[:space:]') contributors. Selected changes:"
    ```
 
 2. If the current version is correct, then skip ahead. But if the version needs


### PR DESCRIPTION
It's early to do a release, but this allows us to clear up some TODOs with the python rename
