### PR TITLE
build(playground): Use `npm ci` for install

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -352,7 +352,7 @@ tasks:
       # Copy the book into the website path, using rsync so it only copies new files
       - rsync -ai --checksum --delete book/book/ website/public/book/
       # (we don't use `build-playground-dependencies`, since that uses the dev profile)
-      - cd playground && npm install && npm run build
+      - cd playground && npm ci && npm run build
       # We place the playground app in a nested path, because we want to use
       # prql-lang.org/playground with an iframe containing the playground.
       # Possibly there's a more elegant way of doing this...
@@ -410,7 +410,7 @@ tasks:
     env:
       PROFILE: dev
     cmds:
-      - npm install
+      - npm ci
     # Note that now we have `PROFILE: dev`, the build is much much faster, and
     # we could remove this sources check if it became inconvenient.
     sources:


### PR DESCRIPTION
Currently the tasks to build the playground will update `package-lock.json`, which leaves a diff in the repo; not exactly what we're intending
