### PR TITLE
ci: Add features to cache key

### DIFF
--- a/.github/actions/build-prqlc-c/action.yaml
+++ b/.github/actions/build-prqlc-c/action.yaml
@@ -35,7 +35,7 @@ runs:
         save-if:
           ${{ (github.ref == 'refs/heads/main') && contains(inputs.target,
           'musl') }}
-        shared-key: rust-${{ inputs.target }}
+        shared-key: rust-${{ inputs.target }}-${{ inputs.features }}
         prefix-key: ${{ env.version }}
 
     - if: runner.os == 'Linux'

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -34,7 +34,7 @@ runs:
         save-if:
           ${{ (github.ref == 'refs/heads/main') && contains(inputs.target,
           'musl') }}
-        shared-key: rust-${{ inputs.target }}
+        shared-key: rust-${{ inputs.target }}-${{ inputs.features }}
         prefix-key: ${{ env.version }}
 
     - if: runner.os == 'Linux'

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -52,7 +52,7 @@ jobs:
         id: cache
         with:
           prefix-key: ${{ env.version }}
-          shared-key: rust-${{ inputs.target }}
+          shared-key: rust-${{ inputs.target }}-${{ inputs.features }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
         # We split up the test compilation as recommended in
         # https://matklad.github.io/2021/09/04/fast-rust-builds.html


### PR DESCRIPTION
The existing approach was failing to cache one of the linux builds, since there are two with different features
