### PR TITLE
devops: Don't remove snapshots in `bacon` `test`

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -4,7 +4,7 @@ default_job = "clippy"
 
 # PRQL additions
 [jobs.test]
-command = ['cargo', 'insta', 'test', "--color=always", "--features=default,test-dbs", "--unreferenced=auto"]
+command = ['cargo', 'insta', 'test', "--color=always", "--features=default,test-dbs"]
 
 [jobs.test-accept]
 command = ['cargo', 'insta', 'test', '--accept', "--color=always", "--features=default,test-dbs", "--unreferenced=auto"]


### PR DESCRIPTION
Only `test-accept`
