### PR TITLE
internal: Align `Token` naming with other AST objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,6 +2964,7 @@ dependencies = [
  "itertools 0.12.1",
  "prqlc-ast",
  "semver",
+ "serde",
  "stacker",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ insta = {version = "1.34", features = ["colors", "glob", "yaml"]}
 insta-cmd = "0.4.0"
 itertools = "0.12.0"
 log = "0.4.20"
+serde = {version = "1.0.196", features = ["derive"]}

--- a/prqlc/prqlc-ast/Cargo.toml
+++ b/prqlc/prqlc-ast/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 [dependencies]
 enum-as-inner = "0.6.0"
 semver = {version = "1.0.21", features = ["serde"]}
-serde = {version = "1.0.196", features = ["derive"]}
+serde = {workspace = true}
 strum = {version = "0.26.1", features = ["std", "derive"]}
 
 [dev-dependencies]

--- a/prqlc/prqlc-parser/Cargo.toml
+++ b/prqlc/prqlc-parser/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 itertools = {workspace = true}
 prqlc-ast = {path = "../prqlc-ast", version = "0.11.4"}
 semver = {version = "1.0.21"}
+serde = {workspace = true}
 
 # Chumsky's default features have issues when running in wasm (though we only
 # see it when compiling on MacOS), so we only include features when running

--- a/prqlc/prqlc-parser/src/expr.rs
+++ b/prqlc/prqlc-parser/src/expr.rs
@@ -9,18 +9,18 @@ use crate::types::type_expr;
 
 use super::common::*;
 use super::interpolation;
-use super::lexer::Token;
+use super::lexer::TokenKind;
 use super::span::ParserSpan;
 
-pub fn expr_call() -> impl Parser<Token, Expr, Error = PError> {
+pub fn expr_call() -> impl Parser<TokenKind, Expr, Error = PError> {
     let expr = expr();
 
     lambda_func(expr.clone()).or(func_call(expr))
 }
 
-pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
+pub fn expr() -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
     recursive(|expr| {
-        let literal = select! { Token::Literal(lit) => ExprKind::Literal(lit) };
+        let literal = select! { TokenKind::Literal(lit) => ExprKind::Literal(lit) };
 
         let ident_kind = ident().map(ExprKind::Ident);
 
@@ -40,12 +40,12 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
             .then_ignore(new_line().repeated())
             .delimited_by(ctrl('{'), ctrl('}'))
             .recover_with(nested_delimiters(
-                Token::Control('{'),
-                Token::Control('}'),
+                TokenKind::Control('{'),
+                TokenKind::Control('}'),
                 [
-                    (Token::Control('{'), Token::Control('}')),
-                    (Token::Control('('), Token::Control(')')),
-                    (Token::Control('['), Token::Control(']')),
+                    (TokenKind::Control('{'), TokenKind::Control('}')),
+                    (TokenKind::Control('('), TokenKind::Control(')')),
+                    (TokenKind::Control('['), TokenKind::Control(']')),
                 ],
                 |_| vec![],
             ))
@@ -60,12 +60,12 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
             .then_ignore(new_line().repeated())
             .delimited_by(ctrl('['), ctrl(']'))
             .recover_with(nested_delimiters(
-                Token::Control('['),
-                Token::Control(']'),
+                TokenKind::Control('['),
+                TokenKind::Control(']'),
                 [
-                    (Token::Control('{'), Token::Control('}')),
-                    (Token::Control('('), Token::Control(')')),
-                    (Token::Control('['), Token::Control(']')),
+                    (TokenKind::Control('{'), TokenKind::Control('}')),
+                    (TokenKind::Control('('), TokenKind::Control(')')),
+                    (TokenKind::Control('['), TokenKind::Control(']')),
                 ],
                 |_| vec![],
             ))
@@ -76,18 +76,18 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
             nested_expr
                 .delimited_by(ctrl('('), ctrl(')'))
                 .recover_with(nested_delimiters(
-                    Token::Control('('),
-                    Token::Control(')'),
+                    TokenKind::Control('('),
+                    TokenKind::Control(')'),
                     [
-                        (Token::Control('['), Token::Control(']')),
-                        (Token::Control('('), Token::Control(')')),
+                        (TokenKind::Control('['), TokenKind::Control(']')),
+                        (TokenKind::Control('('), TokenKind::Control(')')),
                     ],
                     |_| Expr::new(ExprKind::Literal(Literal::Null)),
                 ));
 
         let interpolation = select! {
-            Token::Interpolation('s', string) => (ExprKind::SString as fn(_) -> _, string),
-            Token::Interpolation('f', string) => (ExprKind::FString as fn(_) -> _, string),
+            TokenKind::Interpolation('s', string) => (ExprKind::SString as fn(_) -> _, string),
+            TokenKind::Interpolation('f', string) => (ExprKind::FString as fn(_) -> _, string),
         }
         .validate(|(finish, string), span: ParserSpan, emit| {
             match interpolation::parse(string, span + 2) {
@@ -106,7 +106,7 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
             .ignore_then(
                 func_call(expr.clone())
                     .map(Box::new)
-                    .then_ignore(just(Token::ArrowFat))
+                    .then_ignore(just(TokenKind::ArrowFat))
                     .then(func_call(expr.clone()).map(Box::new))
                     .map(|(condition, value)| SwitchCase { condition, value })
                     .padded_by(new_line().repeated())
@@ -117,7 +117,7 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
             )
             .map(ExprKind::Case);
 
-        let param = select! { Token::Param(id) => ExprKind::Param(id) };
+        let param = select! { TokenKind::Param(id) => ExprKind::Param(id) };
 
         let term = choice((
             literal,
@@ -157,11 +157,11 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
             term.clone()
                 .then(choice((
                     // range and end bound
-                    just(Token::range(true, true))
+                    just(TokenKind::range(true, true))
                         .ignore_then(term.clone())
                         .map(|x| Some(Some(x))),
                     // range and no end bound
-                    select! { Token::Range { bind_left: true, .. } => Some(None) },
+                    select! { TokenKind::Range { bind_left: true, .. } => Some(None) },
                     // no range
                     empty().to(None),
                 )))
@@ -173,11 +173,11 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
                     }
                 }),
             // only end bound
-            select! { Token::Range { bind_right: true, .. } => () }
+            select! { TokenKind::Range { bind_right: true, .. } => () }
                 .ignore_then(term)
                 .map(|range| RangeCase::Range(None, Some(range))),
             // unbounded
-            select! { Token::Range { .. } => RangeCase::Range(None, None) },
+            select! { TokenKind::Range { .. } => RangeCase::Range(None, None) },
         ))
         .map_with_span(|case, span| match case {
             RangeCase::NoOp(x) => x,
@@ -205,9 +205,9 @@ pub fn expr() -> impl Parser<Token, Expr, Error = PError> + Clone {
     })
 }
 
-pub fn pipeline<E>(expr: E) -> impl Parser<Token, Expr, Error = PError>
+pub fn pipeline<E>(expr: E) -> impl Parser<TokenKind, Expr, Error = PError>
 where
-    E: Parser<Token, Expr, Error = PError>,
+    E: Parser<TokenKind, Expr, Error = PError>,
 {
     // expr has to be a param, because it can be either a normal expr() or
     // a recursive expr called from within expr()
@@ -240,10 +240,10 @@ where
 pub fn binary_op_parser<'a, Term, Op>(
     term: Term,
     op: Op,
-) -> impl Parser<Token, Expr, Error = PError> + 'a
+) -> impl Parser<TokenKind, Expr, Error = PError> + 'a
 where
-    Term: Parser<Token, Expr, Error = PError> + 'a,
-    Op: Parser<Token, BinOp, Error = PError> + 'a,
+    Term: Parser<TokenKind, Expr, Error = PError> + 'a,
+    Op: Parser<TokenKind, BinOp, Error = PError> + 'a,
 {
     let term = term.map_with_span(|e, s| (e, s)).boxed();
 
@@ -266,9 +266,9 @@ where
         .boxed()
 }
 
-fn func_call<E>(expr: E) -> impl Parser<Token, Expr, Error = PError>
+fn func_call<E>(expr: E) -> impl Parser<TokenKind, Expr, Error = PError>
 where
-    E: Parser<Token, Expr, Error = PError> + Clone,
+    E: Parser<TokenKind, Expr, Error = PError> + Clone,
 {
     let func_name = expr.clone();
 
@@ -318,9 +318,9 @@ where
         .labelled("function call")
 }
 
-fn lambda_func<E>(expr: E) -> impl Parser<Token, Expr, Error = PError>
+fn lambda_func<E>(expr: E) -> impl Parser<TokenKind, Expr, Error = PError>
 where
-    E: Parser<Token, Expr, Error = PError> + Clone + 'static,
+    E: Parser<TokenKind, Expr, Error = PError> + Clone + 'static,
 {
     let param = ident_part()
         .then(type_expr().delimited_by(ctrl('<'), ctrl('>')).or_not())
@@ -355,7 +355,7 @@ where
         // plain
         param.repeated().map(|params| (Vec::new(), params)),
     ))
-    .then_ignore(just(Token::ArrowThin))
+    .then_ignore(just(TokenKind::ArrowThin))
     // return type
     .then(type_expr().delimited_by(ctrl('<'), ctrl('>')).or_not())
     // body
@@ -384,7 +384,7 @@ where
     .labelled("function definition")
 }
 
-pub fn ident() -> impl Parser<Token, Ident, Error = PError> {
+pub fn ident() -> impl Parser<TokenKind, Ident, Error = PError> {
     let star = ctrl('*').to("*".to_string());
 
     ident_part()
@@ -392,41 +392,41 @@ pub fn ident() -> impl Parser<Token, Ident, Error = PError> {
         .map(Ident::from_path::<String>)
 }
 
-fn operator_unary() -> impl Parser<Token, UnOp, Error = PError> {
+fn operator_unary() -> impl Parser<TokenKind, UnOp, Error = PError> {
     (ctrl('+').to(UnOp::Add))
         .or(ctrl('-').to(UnOp::Neg))
         .or(ctrl('!').to(UnOp::Not))
-        .or(just(Token::Eq).to(UnOp::EqSelf))
+        .or(just(TokenKind::Eq).to(UnOp::EqSelf))
 }
-// fn operator_pow() -> impl Parser<Token, BinOp, Error = PError> {
-//     just(Token::Pow).to(BinOp::Pow)
+// fn operator_pow() -> impl Parser<TokenKind, BinOp, Error = PError> {
+//     just(TokenKind::Pow).to(BinOp::Pow)
 // }
-fn operator_mul() -> impl Parser<Token, BinOp, Error = PError> {
-    (just(Token::DivInt).to(BinOp::DivInt))
+fn operator_mul() -> impl Parser<TokenKind, BinOp, Error = PError> {
+    (just(TokenKind::DivInt).to(BinOp::DivInt))
         .or(ctrl('*').to(BinOp::Mul))
         .or(ctrl('/').to(BinOp::DivFloat))
         .or(ctrl('%').to(BinOp::Mod))
 }
-fn operator_add() -> impl Parser<Token, BinOp, Error = PError> {
+fn operator_add() -> impl Parser<TokenKind, BinOp, Error = PError> {
     (ctrl('+').to(BinOp::Add)).or(ctrl('-').to(BinOp::Sub))
 }
-fn operator_compare() -> impl Parser<Token, BinOp, Error = PError> {
+fn operator_compare() -> impl Parser<TokenKind, BinOp, Error = PError> {
     choice((
-        just(Token::Eq).to(BinOp::Eq),
-        just(Token::Ne).to(BinOp::Ne),
-        just(Token::Lte).to(BinOp::Lte),
-        just(Token::Gte).to(BinOp::Gte),
-        just(Token::RegexSearch).to(BinOp::RegexSearch),
+        just(TokenKind::Eq).to(BinOp::Eq),
+        just(TokenKind::Ne).to(BinOp::Ne),
+        just(TokenKind::Lte).to(BinOp::Lte),
+        just(TokenKind::Gte).to(BinOp::Gte),
+        just(TokenKind::RegexSearch).to(BinOp::RegexSearch),
         ctrl('<').to(BinOp::Lt),
         ctrl('>').to(BinOp::Gt),
     ))
 }
-fn operator_and() -> impl Parser<Token, BinOp, Error = PError> {
-    just(Token::And).to(BinOp::And)
+fn operator_and() -> impl Parser<TokenKind, BinOp, Error = PError> {
+    just(TokenKind::And).to(BinOp::And)
 }
-pub fn operator_or() -> impl Parser<Token, BinOp, Error = PError> {
-    just(Token::Or).to(BinOp::Or)
+pub fn operator_or() -> impl Parser<TokenKind, BinOp, Error = PError> {
+    just(TokenKind::Or).to(BinOp::Or)
 }
-fn operator_coalesce() -> impl Parser<Token, BinOp, Error = PError> {
-    just(Token::Coalesce).to(BinOp::Coalesce)
+fn operator_coalesce() -> impl Parser<TokenKind, BinOp, Error = PError> {
+    just(TokenKind::Coalesce).to(BinOp::Coalesce)
 }

--- a/prqlc/prqlc-parser/src/lexer.rs
+++ b/prqlc/prqlc-parser/src/lexer.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct Token {
     #[serde(flatten)]
     pub kind: TokenKind,
-    pub span: std::ops::Range<usize>, // Option<Span>,
+    pub span: std::ops::Range<usize>,
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]

--- a/prqlc/prqlc-parser/src/lib.rs
+++ b/prqlc/prqlc-parser/src/lib.rs
@@ -15,7 +15,7 @@ use prqlc_ast::error::{Error, WithErrorInfo};
 use prqlc_ast::stmt::*;
 use prqlc_ast::Span;
 
-use lexer::Token;
+use lexer::TokenKind;
 use lexer::{TokenSpan, TokenVec};
 use span::ParserSpan;
 
@@ -33,17 +33,17 @@ pub fn parse_source(source: &str, source_id: u16) -> Result<Vec<Stmt>, Vec<Error
 
     // We don't want comments in the AST (but we do intend to use them as part of
     // formatting)
-    let semantic_only: Option<_> = tokens.map(|tokens| {
+    let semantic_tokens: Option<_> = tokens.map(|tokens| {
         tokens.into_iter().filter(|TokenSpan(t, _)| {
             !matches!(
                 t,
-                Token::Comment(_) | Token::LineWrap(_) | Token::DocComment(_)
+                TokenKind::Comment(_) | TokenKind::LineWrap(_) | TokenKind::DocComment(_)
             )
         })
     });
 
-    let ast = if let Some(semantic_only) = semantic_only {
-        let stream = prepare_stream(semantic_only, source, source_id);
+    let ast = if let Some(semantic_tokens) = semantic_tokens {
+        let stream = prepare_stream(semantic_tokens, source, source_id);
 
         let (ast, parse_errors) = ::chumsky::Parser::parse_recovery(&stmt::source(), stream);
 
@@ -74,32 +74,32 @@ mod common {
     use prqlc_ast::Ty;
     use prqlc_ast::TyKind;
 
-    use super::{lexer::Token, span::ParserSpan};
+    use super::{lexer::TokenKind, span::ParserSpan};
     use prqlc_ast::expr::*;
     use prqlc_ast::stmt::*;
 
-    pub type PError = Simple<Token, ParserSpan>;
+    pub type PError = Simple<TokenKind, ParserSpan>;
 
-    pub fn ident_part() -> impl Parser<Token, String, Error = PError> {
-        select! { Token::Ident(ident) => ident }.map_err(|e: PError| {
+    pub fn ident_part() -> impl Parser<TokenKind, String, Error = PError> {
+        select! { TokenKind::Ident(ident) => ident }.map_err(|e: PError| {
             Simple::expected_input_found(
                 e.span(),
-                [Some(Token::Ident("".to_string()))],
+                [Some(TokenKind::Ident("".to_string()))],
                 e.found().cloned(),
             )
         })
     }
 
-    pub fn keyword(kw: &'static str) -> impl Parser<Token, (), Error = PError> + Clone {
-        just(Token::Keyword(kw.to_string())).ignored()
+    pub fn keyword(kw: &'static str) -> impl Parser<TokenKind, (), Error = PError> + Clone {
+        just(TokenKind::Keyword(kw.to_string())).ignored()
     }
 
-    pub fn new_line() -> impl Parser<Token, (), Error = PError> + Clone {
-        just(Token::NewLine).ignored()
+    pub fn new_line() -> impl Parser<TokenKind, (), Error = PError> + Clone {
+        just(TokenKind::NewLine).ignored()
     }
 
-    pub fn ctrl(char: char) -> impl Parser<Token, (), Error = PError> + Clone {
-        just(Token::Control(char)).ignored()
+    pub fn ctrl(char: char) -> impl Parser<TokenKind, (), Error = PError> + Clone {
+        just(TokenKind::Control(char)).ignored()
     }
 
     pub fn into_stmt((annotations, kind): (Vec<Annotation>, StmtKind), span: ParserSpan) -> Stmt {
@@ -131,7 +131,7 @@ fn prepare_stream(
     tokens: impl Iterator<Item = TokenSpan>,
     source: &str,
     source_id: u16,
-) -> Stream<Token, ParserSpan, impl Iterator<Item = (Token, ParserSpan)> + Sized> {
+) -> Stream<TokenKind, ParserSpan, impl Iterator<Item = (TokenKind, ParserSpan)> + Sized> {
     let tokens = tokens
         .into_iter()
         .map(move |TokenSpan(t, s)| (t, ParserSpan::new(source_id, s)));
@@ -168,32 +168,31 @@ fn convert_parser_error(e: common::PError) -> Error {
         // found end of file
         // fix for span outside of source
         if span.start > 0 && span.end > 0 {
-            span.start -= 1;
-            span.end -= 1;
+            span = span - 1;
         }
     }
 
-    construct_parser_error(e).with_span(Some(*span))
+    construct_parser_error(e).with_span(Some(span.0))
 }
 
-fn construct_parser_error(e: Simple<Token, ParserSpan>) -> Error {
+fn construct_parser_error(e: Simple<TokenKind, ParserSpan>) -> Error {
     if let SimpleReason::Custom(message) = e.reason() {
         return Error::new_simple(message);
     }
 
-    fn token_to_string(t: Option<Token>) -> String {
+    fn token_to_string(t: Option<TokenKind>) -> String {
         t.as_ref()
-            .map(Token::to_string)
+            .map(TokenKind::to_string)
             .unwrap_or_else(|| "end of input".to_string())
     }
 
     let is_all_whitespace = e
         .expected()
-        .all(|t| matches!(t, None | Some(Token::NewLine)));
+        .all(|t| matches!(t, None | Some(TokenKind::NewLine)));
     let expected: Vec<String> = e
         .expected()
         // Only include whitespace if we're _only_ expecting whitespace
-        .filter(|t| is_all_whitespace || !matches!(t, None | Some(Token::NewLine)))
+        .filter(|t| is_all_whitespace || !matches!(t, None | Some(TokenKind::NewLine)))
         .cloned()
         .map(token_to_string)
         .collect();

--- a/prqlc/prqlc-parser/src/span.rs
+++ b/prqlc/prqlc-parser/src/span.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Deref, DerefMut};
+use std::ops::{Add, Deref, DerefMut, Sub};
 
 use crate::Span;
 
@@ -26,6 +26,18 @@ impl Add<usize> for ParserSpan {
         Self(Span {
             start: self.start + rhs,
             end: self.end + rhs,
+            source_id: self.source_id,
+        })
+    }
+}
+
+impl Sub<usize> for ParserSpan {
+    type Output = ParserSpan;
+
+    fn sub(self, rhs: usize) -> ParserSpan {
+        Self(Span {
+            start: self.start - rhs,
+            end: self.end - rhs,
             source_id: self.source_id,
         })
     }

--- a/prqlc/prqlc-parser/src/stmt.rs
+++ b/prqlc/prqlc-parser/src/stmt.rs
@@ -11,16 +11,16 @@ use crate::types::type_expr;
 
 use super::common::*;
 use super::expr::*;
-use super::lexer::Token;
+use super::lexer::TokenKind;
 
-pub fn source() -> impl Parser<Token, Vec<Stmt>, Error = PError> {
+pub fn source() -> impl Parser<TokenKind, Vec<Stmt>, Error = PError> {
     query_def()
         .or_not()
         .chain(module_contents())
         .then_ignore(end())
 }
 
-fn module_contents() -> impl Parser<Token, Vec<Stmt>, Error = PError> {
+fn module_contents() -> impl Parser<TokenKind, Vec<Stmt>, Error = PError> {
     recursive(|module_contents| {
         let module_def = keyword("module")
             .ignore_then(ident_part())
@@ -28,7 +28,7 @@ fn module_contents() -> impl Parser<Token, Vec<Stmt>, Error = PError> {
             .map(|(name, stmts)| StmtKind::ModuleDef(ModuleDef { name, stmts }))
             .labelled("module definition");
 
-        let annotation = just(Token::Annotate)
+        let annotation = just(TokenKind::Annotate)
             .ignore_then(expr())
             .then_ignore(new_line().repeated())
             .map(|expr| Annotation {
@@ -45,7 +45,7 @@ fn module_contents() -> impl Parser<Token, Vec<Stmt>, Error = PError> {
     })
 }
 
-fn query_def() -> impl Parser<Token, Stmt, Error = PError> {
+fn query_def() -> impl Parser<TokenKind, Stmt, Error = PError> {
     new_line()
         .repeated()
         .ignore_then(keyword("prql"))
@@ -103,7 +103,7 @@ fn query_def() -> impl Parser<Token, Stmt, Error = PError> {
         .labelled("query header")
 }
 
-fn var_def() -> impl Parser<Token, StmtKind, Error = PError> {
+fn var_def() -> impl Parser<TokenKind, StmtKind, Error = PError> {
     let let_ = keyword("let")
         .ignore_then(ident_part())
         .then(type_expr().delimited_by(ctrl('<'), ctrl('>')).or_not())
@@ -141,7 +141,7 @@ fn var_def() -> impl Parser<Token, StmtKind, Error = PError> {
     let_.or(main_or_into)
 }
 
-fn type_def() -> impl Parser<Token, StmtKind, Error = PError> {
+fn type_def() -> impl Parser<TokenKind, StmtKind, Error = PError> {
     keyword("type")
         .ignore_then(ident_part())
         .then(ctrl('=').ignore_then(type_expr()).or_not())

--- a/prqlc/prqlc-parser/src/types.rs
+++ b/prqlc/prqlc-parser/src/types.rs
@@ -5,20 +5,20 @@ use prqlc_ast::*;
 use crate::expr::ident;
 
 use super::common::*;
-use super::lexer::Token;
+use super::lexer::TokenKind;
 
-pub fn type_expr() -> impl Parser<Token, Ty, Error = PError> {
+pub fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> {
     recursive(|nested_type_expr| {
         let basic = select! {
-            Token::Literal(lit) => TyKind::Singleton(lit),
-            Token::Ident(i) if i == "int"=> TyKind::Primitive(PrimitiveSet::Int),
-            Token::Ident(i) if i == "float"=> TyKind::Primitive(PrimitiveSet::Float),
-            Token::Ident(i) if i == "bool"=> TyKind::Primitive(PrimitiveSet::Bool),
-            Token::Ident(i) if i == "text"=> TyKind::Primitive(PrimitiveSet::Text),
-            Token::Ident(i) if i == "date"=> TyKind::Primitive(PrimitiveSet::Date),
-            Token::Ident(i) if i == "time"=> TyKind::Primitive(PrimitiveSet::Time),
-            Token::Ident(i) if i == "timestamp"=> TyKind::Primitive(PrimitiveSet::Timestamp),
-            Token::Ident(i) if i == "anytype"=> TyKind::Any,
+            TokenKind::Literal(lit) => TyKind::Singleton(lit),
+            TokenKind::Ident(i) if i == "int"=> TyKind::Primitive(PrimitiveSet::Int),
+            TokenKind::Ident(i) if i == "float"=> TyKind::Primitive(PrimitiveSet::Float),
+            TokenKind::Ident(i) if i == "bool"=> TyKind::Primitive(PrimitiveSet::Bool),
+            TokenKind::Ident(i) if i == "text"=> TyKind::Primitive(PrimitiveSet::Text),
+            TokenKind::Ident(i) if i == "date"=> TyKind::Primitive(PrimitiveSet::Date),
+            TokenKind::Ident(i) if i == "time"=> TyKind::Primitive(PrimitiveSet::Time),
+            TokenKind::Ident(i) if i == "timestamp"=> TyKind::Primitive(PrimitiveSet::Timestamp),
+            TokenKind::Ident(i) if i == "anytype"=> TyKind::Any,
         };
 
         let ident = ident().map(TyKind::Ident);
@@ -29,7 +29,7 @@ pub fn type_expr() -> impl Parser<Token, Ty, Error = PError> {
                     .clone()
                     .map(Some)
                     .repeated()
-                    .then_ignore(just(Token::ArrowThin))
+                    .then_ignore(just(TokenKind::ArrowThin))
                     .then(nested_type_expr.clone().map(Some).map(Box::new))
                     .map(|(args, return_ty)| TyFunc {
                         args,
@@ -48,7 +48,7 @@ pub fn type_expr() -> impl Parser<Token, Ty, Error = PError> {
                 filter(|x| {
                     matches!(
                         x,
-                        Token::Range {
+                        TokenKind::Range {
                             bind_left: true,
                             ..
                         }
@@ -69,12 +69,12 @@ pub fn type_expr() -> impl Parser<Token, Ty, Error = PError> {
             .then_ignore(new_line().repeated())
             .delimited_by(ctrl('{'), ctrl('}'))
             .recover_with(nested_delimiters(
-                Token::Control('{'),
-                Token::Control('}'),
+                TokenKind::Control('{'),
+                TokenKind::Control('}'),
                 [
-                    (Token::Control('{'), Token::Control('}')),
-                    (Token::Control('('), Token::Control(')')),
-                    (Token::Control('['), Token::Control(']')),
+                    (TokenKind::Control('{'), TokenKind::Control('}')),
+                    (TokenKind::Control('('), TokenKind::Control(')')),
+                    (TokenKind::Control('['), TokenKind::Control(']')),
                 ],
                 |_| vec![],
             ))
@@ -86,17 +86,17 @@ pub fn type_expr() -> impl Parser<Token, Ty, Error = PError> {
             .or_not()
             .then(nested_type_expr.clone())
             .padded_by(new_line().repeated())
-            .separated_by(just(Token::Or))
+            .separated_by(just(TokenKind::Or))
             .allow_trailing()
             .then_ignore(new_line().repeated())
             .delimited_by(ctrl('('), ctrl(')'))
             .recover_with(nested_delimiters(
-                Token::Control('('),
-                Token::Control(')'),
+                TokenKind::Control('('),
+                TokenKind::Control(')'),
                 [
-                    (Token::Control('{'), Token::Control('}')),
-                    (Token::Control('('), Token::Control(')')),
-                    (Token::Control('['), Token::Control(']')),
+                    (TokenKind::Control('{'), TokenKind::Control('}')),
+                    (TokenKind::Control('('), TokenKind::Control(')')),
+                    (TokenKind::Control('['), TokenKind::Control(']')),
                 ],
                 |_| vec![],
             ))
@@ -108,12 +108,12 @@ pub fn type_expr() -> impl Parser<Token, Ty, Error = PError> {
             .padded_by(new_line().repeated())
             .delimited_by(ctrl('['), ctrl(']'))
             .recover_with(nested_delimiters(
-                Token::Control('['),
-                Token::Control(']'),
+                TokenKind::Control('['),
+                TokenKind::Control(']'),
                 [
-                    (Token::Control('{'), Token::Control('}')),
-                    (Token::Control('('), Token::Control(')')),
-                    (Token::Control('['), Token::Control(']')),
+                    (TokenKind::Control('{'), TokenKind::Control('}')),
+                    (TokenKind::Control('('), TokenKind::Control(')')),
+                    (TokenKind::Control('['), TokenKind::Control(']')),
                 ],
                 |_| Box::new(Ty::new(Literal::Null)),
             ))
@@ -126,7 +126,7 @@ pub fn type_expr() -> impl Parser<Token, Ty, Error = PError> {
 
         // union
         term.clone()
-            .then(just(Token::Or).ignore_then(term).repeated())
+            .then(just(TokenKind::Or).ignore_then(term).repeated())
             .map_with_span(|(first, following), span| {
                 if following.is_empty() {
                     first

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.19.0"
 regex = "1.10.3"
 semver = {version = "1.0.21", features = ["serde"]}
 # We could put `serde` behind a feature if we wanted to reduce the size of prqlc.
-serde = {version = "1.0.196", features = ["derive"]}
+serde = {workspace = true}
 serde_json = "1.0.113"
 serde_yaml = {version = "0.9.31"}
 sqlformat = "0.2.3"


### PR DESCRIPTION
Previously we had `TokenSpan` meaning a "`Token` & `Span`", but `ParserSpan` was "the `Span` associated with the Parser". So this uses `Token` & `TokenKind`, aligning with the rest of the AST.
