### PR TITLE
ci(release): fix prqlc CLI build

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -68,9 +68,8 @@ runs:
         # even at the cost of slighly less efficiency.)
         args:
           --profile=${{ inputs.profile }} --locked --target=${{ inputs.target }}
-          --no-default-features --features=${{ inputs.features }} ${{
-          contains(inputs.target, 'musl') && '--package=prqlc' ||
-          '--all-targets' }}
+          --features=${{ inputs.features }} ${{ contains(inputs.target, 'musl')
+          && '--package=prqlc' || '--all-targets' }}
 
     - name: Create artifact for Linux and macOS
       shell: bash


### PR DESCRIPTION
Adresses #4254

If this works well, I would like to backport the branch from the 0.11.3 tag.