### PR TITLE
ci: Align `prqlc` cli build

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -45,8 +45,7 @@ runs:
 
     - if: runner.os == 'Windows' && inputs.profile == 'release'
       shell: bash
-      run: |
-        echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >>"$GITHUB_ENV"
+      run: echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >>"$GITHUB_ENV"
 
     - if: inputs.target == 'aarch64-unknown-linux-musl'
       shell: bash
@@ -68,8 +67,9 @@ runs:
         # even at the cost of slighly less efficiency.)
         args:
           --profile=${{ inputs.profile }} --locked --target=${{ inputs.target }}
-          --features=${{ inputs.features }} ${{ contains(inputs.target, 'musl')
-          && '--package=prqlc' || '--all-targets' }}
+          --no-default-features --features=${{ inputs.features }} ${{
+          contains(inputs.target, 'musl') && '--package=prqlc' ||
+          '--all-targets' }}
 
     - name: Create artifact for Linux and macOS
       shell: bash
@@ -100,3 +100,7 @@ runs:
     - id: echo-artifact-name
       shell: bash
       run: echo "artifact-name=${{ env.ARTIFACT_NAME }}" >>"$GITHUB_OUTPUT"
+
+    - name: test-cli-works
+      shell: bash
+      run: ${{ env.ARTIFACT_NAME }} --help

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -100,7 +100,3 @@ runs:
     - id: echo-artifact-name
       shell: bash
       run: echo "artifact-name=${{ env.ARTIFACT_NAME }}" >>"$GITHUB_OUTPUT"
-
-    - name: test-cli-works
-      shell: bash
-      run: ${{ env.ARTIFACT_NAME }} --help

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,11 +69,10 @@ jobs:
       - name: test the CLI works
         if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
         run: |
-          # `prqlc` already exists at the root
+          # `prqlc` is an existing path at the root
           mkdir -p temp_path
           tar xzf ${{ steps.build-artifact.outputs.artifact-name }} -C temp_path
-          cd temp_path
-          ./prqlc/prqlc --help
+          ./temp_path/prqlc --help
 
   build-prqlc-c:
     # Mostly a copy/paste of `build-prqlc`.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,10 @@ jobs:
       - name: test the CLI works
         if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
         run: |
-          tar xzf ${{ steps.build-artifact.outputs.artifact-name }}
+          # `prqlc` already exists at the root
+          mkdir -p extraction_path
+          tar xzf ${{ steps.build-artifact.outputs.artifact-name }} -C extraction_path
+          cd extraction_path
           ./prqlc/prqlc --help
 
   build-prqlc-c:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,8 +67,14 @@ jobs:
           append_body: true
           files: ${{ steps.build-artifact.outputs.artifact-name }}
       - name: test the CLI works
-        # TODO: Add for Windows too (but will require unzipping rather than un-taring)
-        if: ${{ matrix.target != 'x86_64-pc-windows-msvc' }}
+        # TODO: Add for Windows too (but will require unzipping rather than
+        # un-taring)
+        #
+        # Currently filtering by x86, since that's the same as those not
+        # cross-compiled. But we'll have to refine this in the future.
+        if:
+          ${{ contains(matrix.target, 'x86') && matrix.target !=
+          'x86_64-pc-windows-msvc' }}
         run: |
           # `prqlc` is an existing path at the root
           mkdir -p temp_path

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,8 @@ jobs:
           append_body: true
           files: ${{ steps.build-artifact.outputs.artifact-name }}
       - name: test the CLI works
-        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        # TODO: Add for Windows too (but will require unzipping rather than un-taring)
+        if: ${{ matrix.target != 'x86_64-pc-windows-msvc' }}
         run: |
           # `prqlc` is an existing path at the root
           mkdir -p temp_path

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,11 @@ jobs:
         with:
           append_body: true
           files: ${{ steps.build-artifact.outputs.artifact-name }}
+      - name: test the CLI works
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        run: |
+          tar xzf ${{ steps.build-artifact.outputs.artifact-name }}
+          ./prqlc/prqlc --help
 
   build-prqlc-c:
     # Mostly a copy/paste of `build-prqlc`.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           profile: release
+          features: cli
       - name: Upload release artifact
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
@@ -67,7 +68,7 @@ jobs:
           files: ${{ steps.build-artifact.outputs.artifact-name }}
 
   build-prqlc-c:
-    # Currently a copy/paste of `build-prqlc`.
+    # Mostly a copy/paste of `build-prqlc`.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,9 +70,9 @@ jobs:
         if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
         run: |
           # `prqlc` already exists at the root
-          mkdir -p extraction_path
-          tar xzf ${{ steps.build-artifact.outputs.artifact-name }} -C extraction_path
-          cd extraction_path
+          mkdir -p temp_path
+          tar xzf ${{ steps.build-artifact.outputs.artifact-name }} -C temp_path
+          cd temp_path
           ./prqlc/prqlc --help
 
   build-prqlc-c:


### PR DESCRIPTION
This restores the `--no-default-features`, which we use in all builds, and adds the `cli` feature explicitly in the release workflow