### PR TITLE
ci: Fix mac prqlc tar

### DIFF
--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -77,9 +77,10 @@ runs:
       run: |
         export ARTIFACT_NAME="prqlc-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
-        cd target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}
-        cp ../../../prqlc/prqlc/README.md .
-        tar czf "../../../${ARTIFACT_NAME}" prqlc ../../../LICENSE README.md
+        TEMP_DIR=$(mktemp -d)
+        cp prqlc/prqlc/README.md LICENSE "${TEMP_DIR}/"
+        cp -r target/${{ matrix.target }}/${{ inputs.profile == 'release' && 'release' || 'debug' }}/prqlc "${TEMP_DIR}/"
+        tar czf "${ARTIFACT_NAME}" -C "$TEMP_DIR" .
 
     - name: Create artifact for Windows
       shell: bash


### PR DESCRIPTION
Currently the Mac `.tar.gz` unfortunately raises an error on extraction:

```
tar xzf prqlc-v0.11.4-x86_64-apple-darwin.tar.gz
../../../LICENSE: Path contains '..'
tar: Error exit delayed from previous errors.
```

This is an attempt to fix it...