### PR TITLE
web: switch browser build to '--target web' for ESM module usage

### DIFF
--- a/prqlc/bindings/js/README.md
+++ b/prqlc/bindings/js/README.md
@@ -73,18 +73,12 @@ console.log(sql);
 ```html
 <html>
   <head>
-    <script src="./node_modules/prql-js/dist/web/prql_js.js"></script>
-    <script>
-      const { compile } = wasm_bindgen;
+    <script type="module">
+      import init, { compile } from './dist/web/prql_js.js';
+      await init();
 
-      async function run() {
-        await wasm_bindgen("./node_modules/prql-js/dist/web/prql_js_bg.wasm");
-        const sql = compile("from db.employees | select first_name");
-
-        console.log(sql);
-      }
-
-      run();
+      const sql = compile("from db.employees | select first_name");
+      console.log(sql);
     </script>
   </head>
 

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -30,7 +30,7 @@
     "build": "npm run build:node && npm run build:web && npm run build:bundler",
     "build:bundler": "npx cross-env wasm-pack build --target bundler --out-dir dist/bundler --${PROFILE} && rm dist/bundler/.gitignore",
     "build:node": "npx cross-env wasm-pack build --target nodejs --out-dir dist/node --${PROFILE} && rm dist/node/.gitignore",
-    "build:web": "npx cross-env wasm-pack build --target no-modules --out-dir dist/web --${PROFILE} && rm dist/web/.gitignore",
+    "build:web": "npx cross-env wasm-pack build --target web --out-dir dist/web --${PROFILE} && rm dist/web/.gitignore",
     "prepare": "npm run build",
     "test": "mocha tests"
   },


### PR DESCRIPTION
If the updated README.md snippet works remains to be shown. I've tried emulating it via

    import init, { compile } from "https://cdn.jsdelivr.net/gh/srenatus/prql@sr-testing/prqlc/bindings/js/dist/web/prql_js.js";

but it's not entirely the same thing. 😬 

<img width="969" alt="image" src="https://github.com/PRQL/prql/assets/870638/bc0243f3-6ebe-487e-b99a-5ae9ba463b5f">


Fixes https://github.com/PRQL/prql/issues/4273.