### PR TITLE
fix: Prevent panic on `a -> b` query

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/types.rs
+++ b/prqlc/prqlc/src/semantic/resolver/types.rs
@@ -118,9 +118,18 @@ impl Resolver<'_> {
                 // special case: infer a table type
                 // inferred tables are needed for s-strings that represent tables
                 // similarly as normal table references, we want to be able to infer columns
-                // of this table, which means it needs to be defined somewhere in the module structure.
-                let frame =
-                    self.declare_table_for_literal(found.id.unwrap(), None, found.alias.clone());
+                // of this table, which means it needs to be defined somewhere
+                // in the module structure.
+                let frame = self.declare_table_for_literal(
+                    found
+                        .clone()
+                        .id
+                        // This is quite rare but possible with something like
+                        // `a -> b` at the moment.
+                        .ok_or_else(|| Error::new(Reason::Bug { issue: Some(4280) }))?,
+                    None,
+                    found.alias.clone(),
+                );
 
                 // override the empty frame with frame of the new table
                 found.lineage = Some(frame)

--- a/prqlc/prqlc/tests/integration/bad_error_messages.rs
+++ b/prqlc/prqlc/tests/integration/bad_error_messages.rs
@@ -204,3 +204,14 @@ fn nested_groups() {
     ────╯
     "###);
 }
+
+#[test]
+fn a_arrow_b() {
+    // This is fairly low priority, given how idiosyncratic the query is. If
+    // we find other cases, we should increase the priority.
+    assert_display_snapshot!(compile(r###"
+    x -> y
+    "###).unwrap_err(), @r###"
+    Error: internal compiler error; tracked at https://github.com/PRQL/prql/issues/4280
+    "###);
+}


### PR DESCRIPTION
Corner case but let's try to avoid panics.

This ameliorates #4280, though I'd suggest leaving it open to track it — it's idiosyncratic but still bad.