### PR TITLE
refactor: rename `types::TupleField` to `types::TyTupleField`

### DIFF
--- a/lutra/lutra/src/pull_schema.rs
+++ b/lutra/lutra/src/pull_schema.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use arrow::datatypes::{DataType, SchemaRef};
 use connector_arrow::api::SchemaGet;
 use itertools::Itertools;
-use prqlc::ast::{PrimitiveSet, Stmt, TupleField, Ty, TyKind, VarDef};
+use prqlc::ast::{PrimitiveSet, Stmt, TyTupleField, Ty, TyKind, VarDef};
 use prqlc::{Error, WithErrorInfo};
 
 use crate::ProjectCompiled;
@@ -40,7 +40,7 @@ fn convert_arrow_schema_to_table_def(table_name: String, schema: SchemaRef) -> R
 
             // TODO: handle field.is_nullable()
 
-            Ok(TupleField::Single(Some(name.clone()), Some(Ty::new(ty))))
+            Ok(TyTupleField::Single(Some(name.clone()), Some(Ty::new(ty))))
         })
         .try_collect()?;
 

--- a/lutra/lutra/src/pull_schema.rs
+++ b/lutra/lutra/src/pull_schema.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use arrow::datatypes::{DataType, SchemaRef};
 use connector_arrow::api::SchemaGet;
 use itertools::Itertools;
-use prqlc::ast::{PrimitiveSet, Stmt, TyTupleField, Ty, TyKind, VarDef};
+use prqlc::ast::{PrimitiveSet, Stmt, Ty, TyKind, TyTupleField, VarDef};
 use prqlc::{Error, WithErrorInfo};
 
 use crate::ProjectCompiled;

--- a/prqlc/prqlc-ast/src/types.rs
+++ b/prqlc/prqlc-ast/src/types.rs
@@ -31,7 +31,7 @@ pub enum TyKind {
     Union(Vec<(Option<String>, Ty)>),
 
     /// Type of tuples (product)
-    Tuple(Vec<TupleField>),
+    Tuple(Vec<TyTupleField>),
 
     /// Type of arrays
     Array(Box<Ty>),
@@ -51,7 +51,7 @@ pub enum TyKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, EnumAsInner)]
-pub enum TupleField {
+pub enum TyTupleField {
     /// Named tuple element.
     Single(Option<String>, Option<Ty>),
 
@@ -98,7 +98,7 @@ impl Ty {
         }
     }
 
-    pub fn relation(tuple_fields: Vec<TupleField>) -> Self {
+    pub fn relation(tuple_fields: Vec<TyTupleField>) -> Self {
         let tuple = Ty::new(TyKind::Tuple(tuple_fields));
         Ty::new(TyKind::Array(Box::new(tuple)))
     }
@@ -111,15 +111,15 @@ impl Ty {
         self.kind.as_union().map_or(false, |x| x.is_empty())
     }
 
-    pub fn as_relation(&self) -> Option<&Vec<TupleField>> {
+    pub fn as_relation(&self) -> Option<&Vec<TyTupleField>> {
         self.kind.as_array()?.kind.as_tuple()
     }
 
-    pub fn as_relation_mut(&mut self) -> Option<&mut Vec<TupleField>> {
+    pub fn as_relation_mut(&mut self) -> Option<&mut Vec<TyTupleField>> {
         self.kind.as_array_mut()?.kind.as_tuple_mut()
     }
 
-    pub fn into_relation(self) -> Option<Vec<TupleField>> {
+    pub fn into_relation(self) -> Option<Vec<TyTupleField>> {
         self.kind.into_array().ok()?.kind.into_tuple().ok()
     }
 
@@ -133,11 +133,11 @@ impl Ty {
     }
 }
 
-impl TupleField {
+impl TyTupleField {
     pub fn ty(&self) -> Option<&Ty> {
         match self {
-            TupleField::Single(_, ty) => ty.as_ref(),
-            TupleField::Wildcard(ty) => ty.as_ref(),
+            TyTupleField::Single(_, ty) => ty.as_ref(),
+            TyTupleField::Wildcard(ty) => ty.as_ref(),
         }
     }
 }

--- a/prqlc/prqlc-parser/src/types.rs
+++ b/prqlc/prqlc-parser/src/types.rs
@@ -58,9 +58,9 @@ pub fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> {
             )
             .map(|((name, ty), range)| {
                 if range.is_some() {
-                    TupleField::Wildcard(Some(ty))
+                    TyTupleField::Wildcard(Some(ty))
                 } else {
-                    TupleField::Single(name, Some(ty))
+                    TyTupleField::Single(name, Some(ty))
                 }
             })
             .padded_by(new_line().repeated())

--- a/prqlc/prqlc/src/codegen/types.rs
+++ b/prqlc/prqlc/src/codegen/types.rs
@@ -88,7 +88,7 @@ impl WriteSource for TyKind {
     }
 }
 
-impl WriteSource for TupleField {
+impl WriteSource for TyTupleField {
     fn write(&self, opt: WriteOpt) -> Option<String> {
         match self {
             Self::Wildcard(generic_el) => match generic_el {

--- a/prqlc/prqlc/src/ir/pl/fold.rs
+++ b/prqlc/prqlc/src/ir/pl/fold.rs
@@ -3,7 +3,7 @@
 /// type.
 use itertools::Itertools;
 
-use crate::ast::{TupleField, Ty, TyFunc, TyKind};
+use crate::ast::{TyTupleField, Ty, TyFunc, TyKind};
 use crate::Result;
 
 use super::*;
@@ -322,11 +322,11 @@ pub fn fold_type<T: ?Sized + PlFold>(fold: &mut T, ty: Ty) -> Result<Ty> {
                     .into_iter()
                     .map(|field| -> Result<_> {
                         Ok(match field {
-                            TupleField::Single(name, ty) => {
-                                TupleField::Single(name, fold_type_opt(fold, ty)?)
+                            TyTupleField::Single(name, ty) => {
+                                TyTupleField::Single(name, fold_type_opt(fold, ty)?)
                             }
-                            TupleField::Wildcard(ty) => {
-                                TupleField::Wildcard(fold_type_opt(fold, ty)?)
+                            TyTupleField::Wildcard(ty) => {
+                                TyTupleField::Wildcard(fold_type_opt(fold, ty)?)
                             }
                         })
                     })

--- a/prqlc/prqlc/src/ir/pl/fold.rs
+++ b/prqlc/prqlc/src/ir/pl/fold.rs
@@ -3,7 +3,7 @@
 /// type.
 use itertools::Itertools;
 
-use crate::ast::{TyTupleField, Ty, TyFunc, TyKind};
+use crate::ast::{Ty, TyFunc, TyKind, TyTupleField};
 use crate::Result;
 
 use super::*;

--- a/prqlc/prqlc/src/ir/pl/mod.rs
+++ b/prqlc/prqlc/src/ir/pl/mod.rs
@@ -24,7 +24,7 @@ pub use self::utils::*;
 pub use crate::ast::{BinOp, BinaryExpr, Ident, Literal, UnOp, UnaryExpr, ValueAndUnit};
 
 pub fn print_mem_sizes() {
-    use crate::ast::{PrimitiveSet, TupleField, Ty, TyFunc, TyKind};
+    use crate::ast::{PrimitiveSet, TyTupleField, Ty, TyFunc, TyKind};
     use crate::ir::{decl, generic, pl, rq};
     use crate::sql::internal::SqlTransform;
     use crate::{ErrorMessage, ErrorMessages, SourceTree, Span};
@@ -82,7 +82,7 @@ pub fn print_mem_sizes() {
     println!("{:16}= {}", "TableExternRef", size_of::<TableExternRef>());
     println!("{:16}= {}", "TransformCall", size_of::<TransformCall>());
     println!("{:16}= {}", "TransformKind", size_of::<TransformKind>());
-    println!("{:16}= {}", "TupleField", size_of::<TupleField>());
+    println!("{:16}= {}", "TupleField", size_of::<TyTupleField>());
     println!("{:16}= {}", "Ty", size_of::<Ty>());
     println!("{:16}= {}", "TyFunc", size_of::<TyFunc>());
     println!("{:16}= {}", "TyKind", size_of::<TyKind>());

--- a/prqlc/prqlc/src/ir/pl/mod.rs
+++ b/prqlc/prqlc/src/ir/pl/mod.rs
@@ -24,7 +24,7 @@ pub use self::utils::*;
 pub use crate::ast::{BinOp, BinaryExpr, Ident, Literal, UnOp, UnaryExpr, ValueAndUnit};
 
 pub fn print_mem_sizes() {
-    use crate::ast::{PrimitiveSet, TyTupleField, Ty, TyFunc, TyKind};
+    use crate::ast::{PrimitiveSet, Ty, TyFunc, TyKind, TyTupleField};
     use crate::ir::{decl, generic, pl, rq};
     use crate::sql::internal::SqlTransform;
     use crate::{ErrorMessage, ErrorMessages, SourceTree, Span};

--- a/prqlc/prqlc/src/semantic/lowering.rs
+++ b/prqlc/prqlc/src/semantic/lowering.rs
@@ -6,7 +6,7 @@ use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 
 use crate::ast::generic::{InterpolateItem, Range, SwitchCase};
-use crate::ast::TupleField;
+use crate::ast::TyTupleField;
 use crate::ir::decl::{self, DeclKind, Module, RootModule, TableExpr};
 use crate::ir::generic::{ColumnSort, WindowFrame};
 use crate::ir::pl::{self, Ident, Lineage, LineageColumn, PlFold, QueryDef};
@@ -79,7 +79,7 @@ pub fn lower_to_ir(
 }
 
 fn extern_ref_to_relation(
-    mut columns: Vec<TupleField>,
+    mut columns: Vec<TyTupleField>,
     fq_ident: &Ident,
     database_module_path: &[String],
 ) -> Result<(rq::Relation, Option<String>), Error> {
@@ -102,7 +102,7 @@ fn extern_ref_to_relation(
     };
 
     // put wildcards last
-    columns.sort_by_key(|a| matches!(a, TupleField::Wildcard(_)));
+    columns.sort_by_key(|a| matches!(a, TyTupleField::Wildcard(_)));
 
     let relation = rq::Relation {
         kind: rq::RelationKind::ExternRef(extern_name),
@@ -111,12 +111,12 @@ fn extern_ref_to_relation(
     Ok((relation, None))
 }
 
-fn tuple_fields_to_relation_columns(columns: Vec<TupleField>) -> Vec<RelationColumn> {
+fn tuple_fields_to_relation_columns(columns: Vec<TyTupleField>) -> Vec<RelationColumn> {
     columns
         .into_iter()
         .map(|field| match field {
-            TupleField::Single(name, _) => RelationColumn::Single(name),
-            TupleField::Wildcard(_) => RelationColumn::Wildcard,
+            TyTupleField::Single(name, _) => RelationColumn::Single(name),
+            TyTupleField::Wildcard(_) => RelationColumn::Wildcard,
         })
         .collect_vec()
 }

--- a/prqlc/prqlc/src/semantic/module.rs
+++ b/prqlc/prqlc/src/semantic/module.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::QueryDef;
-use crate::ast::{Literal, Span, TupleField, Ty, TyKind};
+use crate::ast::{Literal, Span, TyTupleField, Ty, TyKind};
 use crate::Result;
 
 use crate::ir::pl::{Annotation, Expr, Ident, Lineage, LineageColumn};
@@ -48,7 +48,7 @@ impl Module {
             (
                 NS_INFER.to_string(),
                 Decl::from(DeclKind::Infer(Box::new(DeclKind::TableDecl(TableDecl {
-                    ty: Some(Ty::relation(vec![TupleField::Wildcard(None)])),
+                    ty: Some(Ty::relation(vec![TyTupleField::Wildcard(None)])),
                     expr: TableExpr::LocalTable,
                 })))),
             ),
@@ -232,7 +232,7 @@ impl Module {
                             .flat_map(|x| x.into_single())
                             .find(|(name, _)| name.as_ref() == Some(input_name))
                             .and_then(|(_, ty)| ty)
-                            .or(Some(Ty::new(TyKind::Tuple(vec![TupleField::Wildcard(
+                            .or(Some(Ty::new(TyKind::Tuple(vec![TyTupleField::Wildcard(
                                 None,
                             )]))));
 
@@ -531,8 +531,8 @@ pub fn ty_of_lineage(lineage: &Lineage) -> Ty {
             .columns
             .iter()
             .map(|col| match col {
-                LineageColumn::All { .. } => TupleField::Wildcard(None),
-                LineageColumn::Single { name, .. } => TupleField::Single(
+                LineageColumn::All { .. } => TyTupleField::Wildcard(None),
+                LineageColumn::Single { name, .. } => TyTupleField::Single(
                     name.as_ref().map(|i| i.name.clone()),
                     Some(Ty::new(Literal::Null)),
                 ),

--- a/prqlc/prqlc/src/semantic/module.rs
+++ b/prqlc/prqlc/src/semantic/module.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::QueryDef;
-use crate::ast::{Literal, Span, TyTupleField, Ty, TyKind};
+use crate::ast::{Literal, Span, Ty, TyKind, TyTupleField};
 use crate::Result;
 
 use crate::ir::pl::{Annotation, Expr, Ident, Lineage, LineageColumn};

--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use itertools::Itertools;
 
-use crate::ast::{TyTupleField, Ty, TyKind};
+use crate::ast::{Ty, TyKind, TyTupleField};
 use crate::ir::decl::{DeclKind, Module};
 use crate::ir::pl::*;
 use crate::semantic::resolver::{flatten, types, Resolver};

--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use itertools::Itertools;
 
-use crate::ast::{TupleField, Ty, TyKind};
+use crate::ast::{TyTupleField, Ty, TyKind};
 use crate::ir::decl::{DeclKind, Module};
 use crate::ir::pl::*;
 use crate::semantic::resolver::{flatten, types, Resolver};
@@ -278,7 +278,7 @@ impl Resolver<'_> {
                 id: Some(id.gen()),
                 target_id: decl.declared_at,
                 flatten: true,
-                ty: Some(Ty::new(TyKind::Tuple(vec![TupleField::Wildcard(None)]))),
+                ty: Some(Ty::new(TyKind::Tuple(vec![TyTupleField::Wildcard(None)]))),
                 ..Expr::new(Ident::from_name(NS_SELF))
             };
             return vec![wildcard_field];
@@ -314,8 +314,8 @@ fn ty_of_lineage(lineage: &Lineage) -> Ty {
             .columns
             .iter()
             .map(|col| match col {
-                LineageColumn::All { .. } => TupleField::Wildcard(None),
-                LineageColumn::Single { name, .. } => TupleField::Single(
+                LineageColumn::All { .. } => TyTupleField::Wildcard(None),
+                LineageColumn::Single { name, .. } => TyTupleField::Single(
                     name.as_ref().map(|i| i.name.clone()),
                     Some(Ty::new(Literal::Null)),
                 ),

--- a/prqlc/prqlc/src/semantic/resolver/inference.rs
+++ b/prqlc/prqlc/src/semantic/resolver/inference.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use itertools::Itertools;
 
-use crate::ast::{Ident, TyTupleField, Ty};
+use crate::ast::{Ident, Ty, TyTupleField};
 use crate::ir::decl::{Decl, TableDecl, TableExpr};
 use crate::ir::pl::{Lineage, LineageColumn, LineageInput};
 use crate::semantic::{NS_DEFAULT_DB, NS_INFER};
@@ -21,7 +21,9 @@ impl Resolver<'_> {
             return Err(format!("Variable {table_ident:?} is not a relation."));
         };
 
-        let has_wildcard = columns.iter().any(|c| matches!(c, TyTupleField::Wildcard(_)));
+        let has_wildcard = columns
+            .iter()
+            .any(|c| matches!(c, TyTupleField::Wildcard(_)));
         if !has_wildcard {
             return Err(format!("Table {table_ident:?} does not have wildcard."));
         }

--- a/prqlc/prqlc/src/semantic/resolver/inference.rs
+++ b/prqlc/prqlc/src/semantic/resolver/inference.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use itertools::Itertools;
 
-use crate::ast::{Ident, TupleField, Ty};
+use crate::ast::{Ident, TyTupleField, Ty};
 use crate::ir::decl::{Decl, TableDecl, TableExpr};
 use crate::ir::pl::{Lineage, LineageColumn, LineageInput};
 use crate::semantic::{NS_DEFAULT_DB, NS_INFER};
@@ -21,20 +21,20 @@ impl Resolver<'_> {
             return Err(format!("Variable {table_ident:?} is not a relation."));
         };
 
-        let has_wildcard = columns.iter().any(|c| matches!(c, TupleField::Wildcard(_)));
+        let has_wildcard = columns.iter().any(|c| matches!(c, TyTupleField::Wildcard(_)));
         if !has_wildcard {
             return Err(format!("Table {table_ident:?} does not have wildcard."));
         }
 
         let exists = columns.iter().any(|c| match c {
-            TupleField::Single(Some(n), _) => n == col_name,
+            TyTupleField::Single(Some(n), _) => n == col_name,
             _ => false,
         });
         if exists {
             return Ok(());
         }
 
-        columns.push(TupleField::Single(Some(col_name.to_string()), None));
+        columns.push(TyTupleField::Single(Some(col_name.to_string()), None));
 
         // also add into input tables of this table expression
         if let TableExpr::RelationVar(expr) = &table_decl.expr {
@@ -87,14 +87,14 @@ impl Resolver<'_> {
 
         for col in columns {
             let col = match col {
-                TupleField::Wildcard(_) => LineageColumn::All {
+                TyTupleField::Wildcard(_) => LineageColumn::All {
                     input_id,
                     except: columns
                         .iter()
                         .flat_map(|c| c.as_single().map(|x| x.0).cloned().flatten())
                         .collect(),
                 },
-                TupleField::Single(col_name, _) => LineageColumn::Single {
+                TyTupleField::Single(col_name, _) => LineageColumn::Single {
                     name: col_name
                         .clone()
                         .map(|col_name| Ident::from_path(vec![input_name.clone(), col_name])),
@@ -114,7 +114,7 @@ impl Resolver<'_> {
     pub(super) fn declare_table_for_literal(
         &mut self,
         input_id: usize,
-        columns: Option<Vec<TupleField>>,
+        columns: Option<Vec<TyTupleField>>,
         name_hint: Option<String>,
     ) -> Lineage {
         let id = input_id;

--- a/prqlc/prqlc/src/semantic/resolver/stmt.rs
+++ b/prqlc/prqlc/src/semantic/resolver/stmt.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use std::collections::HashMap;
 
-use crate::ast::{TupleField, Ty, TyKind};
+use crate::ast::{TyTupleField, Ty, TyKind};
 use crate::ir::decl::{Decl, DeclKind, Module, TableDecl, TableExpr};
 use crate::ir::pl::*;
 use crate::WithErrorInfo;
@@ -131,9 +131,9 @@ fn prepare_expr_decl(value: Box<Expr>) -> DeclKind {
         Some(frame) => {
             let columns = (frame.columns.iter())
                 .map(|col| match col {
-                    LineageColumn::All { .. } => TupleField::Wildcard(None),
+                    LineageColumn::All { .. } => TyTupleField::Wildcard(None),
                     LineageColumn::Single { name, .. } => {
-                        TupleField::Single(name.as_ref().map(|n| n.name.clone()), None)
+                        TyTupleField::Single(name.as_ref().map(|n| n.name.clone()), None)
                     }
                 })
                 .collect();

--- a/prqlc/prqlc/src/semantic/resolver/stmt.rs
+++ b/prqlc/prqlc/src/semantic/resolver/stmt.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use std::collections::HashMap;
 
-use crate::ast::{TyTupleField, Ty, TyKind};
+use crate::ast::{Ty, TyKind, TyTupleField};
 use crate::ir::decl::{Decl, DeclKind, Module, TableDecl, TableExpr};
 use crate::ir::pl::*;
 use crate::WithErrorInfo;

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -8,7 +8,7 @@ use crate::ir::decl::{Decl, DeclKind, Module};
 use crate::ir::generic::{SortDirection, WindowKind};
 use crate::ir::pl::*;
 
-use crate::ast::{TupleField, Ty, TyKind};
+use crate::ast::{TyTupleField, Ty, TyKind};
 use crate::semantic::ast_expand::{restrict_null_literal, try_restrict_range};
 use crate::semantic::resolver::functions::expr_of_func;
 use crate::semantic::{write_pl, NS_PARAM, NS_THIS};
@@ -373,7 +373,7 @@ impl Resolver<'_> {
                     .columns
                     .iter()
                     .cloned()
-                    .map(|x| TupleField::Single(Some(x), None))
+                    .map(|x| TyTupleField::Single(Some(x), None))
                     .collect();
 
                 let frame =
@@ -506,7 +506,7 @@ impl Resolver<'_> {
                 let with_name = with.alias.clone();
                 let with = with.ty.clone().unwrap();
                 let with = with.kind.into_array().unwrap();
-                let with = TupleField::Single(with_name, Some(*with));
+                let with = TyTupleField::Single(with_name, Some(*with));
 
                 Some(Ty::new(TyKind::Array(Box::new(Ty::new(ty_tuple_kind(
                     [input, vec![with]].concat(),
@@ -601,7 +601,7 @@ impl Resolver<'_> {
 
         // validate that the return type is a relation
         // this can be removed after we have proper type checking for all std functions
-        let expected = Some(Ty::relation(vec![TupleField::Wildcard(None)]));
+        let expected = Some(Ty::relation(vec![TyTupleField::Wildcard(None)]));
         self.validate_expr_type(&mut pipeline, expected.as_ref(), &|| {
             Some("pipeline".to_string())
         })?;

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -8,7 +8,7 @@ use crate::ir::decl::{Decl, DeclKind, Module};
 use crate::ir::generic::{SortDirection, WindowKind};
 use crate::ir::pl::*;
 
-use crate::ast::{TyTupleField, Ty, TyKind};
+use crate::ast::{Ty, TyKind, TyTupleField};
 use crate::semantic::ast_expand::{restrict_null_literal, try_restrict_range};
 use crate::semantic::resolver::functions::expr_of_func;
 use crate::semantic::{write_pl, NS_PARAM, NS_THIS};

--- a/prqlc/prqlc/src/semantic/resolver/types.rs
+++ b/prqlc/prqlc/src/semantic/resolver/types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::iter::zip;
 
-use crate::ast::{PrimitiveSet, TyTupleField, Ty, TyFunc, TyKind};
+use crate::ast::{PrimitiveSet, Ty, TyFunc, TyKind, TyTupleField};
 use crate::Result;
 use itertools::Itertools;
 


### PR DESCRIPTION
This PR is the first commit in series of trying to formalize what expression aliases are (i.e. `x` in `select x = my_col`).

The idea was that these are all just tuple field names, but it turns out this is not the case, so I'm abandoning that idea.

This PR is just a refactor that makes sense on its own, remaining commits are on branch `feat-tuple-field`.