### PR TITLE
build: run GHA on pull_request to *main* only

### DIFF
--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -3,6 +3,8 @@ name: pull-request-target
 on:
   pull_request_target:
     types: [opened, edited, synchronize, labeled, closed]
+    branches:
+      - main
 
 concurrency:
   # Generally we use `github.ref`, but in pull_request_target, that's always `main`.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,8 @@ on:
     # Add `labeled`, so we can trigger a new run by adding a `pr-nightly`
     # label, which we then use to trigger a `nightly` run.
     types: [opened, reopened, synchronize, labeled]
+    branches:
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
I want customize GHA for pull requests to feat-types branch, I have to limit these actions to pull requests to branch `main`.