### PR TITLE
ci: Only run on macos-14

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,8 +43,6 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
-          - os: macos-latest
-            target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin
           - os: windows-latest
@@ -92,8 +90,6 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
-          - os: macos-latest
-            target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin
           - os: windows-latest
@@ -273,7 +269,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         package:
           - prqlc-python
           - lutra-python

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -199,8 +199,8 @@ jobs:
       # 20 workflow limit.
       oss:
         ${{ (needs.rules.outputs.python == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-latest", "macos-latest", "macos-14",
-        "windows-latest"]' || '["ubuntu-latest"]' }}
+        == 'true') && '["ubuntu-latest", "macos-14", "windows-latest"]' ||
+        '["ubuntu-latest"]' }}
 
   test-js:
     needs: rules
@@ -210,8 +210,8 @@ jobs:
       # Only run on ubuntu unless there's a lang-specific change or we're running nightly.
       oss:
         ${{ (needs.rules.outputs.js == 'true' || needs.rules.outputs.nightly ==
-        'true') && '["ubuntu-latest", "macos-latest", "macos-14",
-        "windows-latest"]' || '["ubuntu-latest"]' }}
+        'true') && '["ubuntu-latest", "macos-14", "windows-latest"]' ||
+        '["ubuntu-latest"]' }}
 
   test-dotnet:
     needs: rules
@@ -232,8 +232,7 @@ jobs:
       # Currently we never run windows
       oss:
         ${{ (needs.rules.outputs.java == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-latest", "macos-latest", "macos-14"]' ||
-        '["ubuntu-latest"]' }}
+        == 'true') && '["ubuntu-latest", "macos-14"]' || '["ubuntu-latest"]' }}
 
   test-elixir:
     needs: rules
@@ -297,10 +296,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # Excluding until https://github.com/PRQL/prql/issues/4362 is resolved.
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-          #   features: default,test-dbs
           - os: macos-14
             target: aarch64-apple-darwin
             features: default,test-dbs
@@ -636,9 +631,6 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             features: default,test-dbs
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            features: default,test-dbs
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             features: default
@@ -672,9 +664,6 @@ jobs:
             features: default
           - os: macos-14
             target: aarch64-apple-darwin
-            features: default,test-dbs
-          - os: macos-latest
-            target: x86_64-apple-darwin
             features: default,test-dbs
           - os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
These are gradually transitioning to `macos-latest`, but because they can't share a cache, we need to tag them explicitly. When it's fully transitioned, we can specify `latest` again (would be great if Dependabot could upgrade runner images too so we could upgrade explicitly!)

Based on https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

This means we no longer test on intel cpus on MacOS. But seems that's the way things are going.
