### PR TITLE
docs(changelog): Add VSCode Great Icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - The syntax highlighter package for Sublime Text is now
   [published](https://packagecontrol.io/packages/PRQL) (@vanillajonathan).
+- The [VSCode Great Icons](https://marketplace.visualstudio.com/items?itemName=emmanuelbeziat.vscode-great-icons)
+  icon pack extension shows a database icon for `.prql` files. (@EmmanuelBeziat)
 
 **Internal changes**:
 


### PR DESCRIPTION
VSCode Great Icons v2.1.103 (2024-04-06) shows a database icon for `.prql` files.

Changelog: https://github.com/EmmanuelBeziat/vscode-great-icons/blob/main/CHANGELOG.md#v21103-2024-04-06

Issue: https://github.com/EmmanuelBeziat/vscode-great-icons/issues/281