### PR TITLE
internal: Remove unneeded `flatten`

### DIFF
--- a/prqlc/prqlc-parser/src/lexer.rs
+++ b/prqlc/prqlc-parser/src/lexer.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Token {
-    #[serde(flatten)]
     pub kind: TokenKind,
     pub span: std::ops::Range<usize>,
 }


### PR DESCRIPTION
This seems default
