### PR TITLE
fix: add error msg for no rows in from_text (#4421)

### DIFF
--- a/prqlc/prqlc/src/sql/gen_query.rs
+++ b/prqlc/prqlc/src/sql/gen_query.rs
@@ -447,7 +447,7 @@ fn translate_relation_literal(data: RelationLiteral, ctx: &Context) -> Result<sq
         return Err(
             Error::new_simple("No rows provided for `from_text`".to_string()).push_hint(
                 "add a newline, then a row of data following the column. If using \
-                the json format, ensure `data` isnt empty",
+                the json format, ensure `data` isn't empty",
             ),
         );
     }

--- a/prqlc/prqlc/src/sql/gen_query.rs
+++ b/prqlc/prqlc/src/sql/gen_query.rs
@@ -443,6 +443,15 @@ fn translate_relation_literal(data: RelationLiteral, ctx: &Context) -> Result<sq
         selects.push(body)
     }
 
+    if selects.is_empty() {
+        return Err(
+            Error::new_simple("No rows provided for `from_text`".to_string()).push_hint(
+                "add a newline, then a row of data following the column. If using \
+                the json format, ensure `data` isnt empty",
+            ),
+        );
+    }
+
     let mut body = selects.remove(0);
     for select in selects {
         body = SetExpr::SetOperation {


### PR DESCRIPTION
addresses #4421 by adding an error message if no data rows are provided with `from_text`