### PR TITLE
build: Replace `atty` with `is-terminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,12 +1809,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,17 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,15 +1672,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
@@ -1833,7 +1813,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2486,7 +2466,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2902,7 +2882,6 @@ dependencies = [
  "anstream",
  "anyhow",
  "ariadne",
- "atty",
  "cfg-if",
  "chrono",
  "clap 4.4.18",
@@ -2919,6 +2898,7 @@ dependencies = [
  "glob",
  "insta",
  "insta-cmd",
+ "is-terminal",
  "itertools 0.12.1",
  "log",
  "minijinja",

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -14,7 +14,7 @@ metadata.msrv = "1.70.0"
 [features]
 cli = [
   "anyhow",
-  "atty",
+  "is-terminal",
   "clap_complete_command",
   "clap_complete",
   "clap",
@@ -33,8 +33,8 @@ test-dbs = ["anyhow", "duckdb", "glob", "rusqlite", "tokio"]
 test-dbs-external = ["anyhow", "duckdb", "glob", "mysql", "pg_bigdecimal", "postgres", "rusqlite", "tiberius", "tokio", "tokio-util"]
 
 [dependencies]
-prqlc-ast = {path = "../prqlc-ast", version = "0.11.5" }
-prqlc-parser = {path = "../prqlc-parser", version = "0.11.5" }
+prqlc-ast = {path = "../prqlc-ast", version = "0.11.5"}
+prqlc-parser = {path = "../prqlc-parser", version = "0.11.5"}
 
 anstream = {version = "0.6.13", features = ["auto"]}
 ariadne = "0.4.0"
@@ -60,13 +60,13 @@ strum_macros = "0.26.2"
 # unique dependencies from the CLI, marked as optional and included in the 'cli'
 # feature
 anyhow = {version = "1.0.82", features = ["backtrace"], optional = true}
-atty = {version = "0.2.14", optional = true}
 clap = {version = "4.4.18", features = ["derive", "env", "wrap_help"], optional = true}
 clap_complete_command = {version = "0.5.1", optional = true}
 clio = {version = "0.3.3", features = ['clap-parse'], optional = true}
 color-eyre = {version = "0.6.3", optional = true}
 colorchoice-clap = {version = "1.0.0", optional = true}
 env_logger = {version = "0.10.2", features = ["color"], optional = true}
+is-terminal = {version = "0.4.0", optional = true}
 notify = {version = "6.1.1", optional = true}
 walkdir = {version = "2.5.0", optional = true}
 

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -66,7 +66,7 @@ clio = {version = "0.3.3", features = ['clap-parse'], optional = true}
 color-eyre = {version = "0.6.3", optional = true}
 colorchoice-clap = {version = "1.0.0", optional = true}
 env_logger = {version = "0.10.2", features = ["color"], optional = true}
-is-terminal = {version = "0.4.0", optional = true}
+is-terminal = {version = "0.4.12", optional = true}
 notify = {version = "6.1.1", optional = true}
 walkdir = {version = "2.5.0", optional = true}
 

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -12,6 +12,7 @@ use ariadne::Source;
 use clap::{CommandFactory, Parser, Subcommand, ValueHint};
 use clio::has_extension;
 use clio::Output;
+use is_terminal::IsTerminal;
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::env;
@@ -464,8 +465,7 @@ impl Command {
         //
         // See https://github.com/PRQL/prql/issues/3228 for details on us not
         // yet using `input.is_tty()`.
-        // if input.is_tty() {
-        if input.path() == Path::new("-") && atty::is(atty::Stream::Stdin) {
+        if input.path() == Path::new("-") && std::io::stdin().is_terminal() {
             #[cfg(unix)]
             eprintln!("Enter PRQL, then press ctrl-d to compile:\n");
             #[cfg(windows)]


### PR DESCRIPTION
Continuation of https://github.com/PRQL/prql/pull/3240, replacing a deprecated dependency

FYI I tried using the clio approach, but it still has the same existing issue re printing the help message even when not in a terminal.
