### PR TITLE
fix: Allow all tokens to be written as YAML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,6 +3123,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "strum 0.26.2",
 ]
 
@@ -3145,6 +3146,7 @@ dependencies = [
  "prqlc-ast",
  "semver",
  "serde",
+ "serde_yaml",
  "stacker",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ insta-cmd = "0.6.0"
 itertools = "0.12.0"
 log = "0.4.21"
 serde = {version = "1.0.202", features = ["derive"]}
+serde_yaml = {version = "0.9.34"}

--- a/prqlc/prqlc-ast/Cargo.toml
+++ b/prqlc/prqlc-ast/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 enum-as-inner = "0.6.0"
 semver = {version = "1.0.23", features = ["serde"]}
 serde = {workspace = true}
+serde_yaml = {workspace = true, optional = true}
 strum = {version = "0.26.2", features = ["std", "derive"]}
 
 [dev-dependencies]

--- a/prqlc/prqlc-ast/src/expr.rs
+++ b/prqlc/prqlc-ast/src/expr.rs
@@ -47,6 +47,10 @@ pub enum ExprKind {
         base: Box<Expr>,
         field: IndirectionKind,
     },
+    #[cfg_attr(
+        feature = "serde_yaml",
+        serde(with = "serde_yaml::with::singleton_map")
+    )]
     Literal(Literal),
     Pipeline(Pipeline),
 

--- a/prqlc/prqlc-parser/Cargo.toml
+++ b/prqlc/prqlc-parser/Cargo.toml
@@ -16,6 +16,7 @@ itertools = {workspace = true}
 prqlc-ast = {path = "../prqlc-ast", version = "0.11.5" }
 semver = {version = "1.0.23"}
 serde = {workspace = true}
+serde_yaml = {workspace = true, optional = true}
 
 # Chumsky's default features have issues when running in wasm (though we only
 # see it when compiling on macOS), so we only include features when running

--- a/prqlc/prqlc-parser/src/lexer.rs
+++ b/prqlc/prqlc-parser/src/lexer.rs
@@ -19,6 +19,10 @@ pub enum TokenKind {
 
     Ident(String),
     Keyword(String),
+    #[cfg_attr(
+        feature = "serde_yaml",
+        serde(with = "serde_yaml::with::singleton_map")
+    )]
     Literal(Literal),
     Param(String),
 

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -14,7 +14,6 @@ metadata.msrv = "1.70.0"
 [features]
 cli = [
   "anyhow",
-  "is-terminal",
   "clap_complete_command",
   "clap_complete",
   "clap",
@@ -22,8 +21,11 @@ cli = [
   "color-eyre",
   "colorchoice-clap",
   "env_logger",
+  "is-terminal",
   "minijinja",
   "notify",
+  "prqlc-ast/serde_yaml",
+  "prqlc-parser/serde_yaml",
   "walkdir",
 ]
 default = ["cli"]
@@ -49,7 +51,7 @@ semver = {version = "1.0.23", features = ["serde"]}
 # We could put `serde` behind a feature if we wanted to reduce the size of prqlc.
 serde = {workspace = true}
 serde_json = "1.0.117"
-serde_yaml = {version = "0.9.34"}
+serde_yaml = {workspace = true}
 sqlformat = "0.2.3"
 sqlparser = {version = "0.46.0", features = ["serde"]}
 strum = {version = "0.26.2", features = ["std", "derive"]}

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -872,4 +872,52 @@ sort full
             end: 17
         "###);
     }
+    #[test]
+    fn lex_nested_enum() {
+        let output = Command::execute(
+            &Command::Lex {
+                io_args: IoArgs::default(),
+                format: Format::Yaml,
+            },
+            &mut r#"
+            from tracks
+            take 10
+            "#
+            .into(),
+            "",
+        )
+        .unwrap();
+
+        assert_snapshot!(String::from_utf8(output).unwrap().trim(), @r###"
+        - kind: NewLine
+          span:
+            start: 0
+            end: 1
+        - kind: !Ident from
+          span:
+            start: 13
+            end: 17
+        - kind: !Ident tracks
+          span:
+            start: 18
+            end: 24
+        - kind: NewLine
+          span:
+            start: 24
+            end: 25
+        - kind: !Ident take
+          span:
+            start: 37
+            end: 41
+        - kind: !Literal
+            Integer: 10
+          span:
+            start: 42
+            end: 44
+        - kind: NewLine
+          span:
+            start: 44
+            end: 45
+        "###);
+    }
 }

--- a/prqlc/prqlc/tests/integration/ast_code_matches.rs
+++ b/prqlc/prqlc/tests/integration/ast_code_matches.rs
@@ -26,12 +26,19 @@ fn test_expr_ast_code_matches() {
     +        within: Box<Expr>,
     +        except: Box<Expr>,
     @@ .. @@
+    -    #[cfg_attr(
+    -        feature = "serde_yaml",
+    -        serde(with = "serde_yaml::with::singleton_map")
+    -    )]
+    @@ .. @@
     -    Pipeline(Pipeline),
     @@ .. @@
     -    Range(Range),
     -    Binary(BinaryExpr),
     -    Unary(UnaryExpr),
     @@ .. @@
+    -}
+    -
     -#[derive(Debug, EnumAsInner, PartialEq, Clone, Serialize, Deserialize)]
     -pub enum IndirectionKind {
     -    Name(String),
@@ -44,8 +51,7 @@ fn test_expr_ast_code_matches() {
     -    pub left: Box<Expr>,
     -    pub op: BinOp,
     -    pub right: Box<Expr>,
-    -}
-    -
+    @@ .. @@
     -#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
     -pub struct UnaryExpr {
     -    pub op: UnOp,
@@ -53,8 +59,6 @@ fn test_expr_ast_code_matches() {
     -}
     -
     @@ .. @@
-    -}
-    -
     -#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
     -pub struct GenericTypeParam {
     -    /// Assigned name of this generic type argument.
@@ -64,7 +68,8 @@ fn test_expr_ast_code_matches() {
     -    /// For a given instance of this function, the argument must be
     -    /// exactly one of types in the domain.
     -    pub domain: Vec<Ty>,
-    @@ .. @@
+    -}
+    -
     -/// A value and a series of functions that are to be applied to that value one after another.
     -#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
     -pub struct Pipeline {


### PR DESCRIPTION
We previously had one that was nested, so it needed a different serializer (which then meant we needed to add the `serde_yaml` feature in a few places..)
