### PR TITLE
fix: Add support for expressions on left hand side of std.in operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 **Fixes**:
 
+- Support expressions on left hand side of `std.in` operator. (@kgutwin, #4498)
+
 **Documentation**:
 
 **Web**:

--- a/prqlc/prqlc/src/sql/gen_expr.rs
+++ b/prqlc/prqlc/src/sql/gen_expr.rs
@@ -160,7 +160,8 @@ fn process_null(name: &str, args: &[Expr], ctx: &mut Context) -> Result<sql_ast:
 fn process_array_in(expr: &Expr, args: &[Expr], ctx: &mut Context) -> Result<sql_ast::Expr> {
     match args {
         [col_expr @ Expr {
-            kind: ExprKind::ColumnRef(_)
+            kind:
+                ExprKind::ColumnRef(_)
                 | ExprKind::Literal(_)
                 | ExprKind::SString(_)
                 | ExprKind::Param(_)
@@ -179,7 +180,7 @@ fn process_array_in(expr: &Expr, args: &[Expr], ctx: &mut Context) -> Result<sql
         }),
         _ => Err(
             Error::new_simple("args to `std.array_in` must be an expression and an array")
-                .with_span(expr.span)
+                .with_span(expr.span),
         ),
     }
 }

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -1226,6 +1226,22 @@ fn test_not_in_values() {
 }
 
 #[test]
+fn test_in_values_err_01() {
+    assert_snapshot!((compile(r###"
+    from employees
+    derive { ng = ([1, 2] | in [3, 4]) }
+    "###).unwrap_err()), @r###"
+    Error:
+       ╭─[:3:29]
+       │
+     3 │     derive { ng = ([1, 2] | in [3, 4]) }
+       │                             ────┬────
+       │                                 ╰────── args to `std.array_in` must be an expression and an array
+    ───╯
+    "###);
+}
+
+#[test]
 fn test_interval() {
     let query = r###"
     from projects

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -1155,6 +1155,8 @@ fn test_in_values_01() {
     from employees
     filter (title | in ["Sales Manager", "Sales Support Agent"])
     filter (employee_id | in [1, 2, 5])
+    filter (f"{emp_group}.{role}" | in ["sales_ne.mgr", "sales_mw.mgr"])
+    filter (s"{metadata} ->> '$.location'" | in ["Northeast", "Midwest"])
     "#).unwrap()), @r#"
     SELECT
       *
@@ -1163,6 +1165,8 @@ fn test_in_values_01() {
     WHERE
       title IN ('Sales Manager', 'Sales Support Agent')
       AND employee_id IN (1, 2, 5)
+      AND CONCAT(emp_group, '.', role) IN ('sales_ne.mgr', 'sales_mw.mgr')
+      AND metadata ->> '$.location' IN ('Northeast', 'Midwest')
     "#);
 }
 


### PR DESCRIPTION
Resolves #4497.

I'm hoping this is as simple as it needs to be to resolve this... if there's a more complex reason why `std.in` needs to not support expressions on the left-hand side, more discussion is appreciated!

Thanks for this package - it's making a big impact on our project, which we hope to release relatively soon!