### PR TITLE
feat: Allow join side to take an ident that resolves to a literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   generates Markdown documentation from `.prql` files. (@vanillajonathan,
   #4152).
 - Add `prqlc lex` command to the CLI (@max-sixty)
+- Join `side` parameter can take a reference that resolves to a literal (@kgutwin, #4499)
 
 **Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   generates Markdown documentation from `.prql` files. (@vanillajonathan,
   #4152).
 - Add `prqlc lex` command to the CLI (@max-sixty)
-- Join `side` parameter can take a reference that resolves to a literal (@kgutwin, #4499)
+- Join `side` parameter can take a reference that resolves to a literal (note: this is an experimental feature which may change in the future) (@kgutwin, #4499)
 
 **Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
   generates Markdown documentation from `.prql` files. (@vanillajonathan,
   #4152).
 - Add `prqlc lex` command to the CLI (@max-sixty)
-- Join `side` parameter can take a reference that resolves to a literal (note: this is an experimental feature which may change in the future) (@kgutwin, #4499)
+- Join `side` parameter can take a reference that resolves to a literal (note:
+  this is an experimental feature which may change in the future) (@kgutwin,
+  #4499)
 
 **Fixes**:
 

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -101,7 +101,9 @@ impl Resolver<'_> {
 
                 let side = {
                     let span = side.span;
-                    let ident = side.try_cast(ExprKind::into_ident, Some("side"), "ident")?;
+                    let ident =
+                        side.clone()
+                            .try_cast(ExprKind::into_ident, Some("side"), "ident")?;
                     match ident.to_string().as_str() {
                         "inner" => JoinSide::Inner,
                         "left" => JoinSide::Left,
@@ -109,12 +111,27 @@ impl Resolver<'_> {
                         "full" => JoinSide::Full,
 
                         found => {
-                            return Err(Error::new(Reason::Expected {
-                                who: Some("`side`".to_string()),
-                                expected: "inner, left, right or full".to_string(),
-                                found: found.to_string(),
-                            })
-                            .with_span(span))
+                            let folded = self.fold_expr(side)?.try_cast(
+                                ExprKind::into_literal,
+                                Some("side"),
+                                "string literal",
+                            )?;
+
+                            match folded.to_string().as_str() {
+                                "\"inner\"" => JoinSide::Inner,
+                                "\"left\"" => JoinSide::Left,
+                                "\"right\"" => JoinSide::Right,
+                                "\"full\"" => JoinSide::Full,
+
+                                _ => {
+                                    return Err(Error::new(Reason::Expected {
+                                        who: Some("`side`".to_string()),
+                                        expected: "inner, left, right or full".to_string(),
+                                        found: found.to_string(),
+                                    })
+                                    .with_span(span))
+                                }
+                            }
                         }
                     }
                 };

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -104,6 +104,8 @@ impl Resolver<'_> {
                     let ident =
                         side.clone()
                             .try_cast(ExprKind::into_ident, Some("side"), "ident")?;
+
+                    // first try to match the raw ident string as a bare word
                     match ident.to_string().as_str() {
                         "inner" => JoinSide::Inner,
                         "left" => JoinSide::Left,
@@ -111,6 +113,10 @@ impl Resolver<'_> {
                         "full" => JoinSide::Full,
 
                         found => {
+                            // if that fails, fold the ident and try
+                            // treating the result as a literal
+                            // this allows the join side to be passed as a
+                            // function parameter
                             let folded = self.fold_expr(side)?.try_cast(
                                 ExprKind::into_literal,
                                 Some("side"),

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -112,7 +112,7 @@ impl Resolver<'_> {
                         "right" => JoinSide::Right,
                         "full" => JoinSide::Full,
 
-                        found => {
+                        _ => {
                             // if that fails, fold the ident and try treating the result as a literal
                             // this allows the join side to be passed as a function parameter
                             // NOTE: this is temporary, pending discussions and implementation, tracked in #4501
@@ -132,7 +132,7 @@ impl Resolver<'_> {
                                     return Err(Error::new(Reason::Expected {
                                         who: Some("`side`".to_string()),
                                         expected: "inner, left, right or full".to_string(),
-                                        found: found.to_string(),
+                                        found: folded.to_string(),
                                     })
                                     .with_span(span))
                                 }

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -113,10 +113,9 @@ impl Resolver<'_> {
                         "full" => JoinSide::Full,
 
                         found => {
-                            // if that fails, fold the ident and try
-                            // treating the result as a literal
-                            // this allows the join side to be passed as a
-                            // function parameter
+                            // if that fails, fold the ident and try treating the result as a literal
+                            // this allows the join side to be passed as a function parameter
+                            // NOTE: this is temporary, pending discussions and implementation, tracked in #4501
                             let folded = self.fold_expr(side)?.try_cast(
                                 ExprKind::into_literal,
                                 Some("side"),

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -2415,7 +2415,7 @@ fn test_join_side_literal_err() {
        │
      5 │     join y (==id) side:my_side
        │                        ───┬───
-       │                           ╰───── `side` expected inner, left, right or full, but found my_side
+       │                           ╰───── `side` expected inner, left, right or full, but found 42
     ───╯
     "###);
 }
@@ -2454,7 +2454,7 @@ fn test_join_side_literal_via_func_err() {
        │
      3 │         join side:_param.s m (c == that.k) tbl
        │                         ─┬
-       │                          ╰── `side` expected inner, left, right or full, but found _param.s
+       │                          ╰── `side` expected inner, left, right or full, but found "four"
     ───╯
     "###);
 }


### PR DESCRIPTION
This PR makes a small addition to the `join` transform, allowing the `side:` parameter to take an Ident that resolves immediately to a string literal.

Example:

```prql
let my_side = "right"

from x
join y (==id) side:my_side
```

compiles as you would expect to

```sql
SELECT 
  x.*, 
  y.* 
FROM 
  x 
  RIGHT JOIN y ON x.id = y.id
```

---

Why this change? I am working on a set of "library" functions for my project, and one of them is a simple "map" transform that takes in a relation as a lookup table and outputs a new column. The basic code for this function is:

```prql
let map_into = func
  map_tbl <relation>
  column <scalar>
  map_tpl <tuple>
  tbl <relation>
  -> (
    join side:left map=map_tbl (column == that.key) tbl
    derive map_tpl
    select !{ map.key, map.value }
)

# usage of the above
let region_lookup = from_text """
key,value
1,northeast
2,southeast
3,midwest
4,northwest
5,southwest
"""

from employees
map_into region_lookup this.region { region_name = that.value }
```

Which works great -- but it isn't configurable as to the join type, which means users of this library function only get one hard-coded option. What I want is to expose the join side as a function parameter... with this PR, it now looks like this:

```prql
let map_into = func
  map_tbl <relation>
  column <scalar>
  map_tpl <tuple>
  side <text>:"left"
  tbl <relation>
  -> (
    join side:_param.side map=map_tbl (column == that.key) tbl
    derive map_tpl
    select !{ map.key, map.value }
)

from employees
map_into region_lookup this.region { region_name = that.value } side:"inner"
# now the resulting SQL uses an inner join rather than a left join
```

Note the use of `join side:_param.side` to pass the side value in via parameter.

Feedback is welcome - thanks!