### PR TITLE
build: Can't put serde behind a feature

### DIFF
--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -52,9 +52,8 @@ log = {workspace = true}
 once_cell = "1.19.0"
 regex = "1.10.4"
 semver = {version = "1.0.23", features = ["serde"]}
-# We could put `serde` behind a feature if we wanted to reduce the size of
-# prqlc, though it's needed for most bindings given they produce JSON, so it
-# would mostly only be a saving for prqlc-c.
+# serde is required for the `from_text` feature of PRQL, so we can't really put
+# it behind a feature.
 serde = {workspace = true}
 serde_json = {workspace = true}
 serde_yaml = {workspace = true, optional = true}


### PR DESCRIPTION
I tried to do this, but then realized we need it for the json feature in `from_text`. So this just changes the comment...
