### PR TITLE
fix: Can't run playground or book from DevContainer

### DIFF
--- a/web/Taskfile.yaml
+++ b/web/Taskfile.yaml
@@ -24,13 +24,13 @@ tasks:
     desc: Build & serve the static website for interactive development.
     dir: website
     cmds:
-      - hugo server
+      - hugo server --bind 0.0.0.0
 
   run-book:
     desc: Build & serve the book for interactive development.
     dir: book
     cmds:
-      - mdbook serve --port=3000
+      - mdbook serve --port=3000 -n 0.0.0.0
 
   run-playground:
     desc: Build & serve the playground for interactive development.

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -42,7 +42,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "prepare": "rsync -ai --checksum --delete ../../prqlc/prqlc/tests/integration/data/ public/data/ && node generateBook.cjs",
     "preview": "vite preview"


### PR DESCRIPTION
The problem was that the DevContainer became sensitive to the difference between 'localhost', '127.0.0.1' and '0.0.0.0'
The fix is to force the components to bind to 0.0.0.0