### PR TITLE
chore: Adjust MSRV definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
   "prqlc/prqlc/examples/compile-files", # An example
   "lutra/lutra",
   "lutra/bindings/python",
-  "web/book", # The book / docs
+  "web/book",
 ]
 resolver = "2"
 
@@ -22,6 +22,8 @@ authors = ["PRQL Developers"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/PRQL/prql"
+# This isn't tested since `cargo-msrv` doesn't support workspaces; instead we
+# test `metadata.msrv` in `prqlc`
 rust-version = "1.70.0"
 version = "0.11.5"
 

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -80,8 +80,8 @@ is-terminal = {version = "0.4.12", optional = true}
 notify = {version = "6.1.1", optional = true}
 walkdir = {version = "2.5.0", optional = true}
 
-# Not direct dependencies, but pinning because of bugs in previous versions. Can
-# remove when dependencies no longer use it. (If CI passes, it can be removed.)
+# Not direct dependencies, but pinning because later versions have a higher MSRV. Can
+# remove when we increase MSRV.
 clap_builder = {version = "=4.4.18", optional = true}
 clap_complete = {version = "=4.4.10", optional = true}
 clap_complete_fig = {version = "=4.4.2", optional = true}

--- a/web/book/Cargo.toml
+++ b/web/book/Cargo.toml
@@ -5,7 +5,6 @@ publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 version.workspace = true
 
 [lib]


### PR DESCRIPTION
The book definition isn't accurate (though doesn't really matter since it's not published). The notes I added in the previous commit were a copy/paste mistake; now fixed.
