### PR TITLE
style: Sort imports

### DIFF
--- a/lutra/bindings/python/src/lib.rs
+++ b/lutra/bindings/python/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg(not(target_family = "wasm"))]
 
-use arrow::{pyarrow::PyArrowType, record_batch::RecordBatch};
-use itertools::Itertools;
 use std::str::FromStr;
 
+use arrow::{pyarrow::PyArrowType, record_batch::RecordBatch};
+use itertools::Itertools;
 use pyo3::prelude::*;
 
 #[pymodule]

--- a/prqlc/bindings/java/src/lib.rs
+++ b/prqlc/bindings/java/src/lib.rs
@@ -1,8 +1,9 @@
+use std::str::FromStr;
+
 use jni::objects::{JClass, JString};
 use jni::sys::{jboolean, jstring};
 use jni::JNIEnv;
 use prqlc::{json, pl_to_prql, prql_to_pl, ErrorMessages, Options, Target};
-use std::str::FromStr;
 
 #[no_mangle]
 #[allow(non_snake_case)]

--- a/prqlc/bindings/prqlc-c/src/lib.rs
+++ b/prqlc/bindings/prqlc-c/src/lib.rs
@@ -2,12 +2,13 @@
 
 extern crate libc;
 
-use libc::{c_char, size_t};
-use prqlc::ErrorMessages;
-use prqlc::Target;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::str::FromStr;
+
+use libc::{c_char, size_t};
+use prqlc::ErrorMessages;
+use prqlc::Target;
 
 /// Compile a PRQL string into a SQL string.
 ///

--- a/prqlc/bindings/prqlc-python/src/lib.rs
+++ b/prqlc/bindings/prqlc-python/src/lib.rs
@@ -134,8 +134,9 @@ pub fn get_targets() -> Vec<String> {
 #[cfg(not(feature = "extension-module"))]
 #[cfg(test)]
 mod test {
-    use super::*;
     use insta::assert_snapshot;
+
+    use super::*;
 
     #[test]
     fn parse_for_python() {

--- a/prqlc/prqlc-ast/src/error.rs
+++ b/prqlc/prqlc-ast/src/error.rs
@@ -191,8 +191,9 @@ impl<T, E: WithErrorInfo> WithErrorInfo for Result<T, E> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use insta::{assert_debug_snapshot, assert_snapshot};
+
+    use super::*;
 
     // Helper function to create a simple Error object
     fn create_simple_error() -> Error {

--- a/prqlc/prqlc-ast/src/expr.rs
+++ b/prqlc/prqlc-ast/src/expr.rs
@@ -3,13 +3,12 @@ mod ident;
 mod literal;
 mod ops;
 
-pub use ident::Ident;
-pub use literal::{Literal, ValueAndUnit};
-pub use ops::{BinOp, UnOp};
-
 use std::collections::HashMap;
 
 use enum_as_inner::EnumAsInner;
+pub use ident::Ident;
+pub use literal::{Literal, ValueAndUnit};
+pub use ops::{BinOp, UnOp};
 use serde::{Deserialize, Serialize};
 
 use crate::{Span, Ty};

--- a/prqlc/prqlc-ast/src/expr.rs
+++ b/prqlc/prqlc-ast/src/expr.rs
@@ -6,11 +6,11 @@ mod ops;
 use std::collections::HashMap;
 
 use enum_as_inner::EnumAsInner;
-pub use ident::Ident;
-pub use literal::{Literal, ValueAndUnit};
-pub use ops::{BinOp, UnOp};
 use serde::{Deserialize, Serialize};
 
+pub use self::ident::Ident;
+pub use self::literal::{Literal, ValueAndUnit};
+pub use self::ops::{BinOp, UnOp};
 use crate::{Span, Ty};
 
 impl Expr {

--- a/prqlc/prqlc-ast/src/span.rs
+++ b/prqlc/prqlc-ast/src/span.rs
@@ -1,7 +1,8 @@
-use serde::de::Visitor;
-use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
 use std::ops::Range;
+
+use serde::de::Visitor;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Copy)]
 pub struct Span {

--- a/prqlc/prqlc-ast/src/types.rs
+++ b/prqlc/prqlc-ast/src/types.rs
@@ -2,9 +2,8 @@ use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 
-use crate::{Ident, Span};
-
 use super::Literal;
+use crate::{Ident, Span};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ty {

--- a/prqlc/prqlc-parser/src/expr.rs
+++ b/prqlc/prqlc-parser/src/expr.rs
@@ -1,16 +1,14 @@
 use std::collections::HashMap;
 
 use chumsky::prelude::*;
-
 use prqlc_ast::expr::*;
 use prqlc_ast::Span;
-
-use crate::types::type_expr;
 
 use super::common::*;
 use super::interpolation;
 use super::lexer::TokenKind;
 use super::span::ParserSpan;
+use crate::types::type_expr;
 
 pub fn expr_call() -> impl Parser<TokenKind, Expr, Error = PError> {
     let expr = expr();

--- a/prqlc/prqlc-parser/src/interpolation.rs
+++ b/prqlc/prqlc-parser/src/interpolation.rs
@@ -2,11 +2,10 @@ use chumsky::{error::Cheap, prelude::*};
 use itertools::Itertools;
 use prqlc_ast::expr::*;
 
-use crate::Span;
-
 use super::common::{into_expr, PError};
 use super::lexer::*;
 use super::span::ParserSpan;
+use crate::Span;
 
 /// Parses interpolated strings
 pub fn parse(string: String, span_base: ParserSpan) -> Result<Vec<InterpolateItem>, Vec<PError>> {

--- a/prqlc/prqlc-parser/src/lexer.rs
+++ b/prqlc/prqlc-parser/src/lexer.rs
@@ -3,7 +3,6 @@ use chumsky::{
     prelude::*,
     text::{newline, Character},
 };
-
 use prqlc_ast::expr::*;
 use serde::{Deserialize, Serialize};
 
@@ -594,9 +593,10 @@ pub struct TokenVec(pub Vec<Token>);
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use insta::assert_debug_snapshot;
     use insta::assert_snapshot;
+
+    use super::*;
 
     #[test]
     fn line_wrap() {

--- a/prqlc/prqlc-parser/src/lib.rs
+++ b/prqlc/prqlc-parser/src/lib.rs
@@ -9,12 +9,13 @@ mod types;
 
 use chumsky::error::SimpleReason;
 use chumsky::{prelude::*, Stream};
-use lexer::Token;
-pub use lexer::{TokenKind, TokenVec};
 use prqlc_ast::error::{Error, Reason, WithErrorInfo};
 use prqlc_ast::stmt::*;
 use prqlc_ast::Span;
-use span::ParserSpan;
+
+use self::lexer::Token;
+pub use self::lexer::{TokenKind, TokenVec};
+use self::span::ParserSpan;
 
 /// Build PRQL AST from a PRQL query string.
 pub fn parse_source(source: &str, source_id: u16) -> Result<Vec<Stmt>, Vec<Error>> {

--- a/prqlc/prqlc-parser/src/lib.rs
+++ b/prqlc/prqlc-parser/src/lib.rs
@@ -9,13 +9,11 @@ mod types;
 
 use chumsky::error::SimpleReason;
 use chumsky::{prelude::*, Stream};
-
+use lexer::Token;
+pub use lexer::{TokenKind, TokenVec};
 use prqlc_ast::error::{Error, Reason, WithErrorInfo};
 use prqlc_ast::stmt::*;
 use prqlc_ast::Span;
-
-use lexer::Token;
-pub use lexer::{TokenKind, TokenVec};
 use span::ParserSpan;
 
 /// Build PRQL AST from a PRQL query string.
@@ -70,12 +68,12 @@ pub fn lex_source(source: &str) -> Result<TokenVec, Vec<Error>> {
 
 mod common {
     use chumsky::prelude::*;
+    use prqlc_ast::expr::*;
+    use prqlc_ast::stmt::*;
     use prqlc_ast::Ty;
     use prqlc_ast::TyKind;
 
     use super::{lexer::TokenKind, span::ParserSpan};
-    use prqlc_ast::expr::*;
-    use prqlc_ast::stmt::*;
 
     pub type PError = Simple<TokenKind, ParserSpan>;
 

--- a/prqlc/prqlc-parser/src/stmt.rs
+++ b/prqlc/prqlc-parser/src/stmt.rs
@@ -1,17 +1,15 @@
-use itertools::Itertools;
 use std::collections::HashMap;
 
 use chumsky::prelude::*;
-use semver::VersionReq;
-
+use itertools::Itertools;
 use prqlc_ast::expr::*;
 use prqlc_ast::stmt::*;
-
-use crate::types::type_expr;
+use semver::VersionReq;
 
 use super::common::*;
 use super::expr::*;
 use super::lexer::TokenKind;
+use crate::types::type_expr;
 
 pub fn source() -> impl Parser<TokenKind, Vec<Stmt>, Error = PError> {
     query_def()

--- a/prqlc/prqlc-parser/src/types.rs
+++ b/prqlc/prqlc-parser/src/types.rs
@@ -1,11 +1,9 @@
 use chumsky::prelude::*;
-
 use prqlc_ast::*;
-
-use crate::expr::ident;
 
 use super::common::*;
 use super::lexer::TokenKind;
+use crate::expr::ident;
 
 pub fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> {
     recursive(|nested_type_expr| {

--- a/prqlc/prqlc/examples/compile-files/build.rs
+++ b/prqlc/prqlc/examples/compile-files/build.rs
@@ -1,5 +1,6 @@
-use prqlc::{compile, Options};
 use std::{env, fs, path::Path};
+
+use prqlc::{compile, Options};
 
 fn main() {
     // we expect queries to reside in `queries/` dir

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -311,9 +311,10 @@ Generated with [prqlc](https://prql-lang.org/) {}.
 
 #[cfg(test)]
 mod tests {
+    use std::process::Command;
+
     use insta_cmd::assert_cmd_snapshot;
     use insta_cmd::get_cargo_bin;
-    use std::process::Command;
 
     #[test]
     fn generate_markdown_docs() {

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -19,7 +19,6 @@ use clio::has_extension;
 use clio::Output;
 use is_terminal::IsTerminal;
 use itertools::Itertools;
-
 use prqlc::semantic;
 use prqlc::semantic::reporting::{collect_frames, label_references};
 use prqlc::semantic::NS_DEFAULT_DB;

--- a/prqlc/prqlc/src/codegen/ast.rs
+++ b/prqlc/prqlc/src/codegen/ast.rs
@@ -1,13 +1,11 @@
 use std::collections::HashSet;
 
 use once_cell::sync::Lazy;
-
-use crate::ast::*;
 use regex::Regex;
 
-use crate::codegen::SeparatedExprs;
-
 use super::{WriteOpt, WriteSource};
+use crate::ast::*;
+use crate::codegen::SeparatedExprs;
 
 pub(crate) fn write_expr(expr: &Expr) -> String {
     expr.write(WriteOpt::new_width(u16::MAX)).unwrap()

--- a/prqlc/prqlc/src/codegen/mod.rs
+++ b/prqlc/prqlc/src/codegen/mod.rs
@@ -203,9 +203,10 @@ impl<'a, T: WriteSource> SeparatedExprs<'a, T> {
 
 #[cfg(test)]
 mod test {
+    use insta::assert_snapshot;
+
     use super::*;
     use crate::ast::{Expr, ExprKind, Literal};
-    use insta::assert_snapshot;
 
     #[test]
     fn test_string_quoting() {

--- a/prqlc/prqlc/src/codegen/types.rs
+++ b/prqlc/prqlc/src/codegen/types.rs
@@ -1,7 +1,6 @@
+use super::{WriteOpt, WriteSource};
 use crate::ast::*;
 use crate::codegen::SeparatedExprs;
-
-use super::{WriteOpt, WriteSource};
 
 pub(crate) fn write_ty(ty: &Ty) -> String {
     ty.write(WriteOpt::new_width(u16::MAX)).unwrap()

--- a/prqlc/prqlc/src/error_message.rs
+++ b/prqlc/prqlc/src/error_message.rs
@@ -1,17 +1,15 @@
-use anstream::adapter::strip_str;
-
-use ariadne::{Cache, Config, Label, Report, ReportKind, Source};
-use serde::Serialize;
-
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Range;
 use std::path::PathBuf;
 use std::{collections::HashMap, io::stderr};
 
-use crate::{Error, Errors, MessageKind, SourceTree};
+use anstream::adapter::strip_str;
+use ariadne::{Cache, Config, Label, Report, ReportKind, Source};
+use serde::Serialize;
 
 pub use crate::ir::Span;
+use crate::{Error, Errors, MessageKind, SourceTree};
 
 #[derive(Clone, Serialize)]
 pub struct ErrorMessage {

--- a/prqlc/prqlc/src/ir/constant.rs
+++ b/prqlc/prqlc/src/ir/constant.rs
@@ -1,5 +1,6 @@
-use crate::ast::{Literal, Span};
 use serde::{Deserialize, Serialize};
+
+use crate::ast::{Literal, Span};
 
 /// A subset of PL expressions that are constant.
 #[derive(Serialize, Deserialize)]

--- a/prqlc/prqlc/src/ir/decl.rs
+++ b/prqlc/prqlc/src/ir/decl.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+
 use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fmt::Debug;
 
 use crate::ast::{Span, Ty};
 use crate::codegen::write_ty;

--- a/prqlc/prqlc/src/ir/pl/expr.rs
+++ b/prqlc/prqlc/src/ir/pl/expr.rs
@@ -1,15 +1,12 @@
 use std::collections::HashMap;
 
 use enum_as_inner::EnumAsInner;
-
 use serde::{Deserialize, Serialize};
 
+use super::{Lineage, TransformCall};
 use crate::ast::generic;
 use crate::ast::{GenericTypeParam, Ident, Literal, Span, Ty};
-
 use crate::codegen::write_ty;
-
-use super::{Lineage, TransformCall};
 
 // The following code is tested by the tests_misc crate to match expr.rs in prqlc_ast.
 

--- a/prqlc/prqlc/src/ir/pl/fold.rs
+++ b/prqlc/prqlc/src/ir/pl/fold.rs
@@ -3,10 +3,9 @@
 /// type.
 use itertools::Itertools;
 
+use super::*;
 use crate::ast::{Ty, TyFunc, TyKind, TyTupleField};
 use crate::Result;
-
-use super::*;
 
 // Fold pattern:
 // - https://rust-unofficial.github.io/patterns/patterns/creational/fold.html

--- a/prqlc/prqlc/src/ir/pl/mod.rs
+++ b/prqlc/prqlc/src/ir/pl/mod.rs
@@ -24,12 +24,12 @@ pub use self::utils::*;
 pub use crate::ast::{BinOp, BinaryExpr, Ident, Literal, UnOp, UnaryExpr, ValueAndUnit};
 
 pub fn print_mem_sizes() {
+    use std::mem::size_of;
+
     use crate::ast::{PrimitiveSet, Ty, TyFunc, TyKind, TyTupleField};
     use crate::ir::{decl, generic, pl, rq};
     use crate::sql::internal::SqlTransform;
     use crate::{ErrorMessage, ErrorMessages, SourceTree, Span};
-
-    use std::mem::size_of;
 
     println!("{:16}= {}", "Annotation", size_of::<Annotation>());
     println!("{:16}= {}", "BinaryExpr", size_of::<BinaryExpr>());

--- a/prqlc/prqlc/src/ir/pl/stmt.rs
+++ b/prqlc/prqlc/src/ir/pl/stmt.rs
@@ -2,10 +2,9 @@ use enum_as_inner::EnumAsInner;
 use prqlc_ast::Ident;
 use serde::{Deserialize, Serialize};
 
+use super::expr::Expr;
 pub use crate::ast::stmt::QueryDef;
 use crate::ast::{Span, Ty};
-
-use super::expr::Expr;
 
 // The following code is tested by the tests_misc crate to match stmt.rs in prqlc_ast.
 

--- a/prqlc/prqlc/src/ir/pl/utils.rs
+++ b/prqlc/prqlc/src/ir/pl/utils.rs
@@ -1,6 +1,5 @@
-use crate::ast::expr::Ident;
-
 use super::{Expr, ExprKind, FuncCall};
+use crate::ast::expr::Ident;
 
 pub fn maybe_binop(left: Option<Expr>, op_name: &[&str], right: Option<Expr>) -> Option<Expr> {
     match (left, right) {

--- a/prqlc/prqlc/src/ir/rq/fold.rs
+++ b/prqlc/prqlc/src/ir/rq/fold.rs
@@ -3,10 +3,9 @@
 /// type.
 use itertools::Itertools;
 
+use super::*;
 use crate::ir::generic::{ColumnSort, WindowFrame};
 use crate::Result;
-
-use super::*;
 
 // Fold pattern:
 // - https://rust-unofficial.github.io/patterns/patterns/creational/fold.html

--- a/prqlc/prqlc/src/ir/rq/mod.rs
+++ b/prqlc/prqlc/src/ir/rq/mod.rs
@@ -9,14 +9,14 @@ mod transform;
 mod utils;
 
 use enum_as_inner::EnumAsInner;
-pub use expr::{Expr, ExprKind, UnOp};
-use expr::{InterpolateItem, Range, SwitchCase};
-pub use fold::*;
-pub use ids::*;
 use serde::{Deserialize, Serialize};
-pub use transform::*;
-pub use utils::*;
 
+pub use self::expr::{Expr, ExprKind, UnOp};
+use self::expr::{InterpolateItem, Range, SwitchCase};
+pub use self::fold::*;
+pub use self::ids::*;
+pub use self::transform::*;
+pub use self::utils::*;
 use super::pl::TableExternRef;
 use super::pl::{Literal, QueryDef};
 

--- a/prqlc/prqlc/src/ir/rq/mod.rs
+++ b/prqlc/prqlc/src/ir/rq/mod.rs
@@ -8,15 +8,14 @@ mod ids;
 mod transform;
 mod utils;
 
+use enum_as_inner::EnumAsInner;
 pub use expr::{Expr, ExprKind, UnOp};
+use expr::{InterpolateItem, Range, SwitchCase};
 pub use fold::*;
 pub use ids::*;
+use serde::{Deserialize, Serialize};
 pub use transform::*;
 pub use utils::*;
-
-use enum_as_inner::EnumAsInner;
-use expr::{InterpolateItem, Range, SwitchCase};
-use serde::{Deserialize, Serialize};
 
 use super::pl::TableExternRef;
 use super::pl::{Literal, QueryDef};

--- a/prqlc/prqlc/src/ir/rq/transform.rs
+++ b/prqlc/prqlc/src/ir/rq/transform.rs
@@ -1,11 +1,10 @@
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 
+use super::*;
 use crate::ir::generic::ColumnSort;
 use crate::ir::generic::WindowFrame;
 use crate::ir::pl::JoinSide;
-
-use super::*;
 
 /// Transformation of a table.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, strum::AsRefStr, EnumAsInner)]

--- a/prqlc/prqlc/src/lib.rs
+++ b/prqlc/prqlc/src/lib.rs
@@ -101,22 +101,24 @@ pub mod semantic;
 pub mod sql;
 mod utils;
 
-pub use crate::ast::error::{Error, Errors, MessageKind, Reason, WithErrorInfo};
 use anstream::adapter::strip_str;
 pub use error_message::{ErrorMessage, ErrorMessages, SourceLocation};
 pub use ir::Span;
 pub use prqlc_ast as ast;
+
+pub use crate::ast::error::{Error, Errors, MessageKind, Reason, WithErrorInfo};
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 pub static COMPILER_VERSION: Lazy<Version> =
     Lazy::new(|| Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid prqlc version number"));
 
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
+
 use once_cell::sync::Lazy;
 use prqlc_parser::TokenVec;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
 use strum::VariantNames;
 
 /// Compile a PRQL string into a SQL string.
@@ -448,10 +450,12 @@ impl<S: ToString> From<S> for SourceTree {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use insta::assert_debug_snapshot;
+
     use crate::ast::expr::Ident;
     use crate::Target;
-    use insta::assert_debug_snapshot;
-    use std::str::FromStr;
 
     pub fn compile(prql: &str) -> Result<String, super::ErrorMessages> {
         anstream::ColorChoice::Never.write_global();

--- a/prqlc/prqlc/src/parser.rs
+++ b/prqlc/prqlc/src/parser.rs
@@ -1,6 +1,7 @@
-use itertools::Itertools;
 use std::path::PathBuf;
 use std::{collections::HashMap, path::Path};
+
+use itertools::Itertools;
 
 use crate::ast::{ModuleDef, Stmt, StmtKind};
 use crate::{Error, Errors, Result, SourceTree, WithErrorInfo};

--- a/prqlc/prqlc/src/semantic/eval.rs
+++ b/prqlc/prqlc/src/semantic/eval.rs
@@ -452,9 +452,8 @@ mod test {
 
     use insta::assert_snapshot;
 
-    use crate::semantic::write_pl;
-
     use super::*;
+    use crate::semantic::write_pl;
 
     #[track_caller]
     fn eval(source: &str) -> Result<String> {

--- a/prqlc/prqlc/src/semantic/mod.rs
+++ b/prqlc/prqlc/src/semantic/mod.rs
@@ -7,11 +7,11 @@ mod module;
 pub mod reporting;
 mod resolver;
 
-use self::resolver::Resolver;
-pub use self::resolver::ResolverOptions;
 pub use eval::eval;
 pub use lowering::lower_to_ir;
 
+use self::resolver::Resolver;
+pub use self::resolver::ResolverOptions;
 use crate::ast;
 use crate::ir::constant::ConstExpr;
 use crate::ir::decl::{Module, RootModule};
@@ -160,11 +160,10 @@ pub fn write_pl(expr: pl::Expr) -> String {
 pub mod test {
     use insta::assert_yaml_snapshot;
 
+    use super::{resolve, resolve_and_lower, RootModule};
     use crate::ir::rq::RelationalQuery;
     use crate::parser::parse;
     use crate::Errors;
-
-    use super::{resolve, resolve_and_lower, RootModule};
 
     pub fn parse_resolve_and_lower(query: &str) -> Result<RelationalQuery, Errors> {
         let source_tree = query.into();

--- a/prqlc/prqlc/src/semantic/module.rs
+++ b/prqlc/prqlc/src/semantic/module.rs
@@ -1,17 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::QueryDef;
-use crate::ast::{Literal, Span, Ty, TyKind, TyTupleField};
-use crate::Result;
-
-use crate::ir::pl::{Annotation, Expr, Ident, Lineage, LineageColumn};
-use crate::Error;
-
 use super::{
     NS_DEFAULT_DB, NS_GENERIC, NS_INFER, NS_INFER_MODULE, NS_MAIN, NS_PARAM, NS_QUERY_DEF, NS_SELF,
     NS_STD, NS_THAT, NS_THIS,
 };
+use crate::ast::QueryDef;
+use crate::ast::{Literal, Span, Ty, TyKind, TyTupleField};
 use crate::ir::decl::{Decl, DeclKind, Module, RootModule, TableDecl, TableExpr};
+use crate::ir::pl::{Annotation, Expr, Ident, Lineage, LineageColumn};
+use crate::Error;
+use crate::Result;
 
 impl Module {
     pub fn singleton<S: ToString>(name: S, entry: Decl) -> Module {

--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -1,4 +1,3 @@
-use crate::Result;
 use itertools::Itertools;
 
 use crate::ast::{Ty, TyKind, TyTupleField};
@@ -7,6 +6,7 @@ use crate::ir::pl::*;
 use crate::semantic::resolver::{flatten, types, Resolver};
 use crate::semantic::{NS_INFER, NS_SELF, NS_THAT, NS_THIS};
 use crate::utils::IdGenerator;
+use crate::Result;
 use crate::{Error, Reason, Span, WithErrorInfo};
 
 impl PlFold for Resolver<'_> {

--- a/prqlc/prqlc/src/semantic/resolver/flatten.rs
+++ b/prqlc/prqlc/src/semantic/resolver/flatten.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use crate::Result;
-
 use crate::ir::pl::{
     fold_column_sorts, fold_transform_kind, ColumnSort, Expr, ExprKind, PlFold, TransformCall,
     TransformKind, WindowFrame,
 };
+use crate::Result;
 
 /// Flattens group and window [TransformCall]s into a single pipeline.
 /// Sets partition, window and sort of [TransformCall].

--- a/prqlc/prqlc/src/semantic/resolver/functions.rs
+++ b/prqlc/prqlc/src/semantic/resolver/functions.rs
@@ -1,17 +1,16 @@
 use std::collections::HashMap;
 use std::iter::zip;
 
-use crate::Result;
 use itertools::{Itertools, Position};
 
+use super::Resolver;
 use crate::ast::{Ty, TyFunc, TyKind};
 use crate::ir::decl::{Decl, DeclKind, Module};
 use crate::ir::pl::*;
 use crate::semantic::resolver::types;
 use crate::semantic::{NS_GENERIC, NS_PARAM, NS_THAT, NS_THIS};
+use crate::Result;
 use crate::{Error, Span, WithErrorInfo};
-
-use super::Resolver;
 
 impl Resolver<'_> {
     pub fn fold_function(

--- a/prqlc/prqlc/src/semantic/resolver/inference.rs
+++ b/prqlc/prqlc/src/semantic/resolver/inference.rs
@@ -1,12 +1,11 @@
-use crate::Result;
 use itertools::Itertools;
 
+use super::Resolver;
 use crate::ast::{Ident, Ty, TyTupleField};
 use crate::ir::decl::{Decl, TableDecl, TableExpr};
 use crate::ir::pl::{Lineage, LineageColumn, LineageInput};
 use crate::semantic::{NS_DEFAULT_DB, NS_INFER};
-
-use super::Resolver;
+use crate::Result;
 
 impl Resolver<'_> {
     pub fn infer_table_column(

--- a/prqlc/prqlc/src/semantic/resolver/mod.rs
+++ b/prqlc/prqlc/src/semantic/resolver/mod.rs
@@ -50,10 +50,10 @@ impl Resolver<'_> {
 
 #[cfg(test)]
 pub(super) mod test {
-    use crate::{Errors, Result};
     use insta::assert_yaml_snapshot;
 
     use crate::ir::pl::{Expr, Lineage, PlFold};
+    use crate::{Errors, Result};
 
     pub fn erase_ids(expr: Expr) -> Expr {
         IdEraser {}.fold_expr(expr).unwrap()

--- a/prqlc/prqlc/src/semantic/resolver/names.rs
+++ b/prqlc/prqlc/src/semantic/resolver/names.rs
@@ -2,17 +2,14 @@ use std::collections::HashSet;
 
 use itertools::Itertools;
 
-use crate::Result;
-
+use super::Resolver;
 use crate::ast::Ident;
-
 use crate::ir::decl::{Decl, DeclKind, Module};
 use crate::ir::pl::{Expr, ExprKind};
 use crate::semantic::{NS_INFER, NS_INFER_MODULE, NS_SELF, NS_THAT, NS_THIS};
 use crate::Error;
+use crate::Result;
 use crate::WithErrorInfo;
-
-use super::Resolver;
 
 impl Resolver<'_> {
     pub(super) fn resolve_ident(&mut self, ident: &Ident) -> Result<Ident, Error> {

--- a/prqlc/prqlc/src/semantic/resolver/stmt.rs
+++ b/prqlc/prqlc/src/semantic/resolver/stmt.rs
@@ -1,9 +1,9 @@
-use crate::Result;
 use std::collections::HashMap;
 
 use crate::ast::{Ty, TyKind, TyTupleField};
 use crate::ir::decl::{Decl, DeclKind, Module, TableDecl, TableExpr};
 use crate::ir::pl::*;
+use crate::Result;
 use crate::WithErrorInfo;
 
 impl super::Resolver<'_> {

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -1,21 +1,19 @@
 use std::collections::HashMap;
+use std::iter::zip;
 
 use itertools::Itertools;
 use serde::Deserialize;
-use std::iter::zip;
 
+use super::types::{ty_tuple_kind, type_intersection};
+use super::Resolver;
+use crate::ast::{Ty, TyKind, TyTupleField};
 use crate::ir::decl::{Decl, DeclKind, Module};
 use crate::ir::generic::{SortDirection, WindowKind};
 use crate::ir::pl::*;
-
-use crate::ast::{Ty, TyKind, TyTupleField};
 use crate::semantic::ast_expand::{restrict_null_literal, try_restrict_range};
 use crate::semantic::resolver::functions::expr_of_func;
 use crate::semantic::{write_pl, NS_PARAM, NS_THIS};
 use crate::{Error, Reason, Result, WithErrorInfo, COMPILER_VERSION};
-
-use super::types::{ty_tuple_kind, type_intersection};
-use super::Resolver;
 
 impl Resolver<'_> {
     /// try to convert function call with enough args into transform
@@ -981,9 +979,8 @@ fn unpack<const P: usize>(func_args: Vec<Expr>) -> [Expr; P] {
 }
 
 mod from_text {
-    use crate::ir::rq::RelationLiteral;
-
     use super::*;
+    use crate::ir::rq::RelationLiteral;
 
     // TODO: Can we dynamically get the types, like in pandas? We need to put
     // quotes around strings and not around numbers.

--- a/prqlc/prqlc/src/semantic/resolver/types.rs
+++ b/prqlc/prqlc/src/semantic/resolver/types.rs
@@ -1,17 +1,15 @@
 use std::collections::HashMap;
 use std::iter::zip;
 
-use crate::ast::{PrimitiveSet, Ty, TyFunc, TyKind, TyTupleField};
-use crate::Result;
 use itertools::Itertools;
 
+use super::Resolver;
+use crate::ast::{PrimitiveSet, Ty, TyFunc, TyKind, TyTupleField};
 use crate::codegen::{write_ty, write_ty_kind};
 use crate::ir::decl::DeclKind;
 use crate::ir::pl::*;
-
+use crate::Result;
 use crate::{Error, Reason, WithErrorInfo};
-
-use super::Resolver;
 
 impl Resolver<'_> {
     pub fn infer_type(expr: &Expr) -> Result<Option<Ty>> {

--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -11,10 +11,11 @@
 //!
 //! As a consequence, generated SQL may be verbose, since it will avoid newer or less adopted SQL
 //! constructs. The upside is much less complex translator.
-use chrono::format::{Fixed, Item, Numeric, Pad, StrftimeItems};
 use core::fmt::Debug;
-use serde::{Deserialize, Serialize};
 use std::any::{Any, TypeId};
+
+use chrono::format::{Fixed, Item, Numeric, Pad, StrftimeItems};
+use serde::{Deserialize, Serialize};
 use strum::VariantNames;
 
 use crate::{Error, Result};
@@ -515,9 +516,11 @@ impl DialectHandler for DuckDbDialect {
 
 #[cfg(test)]
 mod tests {
-    use super::Dialect;
-    use insta::assert_debug_snapshot;
     use std::str::FromStr;
+
+    use insta::assert_debug_snapshot;
+
+    use super::Dialect;
 
     #[test]
     fn test_dialect_from_str() {

--- a/prqlc/prqlc/src/sql/gen_expr.rs
+++ b/prqlc/prqlc/src/sql/gen_expr.rs
@@ -1,5 +1,7 @@
 //! Contains functions that compile [crate::ast::pl] nodes into [sqlparser] nodes.
 
+use std::cmp::Ordering;
+
 use itertools::Itertools;
 use regex::Regex;
 use sqlparser::ast::{
@@ -7,8 +9,9 @@ use sqlparser::ast::{
     FunctionArgumentList, ObjectName, OrderByExpr, SelectItem, UnaryOperator, Value,
     WindowFrameBound, WindowSpec,
 };
-use std::cmp::Ordering;
 
+use super::gen_projection::try_into_exprs;
+use super::{keywords, Context};
 use crate::ast::expr::generic::{InterpolateItem, Range};
 use crate::ir::generic::{ColumnSort, SortDirection, WindowFrame, WindowKind};
 use crate::ir::pl::{self, Ident, Literal};
@@ -16,9 +19,6 @@ use crate::ir::rq::*;
 use crate::sql::srq::context::ColumnDecl;
 use crate::utils::{OrMap, VALID_IDENT};
 use crate::{Error, Reason, Result, Span, WithErrorInfo};
-
-use super::gen_projection::try_into_exprs;
-use super::{keywords, Context};
 
 pub(super) fn translate_expr(expr: Expr, ctx: &mut Context) -> Result<ExprOrSource> {
     Ok(match expr.kind {
@@ -1022,9 +1022,9 @@ impl From<sql_ast::Expr> for ExprOrSource {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     use insta::assert_yaml_snapshot;
+
+    use super::*;
 
     #[test]
     fn test_range_of_ranges() -> Result<()> {

--- a/prqlc/prqlc/src/sql/gen_projection.rs
+++ b/prqlc/prqlc/src/sql/gen_projection.rs
@@ -1,20 +1,19 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::Result;
 use itertools::Itertools;
 use sqlparser::ast::{
     self as sql_ast, ExceptSelectItem, ExcludeSelectItem, ObjectName, SelectItem,
     WildcardAdditionalOptions,
 };
 
-use crate::ir::pl::Ident;
-use crate::ir::rq::{CId, RelationColumn};
-use crate::{Error, Span, WithErrorInfo};
-
 use super::dialect::ColumnExclude;
 use super::gen_expr::*;
 use super::srq::context::{AnchorContext, ColumnDecl};
 use super::Context;
+use crate::ir::pl::Ident;
+use crate::ir::rq::{CId, RelationColumn};
+use crate::Result;
+use crate::{Error, Span, WithErrorInfo};
 
 pub(super) fn try_into_exprs(
     cids: Vec<CId>,

--- a/prqlc/prqlc/src/sql/gen_query.rs
+++ b/prqlc/prqlc/src/sql/gen_query.rs
@@ -9,18 +9,16 @@ use sqlparser::ast::{
     TableFactor, TableWithJoins,
 };
 
+use super::gen_expr::*;
+use super::gen_projection::*;
+use super::operators::translate_operator;
+use super::srq::ast::{Cte, CteKind, RelationExpr, RelationExprKind, SqlRelation, SqlTransform};
+use super::{Context, Dialect};
 use crate::ast::generic::InterpolateItem;
 use crate::ir::pl::{JoinSide, Literal};
 use crate::ir::rq::{CId, Expr, ExprKind, RelationLiteral, RelationalQuery};
 use crate::utils::{BreakUp, Pluck};
 use crate::{Error, Result, WithErrorInfo};
-
-use super::gen_expr::*;
-use super::gen_projection::*;
-use super::srq::ast::{Cte, CteKind, RelationExpr, RelationExprKind, SqlRelation, SqlTransform};
-
-use super::operators::translate_operator;
-use super::{Context, Dialect};
 
 type Transform = SqlTransform<RelationExpr, ()>;
 

--- a/prqlc/prqlc/src/sql/mod.rs
+++ b/prqlc/prqlc/src/sql/mod.rs
@@ -10,13 +10,11 @@ mod srq;
 
 pub use dialect::{Dialect, SupportLevel};
 
-use crate::Result;
-
-use crate::{ir::rq::RelationalQuery, Options, COMPILER_VERSION};
-
 use self::dialect::DialectHandler;
 use self::srq::ast::Cte;
 use self::srq::context::AnchorContext;
+use crate::Result;
+use crate::{ir::rq::RelationalQuery, Options, COMPILER_VERSION};
 
 /// Translate a PRQL AST into a SQL string.
 pub fn compile(query: RelationalQuery, options: &Options) -> Result<String> {
@@ -59,11 +57,10 @@ pub fn compile(query: RelationalQuery, options: &Options) -> Result<String> {
 
 /// This module gives access to internal machinery that gives no stability guarantees.
 pub mod internal {
+    pub use super::srq::ast::SqlTransform;
     use super::*;
     use crate::ir::rq::Transform;
     use crate::Error;
-
-    pub use super::srq::ast::SqlTransform;
 
     fn init(query: RelationalQuery) -> Result<(Vec<Transform>, Context)> {
         let (ctx, relation) = AnchorContext::of(query);

--- a/prqlc/prqlc/src/sql/operators.rs
+++ b/prqlc/prqlc/src/sql/operators.rs
@@ -2,16 +2,15 @@ use std::collections::HashMap;
 use std::iter::zip;
 use std::path::PathBuf;
 
-use crate::Result;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 
 use super::gen_expr::{translate_operand, ExprOrSource, SourceExpr};
 use super::{Context, Dialect};
-
 use crate::ir::{decl, pl, rq};
 use crate::semantic;
 use crate::utils::Pluck;
+use crate::Result;
 use crate::{Error, WithErrorInfo};
 
 static STD: Lazy<decl::Module> = Lazy::new(load_std_sql);

--- a/prqlc/prqlc/src/sql/srq/anchor.rs
+++ b/prqlc/prqlc/src/sql/srq/anchor.rs
@@ -1,16 +1,16 @@
-use crate::Result;
-use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 
+use itertools::Itertools;
+
+use super::ast::{SqlTransform, SrqMapper};
+use super::context::{AnchorContext, ColumnDecl, RIId, RelationStatus, SqlTableDecl};
 use crate::ir::generic::ColumnSort;
 use crate::ir::rq::{
     self, fold_column_sorts, fold_transform, CId, Compute, Expr, RelationColumn, RqFold, TableRef,
     Transform,
 };
 use crate::sql::srq::context::RelationAdapter;
-
-use super::ast::{SqlTransform, SrqMapper};
-use super::context::{AnchorContext, ColumnDecl, RIId, RelationStatus, SqlTableDecl};
+use crate::Result;
 
 /// Extract last part of pipeline that is able to "fit" into a single SELECT statement.
 /// Remaining proceeding pipeline is declared as a table and stored in AnchorContext.

--- a/prqlc/prqlc/src/sql/srq/ast.rs
+++ b/prqlc/prqlc/src/sql/srq/ast.rs
@@ -3,17 +3,16 @@
 //! This IR dictates the structure of the resulting SQL query. This includes number of CTEs,
 //! position of sub-queries and set operations.
 
-use crate::Result;
 use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 use serde::Serialize;
 
+use super::context::RIId;
 use crate::ast::generic::InterpolateItem;
 use crate::ir::generic::ColumnSort;
 use crate::ir::pl::JoinSide;
 use crate::ir::rq::{self, fold_column_sorts, RelationLiteral, RqFold};
-
-use super::context::RIId;
+use crate::Result;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SqlQuery {

--- a/prqlc/prqlc/src/sql/srq/context.rs
+++ b/prqlc/prqlc/src/sql/srq/context.rs
@@ -4,19 +4,17 @@
 use std::collections::HashMap;
 use std::iter::zip;
 
-use crate::{ir::pl::TableExternRef::LocalTable, Result};
 use enum_as_inner::EnumAsInner;
 use serde::Serialize;
 
+use super::ast::{SqlRelation, SqlTransform};
 use crate::ir::pl::Ident;
 use crate::ir::rq::{
     fold_table, CId, Compute, Relation, RelationColumn, RelationKind, RelationalQuery, RqFold, TId,
     TableDecl, TableRef, Transform,
 };
-
 use crate::utils::{IdGenerator, NameGenerator};
-
-use super::ast::{SqlRelation, SqlTransform};
+use crate::{ir::pl::TableExternRef::LocalTable, Result};
 
 /// The AnchorContext struct stores information about tables and columns, and
 /// is used to generate new IDs and names.

--- a/prqlc/prqlc/src/sql/srq/gen_query.rs
+++ b/prqlc/prqlc/src/sql/srq/gen_query.rs
@@ -2,22 +2,20 @@
 
 use std::str::FromStr;
 
-use crate::Result;
 use itertools::Itertools;
 
-use crate::ir::rq::{RelationKind, RelationalQuery, RqFold, Transform};
-use crate::utils::BreakUp;
-use crate::Target;
-
+use super::super::{Context, Dialect};
 use super::anchor::{self, anchor_split};
 use super::ast::{
     fold_sql_transform, Cte, CteKind, RelationExpr, RelationExprKind, SqlQuery, SqlRelation,
     SqlTransform, SrqMapper,
 };
 use super::context::{AnchorContext, RIId, RelationAdapter, RelationStatus};
-
-use super::super::{Context, Dialect};
 use super::{postprocess, preprocess};
+use crate::ir::rq::{RelationKind, RelationalQuery, RqFold, Transform};
+use crate::utils::BreakUp;
+use crate::Result;
+use crate::Target;
 
 pub(in super::super) fn compile_query(
     query: RelationalQuery,

--- a/prqlc/prqlc/src/sql/srq/mod.rs
+++ b/prqlc/prqlc/src/sql/srq/mod.rs
@@ -19,12 +19,10 @@ pub(super) use gen_query::compile_query;
 
 #[cfg(test)]
 mod test {
-    use crate::{Errors, Result};
-
     use super::ast::SqlQuery;
     use super::*;
-
     use crate::sql::Dialect;
+    use crate::{Errors, Result};
 
     fn parse_and_resolve(source: &str) -> Result<SqlQuery, Errors> {
         let query = crate::semantic::test::parse_resolve_and_lower(source)?;

--- a/prqlc/prqlc/src/sql/srq/postprocess.rs
+++ b/prqlc/prqlc/src/sql/srq/postprocess.rs
@@ -4,16 +4,15 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::Result;
 use itertools::Itertools;
 
+use super::anchor::CidRedirector;
+use super::ast::*;
 use crate::ir::generic::ColumnSort;
 use crate::ir::pl::Ident;
 use crate::ir::rq::{CId, RqFold, TId};
 use crate::sql::Context;
-
-use super::anchor::CidRedirector;
-use super::ast::*;
+use crate::Result;
 
 type Sorting = Vec<ColumnSort<CId>>;
 

--- a/prqlc/prqlc/src/sql/srq/preprocess.rs
+++ b/prqlc/prqlc/src/sql/srq/preprocess.rs
@@ -1,8 +1,12 @@
-use itertools::Itertools;
 use std::cmp::Ordering;
 use std::collections::hash_map::RandomState;
 use std::collections::HashSet;
 
+use itertools::Itertools;
+
+use super::anchor::{infer_complexity, CidCollector, Complexity};
+use super::ast::*;
+use super::context::RIId;
 use crate::ast::generic::{InterpolateItem, Range};
 use crate::ir::generic::{ColumnSort, SortDirection, WindowFrame, WindowKind};
 use crate::ir::pl::{JoinSide, Literal};
@@ -12,10 +16,6 @@ use crate::ir::rq::{
 use crate::sql::srq::context::ColumnDecl;
 use crate::sql::Context;
 use crate::{Error, Result, WithErrorInfo};
-
-use super::anchor::{infer_complexity, CidCollector, Complexity};
-use super::ast::*;
-use super::context::RIId;
 
 /// Converts RQ AST into SqlRQ AST and applies a few preprocessing operations.
 ///

--- a/prqlc/prqlc/src/utils/mod.rs
+++ b/prqlc/prqlc/src/utils/mod.rs
@@ -2,12 +2,12 @@ mod id_gen;
 mod toposort;
 
 pub use id_gen::{IdGenerator, NameGenerator};
+use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
 pub use toposort::toposort;
 
 use crate::Result;
-use itertools::Itertools;
 
 pub trait OrMap<T> {
     /// Merges two options into one using `f`.

--- a/prqlc/prqlc/tests/integration/bad_error_messages.rs
+++ b/prqlc/prqlc/tests/integration/bad_error_messages.rs
@@ -15,8 +15,9 @@
 //! be a huge number of issues, and it would be difficult to see what's current.
 //! So instead, add the error message as a test here.
 
-use super::sql::compile;
 use insta::assert_snapshot;
+
+use super::sql::compile;
 
 #[test]
 fn test_bad_error_messages() {

--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -1,10 +1,11 @@
 #![cfg(all(not(target_family = "wasm"), feature = "cli"))]
 
-use insta_cmd::assert_cmd_snapshot;
-use insta_cmd::get_cargo_bin;
 use std::env::current_dir;
 use std::path::PathBuf;
 use std::process::Command;
+
+use insta_cmd::assert_cmd_snapshot;
+use insta_cmd::get_cargo_bin;
 
 #[cfg(not(windows))] // Windows has slightly different output (e.g. `prqlc.exe`), so we exclude.
 #[test]

--- a/prqlc/prqlc/tests/integration/dbs/mod.rs
+++ b/prqlc/prqlc/tests/integration/dbs/mod.rs
@@ -9,10 +9,9 @@ use prqlc::{sql::Dialect, sql::SupportLevel, Options, Target};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+pub use self::protocol::DbProtocol;
 use self::protocol::DbProtocolHandler;
 use self::runner::DbTestRunner;
-
-pub use self::protocol::DbProtocol;
 pub type Row = Vec<String>;
 
 pub struct DbConnection {

--- a/prqlc/prqlc/tests/integration/dbs/runner.rs
+++ b/prqlc/prqlc/tests/integration/dbs/runner.rs
@@ -1,6 +1,7 @@
+use std::fs;
+
 use itertools::Itertools;
 use regex::Regex;
-use std::fs;
 
 use super::protocol::DbProtocolHandler;
 

--- a/prqlc/prqlc/tests/integration/error_messages.rs
+++ b/prqlc/prqlc/tests/integration/error_messages.rs
@@ -2,8 +2,9 @@
 //! It's also fine to put errors by the things that they're testing.
 //! See also [test_bad_error_messages.rs](test_bad_error_messages.rs) for error
 //! messages which need to be improved.
-use super::sql::compile;
 use insta::assert_snapshot;
+
+use super::sql::compile;
 
 #[test]
 fn test_errors() {

--- a/prqlc/prqlc/tests/integration/queries.rs
+++ b/prqlc/prqlc/tests/integration/queries.rs
@@ -4,7 +4,6 @@ use std::{env, fs};
 
 use insta::assert_debug_snapshot;
 use insta::{assert_snapshot, with_settings};
-
 use prqlc::sql::Dialect;
 use prqlc::{Options, Target};
 use test_each_file::test_each_path;
@@ -71,13 +70,12 @@ mod fmt {
 
 #[cfg(any(feature = "test-dbs", feature = "test-dbs-external"))]
 mod results {
-    use super::*;
-
     use std::{ops::DerefMut, sync::Mutex};
 
     use once_cell::sync::Lazy;
     use prqlc::sql::SupportLevel;
 
+    use super::*;
     use crate::dbs::{ConnectionCfg, DbConnection, DbProtocol};
 
     static CONNECTIONS: Lazy<Mutex<Vec<DbConnection>>> = Lazy::new(init_connections);

--- a/web/book/src/lib.rs
+++ b/web/book/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
 
+use std::str::FromStr;
+
 use anyhow::{bail, Result};
 use itertools::Itertools;
 use mdbook::preprocess::Preprocessor;
@@ -8,9 +10,6 @@ use mdbook::{book::Book, BookItem};
 use prqlc::compile;
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
 use pulldown_cmark_to_cmark::cmark_with_options;
-
-use std::str::FromStr;
-
 use strum::EnumString;
 
 pub struct ComparisonPreprocessor;

--- a/web/book/tests/documentation/book.rs
+++ b/web/book/tests/documentation/book.rs
@@ -1,4 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
+use std::fs;
+use std::path::Path;
+
 use anyhow::{anyhow, bail, Result};
 use globset::Glob;
 use insta::assert_snapshot;
@@ -6,8 +9,6 @@ use itertools::Itertools;
 use mdbook_prql::{code_block_lang_tags, LangTag};
 use prqlc::{pl_to_prql, pl_to_rq, prql_to_pl};
 use pulldown_cmark::Tag;
-use std::fs;
-use std::path::Path;
 use walkdir::WalkDir;
 
 use super::compile;

--- a/web/book/tests/documentation/website.rs
+++ b/web/book/tests/documentation/website.rs
@@ -1,8 +1,8 @@
-use similar_asserts::assert_eq;
 use std::fs::read_dir;
 
 use regex::Regex;
 use serde_yaml::Value;
+use similar_asserts::assert_eq;
 
 use super::compile;
 


### PR DESCRIPTION
Currently our imports are kinda all over. This uses an unstable feature to sort them into groups. While it's not possible to run this on every commit, hopefully having them in groups makes it easier to maintain.

To re-run:

```sh
echo 'group_imports = "StdExternalCrate"' > rustfmt.toml
cargo +nightly fmt
```

...and when the feature is made stable, then we can enable it...
