### PR TITLE
revert: bump oxsecurity/megalinter from 7.11.1 to 7.12.0

### DIFF
--- a/.github/workflows/lint-megalinter.yaml
+++ b/.github/workflows/lint-megalinter.yaml
@@ -55,7 +55,7 @@ jobs:
 
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter@v7.12.0
+        uses: oxsecurity/megalinter@v7.11.1
 
         id: ml
 


### PR DESCRIPTION
Reverts PRQL/prql#4529 — the default megalinter config runs checks only for changed code, which then creates a failure when the megalinter version changes.