### PR TITLE
ci: Only publish codecov patch on PRs

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -8,3 +8,7 @@ coverage:
     project:
       default:
         removed_code_behavior: adjust_base
+
+    patch:
+      default:
+        only_pulls: true


### PR DESCRIPTION
Otherwise we get failures on main after moving code around, which doesn't make sense
