### PR TITLE
ci: Fix python upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -321,7 +321,7 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
-          args: --skip-existing *
+          args: --skip-existing **/*{.whl,.tar.gz}
 
   publish-prql-js:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It was trying to upload directories: https://github.com/PRQL/prql/actions/runs/9432185880/job/25981724946#step:3:54

This limits it to the wheel and source extensions
