### PR TITLE
build: Set version on Snap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,6 +248,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Move Snap to project root directory
         run: cp -r prqlc/packages/snap/ .
+      - name: Applying prqlc version to snapcraft.yaml
+        if: github.event_name == 'release'
+        run: |
+          sed -i "s/version: git/version: '${{ github.ref_name }}'/" snap/snapcraft.yaml
       - name: 📦 Build Snap
         id: build
         uses: snapcore/action-build@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,10 +248,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Move Snap to project root directory
         run: cp -r prqlc/packages/snap/ .
-      - name: Applying prqlc version to snapcraft.yaml
-        if: github.event_name == 'release'
-        run: |
-          sed -i "s/version: git/version: '${{ github.ref_name }}'/" snap/snapcraft.yaml
       - name: 📦 Build Snap
         id: build
         uses: snapcore/action-build@v1

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: git
+version: '0.12.2'
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: '0.12.2'
+version: "0.12.2"
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -126,8 +126,8 @@ name = "bench"
 [[package.metadata.release.pre-release-replacements]]
 exactly = 1
 file = "../packages/snap/snapcraft.yaml"
-search = "^version: '[\\d.]+'$"
-replace = "version: '{{version}}'"
+search = '^version: "[\d.]+"$'
+replace = 'version: "{{version}}"'
 
 [[package.metadata.release.pre-release-replacements]]
 exactly = 1

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -126,7 +126,7 @@ name = "bench"
 [[package.metadata.release.pre-release-replacements]]
 exactly = 1
 file = "../packages/snap/snapcraft.yaml"
-search = "^version: (git|'[\\w.\\-]+')$"
+search = "^version: '[\\d.]+'$"
 replace = "version: '{{version}}'"
 
 [[package.metadata.release.pre-release-replacements]]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -125,6 +125,12 @@ name = "bench"
 
 [[package.metadata.release.pre-release-replacements]]
 exactly = 1
+file = "../packages/snap/snapcraft.yaml"
+search = "^version: (git|'[\\w.\\-]+')$"
+replace = "version: '{{version}}'"
+
+[[package.metadata.release.pre-release-replacements]]
+exactly = 1
 file = "../../web/book/src/project/target.md"
 replace = 'prql version:"{{version}}"'
 search = 'prql version:"[\d.]+"'


### PR DESCRIPTION
This replaces the `version` field in the `snapcraft.yaml` manifest file with the `github.ref_name` variable from the GitHub Action context.

This uses the name of the tagged release instead of the Git commit hash as version.