### PR TITLE
ci: Update to Node20 actions

### DIFF
--- a/.github/actions/build-prqlc-c/action.yaml
+++ b/.github/actions/build-prqlc-c/action.yaml
@@ -57,7 +57,7 @@ runs:
         echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
 
     - name: cargo build
-      uses: richb-hanover/cargo@v1.1.0
+      uses: clechasseur/rs-cargo@v2
       with:
         command: build
         args:

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -56,7 +56,7 @@ runs:
         echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
 
     - name: cargo build
-      uses: richb-hanover/cargo@v1.1.0
+      uses: clechasseur/rs-cargo@v2
       with:
         command: build
         # We previously had `--package=prqlc` for all, but this caches much

--- a/.github/actions/time-compilation/action.yaml
+++ b/.github/actions/time-compilation/action.yaml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: rm -rf target/cargo-timings
     - name: 🏭 Compile
-      uses: richb-hanover/cargo@v1.1.0
+      uses: clechasseur/rs-cargo@v2
       with:
         command: build
         args: --timings --all-targets

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: richb-hanover/cargo@1.1.1
+      - uses: clechasseur/rs-cargo@v2
         with:
           command: bench
           args: --timings --all-targets
@@ -100,11 +100,11 @@ jobs:
           crate: cargo-udeps
       # Once with all targets, once without, to find anything that should be in
       # `dev` but is more general.
-      - uses: richb-hanover/cargo@1.1.1
+      - uses: clechasseur/rs-cargo@v2
         with:
           command: udeps
           args: --all-targets
-      - uses: richb-hanover/cargo@1.1.1
+      - uses: clechasseur/rs-cargo@v2
         with:
           command: udeps
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v1
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Only used in tests. Waiting for tiberius to publish a new release.

--- a/.github/workflows/test-prqlc-c.yaml
+++ b/.github/workflows/test-prqlc-c.yaml
@@ -18,7 +18,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           shared-key: lib
       - name: Build
-        uses: richb-hanover/cargo@1.1.1
+        uses: clechasseur/rs-cargo@v2
         with:
           command: build
           # Currently requires a release build; would be useful to allow a debug build.

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -86,7 +86,7 @@ jobs:
       # We split up the test compilation as recommended in
       # https://matklad.github.io/2021/09/04/fast-rust-builds.html
       - name: 🏭 Compile
-        uses: richb-hanover/cargo@1.1.1
+        uses: clechasseur/rs-cargo@v2
         with:
           command: test
           args: >
@@ -99,7 +99,7 @@ jobs:
           timeout: 60000
         if: ${{ contains(inputs.features, 'test-dbs-external') }}
       - name: 📋 Test
-        uses: richb-hanover/cargo@1.1.1
+        uses: clechasseur/rs-cargo@v2
         with:
           command: insta
           # Here, we also add:
@@ -111,7 +111,7 @@ jobs:
             'test-dbs') && inputs.target == 'x86_64-unknown-linux-gnu' &&
             '--unreferenced=auto' || '' }}
       - name: 📎 Clippy
-        uses: richb-hanover/cargo@1.1.1
+        uses: clechasseur/rs-cargo@v2
         with:
           command: clippy
           # Note that `--all-targets` doesn't refer to targets like
@@ -121,7 +121,7 @@ jobs:
             --all-targets --target=${{ inputs.target }} --no-default-features
             --features=${{ inputs.features }} -- -D warnings
       - name: ⌨️ Fmt
-        uses: richb-hanover/cargo@1.1.1
+        uses: clechasseur/rs-cargo@v2
         with:
           command: fmt
           args: --all --check
@@ -130,7 +130,7 @@ jobs:
         # https://github.com/duckdb/duckdb-rs/issues/179#issuecomment-1710986020.
         if:
           inputs.nightly == 'true' && inputs.target != 'wasm32-unknown-unknown'
-        uses: richb-hanover/cargo@1.1.1
+        uses: clechasseur/rs-cargo@v2
         with:
           command: doc
           # Only run with deps on nightly, since it's much slower, and so far™
@@ -145,7 +145,7 @@ jobs:
         if:
           ${{ github.ref == 'refs/heads/main' && steps.cache.outputs.cache-hit
           == 'false' }}
-        uses: richb-hanover/cargo@1.1.1
+        uses: clechasseur/rs-cargo@v2
         with:
           command: build
           args:


### PR DESCRIPTION
Rather than use my `richb-hanover/cargo` (which will forever lag the proper versions), switch to `clechasseur/rs-cargo` which seems to be in active maintenance. This clears up the lion's share of "Node 16 is deprecated..." warnings during builds.

@clechasseur was also kind enough to update `rustsec/audit-check@v1` to use Node 20 (it's `v1.4.1` now). However, it appears that the upstream hasn't published that new action. There's an [Issue in the repo](https://github.com/rustsec/audit-check/issues/22) requesting this.

Once that's complete, it looks as if all the warnings during nightly builds will have been eliminated.