### PR TITLE
devops: Standardize `Taskfile` extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        // Keep in sync with Taskfile.yml
+        // Keep in sync with Taskfile.yaml
         "prql-lang.prql-vscode",
         "rust-lang.rust-analyzer",
         "mitsuhiko.insta",

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Prep args
         run: |
-          echo "cargo_crates=$(yq -r '.vars.cargo_crates' Taskfile.yml)" >>"$GITHUB_ENV"
+          echo "cargo_crates=$(yq -r '.vars.cargo_crates' Taskfile.yaml)" >>"$GITHUB_ENV"
 
       - name: Build
         uses: docker/build-push-action@v5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,11 +76,11 @@ jobs:
               - .github/workflows/test-dotnet.yaml
             devcontainer-push:
               - .devcontainer/**/*Dockerfile
-              - Taskfile.yml
+              - Taskfile.yaml
             devcontainer-build:
               - .devcontainer/**/*Dockerfile
               - .github/workflows/build-devcontainer.yaml
-              - Taskfile.yml
+              - Taskfile.yaml
             grammars:
               - grammars/**
             elixir:
@@ -119,7 +119,7 @@ jobs:
               - web/book/**
               - .github/workflows/test-rust.yaml
             taskfile:
-              - Taskfile.yml
+              - Taskfile.yaml
             web:
               - "web/**"
               - ".github/workflows/build-web.yaml"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    // Keep in sync with Taskfile.yml
+    // Keep in sync with Taskfile.yaml
     "prql-lang.prql-vscode",
     "rust-lang.rust-analyzer",
     "mitsuhiko.insta",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1175,8 +1175,8 @@ below in this release).
 
 **Documentation**:
 
-[This release, the changelog only contains a subset of documentation
-improvements]
+[This release, the changelog only contains a subset of
+documentation improvements]
 
 - Add docs on aliases in
   [Select](https://prql-lang.org/book/reference/stdlib/transforms/select.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,7 +318,7 @@ This release has 155 commits from 9 contributors. Selected changes:
 
 - Rename some of the internal crates, and refactored their paths in the repo.
   (@aljazerzen, #3683).
-- Add a `justfile` for developers who prefer that above our `Taskfile.yml`
+- Add a `justfile` for developers who prefer that above our `Taskfile.yaml`
   (@aljazerzen, #3681)
 
 **New Contributors**:
@@ -1175,8 +1175,8 @@ below in this release).
 
 **Documentation**:
 
-[This release, the changelog only contains a subset of
-documentation improvements]
+[This release, the changelog only contains a subset of documentation
+improvements]
 
 - Add docs on aliases in
   [Select](https://prql-lang.org/book/reference/stdlib/transforms/select.html)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -384,8 +384,8 @@ tasks:
 # The next two tasks are not used for either:
 #  - the Dockerfile (installing brew takes forever)
 #    so the Dockerfile simply installs hugo & nodejs directly
-#  - the "desktop setup" - it uses other tasks in the Taskfile.yml
-# They remain in the Taskfile.yml as a hint if they should ever be needed
+#  - the "desktop setup" - it uses other tasks in the Taskfile.yaml
+# They remain in the Taskfile.yaml as a hint if they should ever be needed
 
 # install-hugo:
 #   cmds:

--- a/lutra/Taskfile.yaml
+++ b/lutra/Taskfile.yaml
@@ -14,7 +14,9 @@ tasks:
       - cmd: cargo run --package lutra -- execute example-project
 
   fmt:
-    desc: Format prqlc source files
+    desc:
+      Format prqlc source files (Duplicates `pre-commit` checks, but some
+      developers prefer to use this directly.)
     cmds:
       - cmd: |
           # remove trailing whitespace

--- a/lutra/bindings/python/Taskfile.yaml
+++ b/lutra/bindings/python/Taskfile.yaml
@@ -5,6 +5,8 @@ vars:
   venv_dir: "../../../target/venv"
 
 tasks:
+  # (Duplicates `pre-commit` checks, but some developers prefer to use this
+  # directly.)
   fmt:
     desc: "Format"
     cmds:

--- a/prqlc/Taskfile.yaml
+++ b/prqlc/Taskfile.yaml
@@ -13,8 +13,8 @@ vars:
 tasks:
   fmt:
     desc:
-      Format prqlc source files. Duplicates `pre-commit` checks, but some
-      developers prefer to use this directly.
+      Format prqlc source files. (Duplicates `pre-commit` checks, but some
+      developers prefer to use this directly.)
     cmds:
       - cmd: |
           # remove trailing whitespace

--- a/web/Taskfile.yaml
+++ b/web/Taskfile.yaml
@@ -42,6 +42,7 @@ tasks:
       - npm run dev
 
   fmt:
+    # (Duplicates `pre-commit` checks, but some developers prefer to use this directly.)
     cmds:
       - cmd: |
           prettier --write . \

--- a/web/book/src/project/bindings/README.md
+++ b/web/book/src/project/bindings/README.md
@@ -17,7 +17,7 @@ Supported bindings require:
   [core compile functions](https://docs.rs/prqlc/latest/prqlc/#functions).
 - Test coverage for these functions.
 - A published package to the language's standard package repository.
-- A script in `Taskfile.yml` to bootstrap a development environment.
+- A script in `Taskfile.yaml` to bootstrap a development environment.
 - Any dev tools, such as a linter & formatter, in pre-commit or MegaLinter.
 
 The currently supported bindings are:

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -7,7 +7,8 @@ editing, and testing PRQL's compiler code in two minutes:
 
 - Install
   [`rustup` & `cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-- [Optional but highly recommended] Install `cargo-insta`, our testing framework:
+- [Optional but highly recommended] Install `cargo-insta`, our testing
+  framework:
 
   ```sh
   cargo install cargo-insta
@@ -54,7 +55,7 @@ since it relies on `brew`.
 
 - [Install Task](https://taskfile.dev/installation/).
 - Then run the `setup-dev` task. This runs commands from our
-  [Taskfile.yml](https://github.com/PRQL/prql/blob/main/Taskfile.yml),
+  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yaml),
   installing dependencies with `cargo`, `brew`, `npm` & `pip`, and suggests some
   VS Code extensions.
 
@@ -84,8 +85,8 @@ since it relies on `brew`.
   book, or some release artifacts, we'll need some additional tools. But we
   won't need those immediately, and the error messages on what's missing should
   be clear when we attempt those things. When we hit them, the
-  [Taskfile.yml](https://github.com/PRQL/prql/blob/main/Taskfile.yml) will be a
-  good source to copy & paste instructions from.
+  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yaml) will be
+  a good source to copy & paste instructions from.
 
 ### Option 3: Use a Dev Container
 
@@ -473,9 +474,8 @@ Currently we release in a semi-automated way:
 
 3. After merging, go to
    [Draft a new release](https://github.com/PRQL/prql/releases/new){{footnote: Only
-       maintainers have access to this page.}},
-   copy the changelog entry into the release
-   description{{footnote: Unfortunately GitHub's markdown parser
+       maintainers have access to this page.}}, copy the changelog entry into the
+   release description{{footnote: Unfortunately GitHub's markdown parser
         interprets linebreaks as newlines. I haven't found a better way of
         editing the markdown to look reasonable than manually editing the text
         or asking LLM to help.}}, enter the tag to be created, and hit

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -7,8 +7,7 @@ editing, and testing PRQL's compiler code in two minutes:
 
 - Install
   [`rustup` & `cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-- [Optional but highly recommended] Install `cargo-insta`, our testing
-  framework:
+- [Optional but highly recommended] Install `cargo-insta`, our testing framework:
 
   ```sh
   cargo install cargo-insta
@@ -474,8 +473,9 @@ Currently we release in a semi-automated way:
 
 3. After merging, go to
    [Draft a new release](https://github.com/PRQL/prql/releases/new){{footnote: Only
-       maintainers have access to this page.}}, copy the changelog entry into the
-   release description{{footnote: Unfortunately GitHub's markdown parser
+       maintainers have access to this page.}},
+   copy the changelog entry into the release
+   description{{footnote: Unfortunately GitHub's markdown parser
         interprets linebreaks as newlines. I haven't found a better way of
         editing the markdown to look reasonable than manually editing the text
         or asking LLM to help.}}, enter the tag to be created, and hit

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -84,8 +84,8 @@ since it relies on `brew`.
   book, or some release artifacts, we'll need some additional tools. But we
   won't need those immediately, and the error messages on what's missing should
   be clear when we attempt those things. When we hit them, the
-  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yml) will be
-  a good source to copy & paste instructions from.
+  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yml) will be a
+  good source to copy & paste instructions from.
 
 ### Option 3: Use a Dev Container
 

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -7,7 +7,8 @@ editing, and testing PRQL's compiler code in two minutes:
 
 - Install
   [`rustup` & `cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-- [Optional but highly recommended] Install `cargo-insta`, our testing framework:
+- [Optional but highly recommended] Install `cargo-insta`, our testing
+  framework:
 
   ```sh
   cargo install cargo-insta
@@ -54,7 +55,7 @@ since it relies on `brew`.
 
 - [Install Task](https://taskfile.dev/installation/).
 - Then run the `setup-dev` task. This runs commands from our
-  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yaml),
+  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yml),
   installing dependencies with `cargo`, `brew`, `npm` & `pip`, and suggests some
   VS Code extensions.
 
@@ -84,8 +85,8 @@ since it relies on `brew`.
   book, or some release artifacts, we'll need some additional tools. But we
   won't need those immediately, and the error messages on what's missing should
   be clear when we attempt those things. When we hit them, the
-  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yaml) will be
-  a good source to copy & paste instructions from.
+  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yml) will be a
+  good source to copy & paste instructions from.
 
 ### Option 3: Use a Dev Container
 
@@ -473,9 +474,8 @@ Currently we release in a semi-automated way:
 
 3. After merging, go to
    [Draft a new release](https://github.com/PRQL/prql/releases/new){{footnote: Only
-       maintainers have access to this page.}},
-   copy the changelog entry into the release
-   description{{footnote: Unfortunately GitHub's markdown parser
+       maintainers have access to this page.}}, copy the changelog entry into the
+   release description{{footnote: Unfortunately GitHub's markdown parser
         interprets linebreaks as newlines. I haven't found a better way of
         editing the markdown to look reasonable than manually editing the text
         or asking LLM to help.}}, enter the tag to be created, and hit

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -54,7 +54,7 @@ since it relies on `brew`.
 
 - [Install Task](https://taskfile.dev/installation/).
 - Then run the `setup-dev` task. This runs commands from our
-  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yaml),
+  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yml),
   installing dependencies with `cargo`, `brew`, `npm` & `pip`, and suggests some
   VS Code extensions.
 
@@ -84,7 +84,7 @@ since it relies on `brew`.
   book, or some release artifacts, we'll need some additional tools. But we
   won't need those immediately, and the error messages on what's missing should
   be clear when we attempt those things. When we hit them, the
-  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yaml) will be
+  [Taskfile.yaml](https://github.com/PRQL/prql/blob/main/Taskfile.yml) will be
   a good source to copy & paste instructions from.
 
 ### Option 3: Use a Dev Container


### PR DESCRIPTION
They're all `.yaml` now.

Also added a note onto tasks that duplicate pre-commit functionality.
