### PR TITLE
build: Rename `prql-js` to `prqlc-js`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// Dev Container for Rust, website, prql-js and prqlc-python
+// Dev Container for Rust, website, prqlc-js and prqlc-python
 {
   "image": "ghcr.io/prql/prql-devcontainer-base:latest",
   "features": {

--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -33,6 +33,8 @@ DISABLE_ERRORS_LINTERS:
   - JSON_JSONLINT
   - MAKEFILE_CHECKMAKE
   - MARKDOWN_MARKDOWN_LINK_CHECK
+  # Prevents us from starting a new library, since it raises an error on unpublished libraries. Can remove after publishing...
+  - REPOSITORY_DUSTILOCK
   - SPELL_MISSPELL
   # Disabled for now, as @max-sixty didn't know whether "Unable to locate the
   # project file. A project file (tsconfig.json or tsconfig.eslint.json) is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,16 +3046,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prql-js"
-version = "0.12.2"
-dependencies = [
- "console_error_panic_hook",
- "prqlc",
- "wasm-bindgen",
- "wasm-bindgen-test",
-]
-
-[[package]]
 name = "prqlc"
 version = "0.12.2"
 dependencies = [
@@ -3134,6 +3124,16 @@ dependencies = [
  "libc",
  "prqlc",
  "serde_json",
+]
+
+[[package]]
+name = "prqlc-js"
+version = "0.12.2"
+dependencies = [
+ "console_error_panic_hook",
+ "prqlc",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To stay in touch with PRQL:
 - [pyprql Docs](https://pyprql.readthedocs.io) — the pyprql documentation, the
   Python bindings to PRQL, including Jupyter magic.
 - [PRQL VS Code extension](https://marketplace.visualstudio.com/items?itemName=prql-lang.prql-vscode)
-- [prql-js](https://www.npmjs.com/package/prql-js) — JavaScript bindings for
+- [prqlc-js](https://www.npmjs.com/package/prqlc-js) — JavaScript bindings for
   PRQL.
 
 ## Repo organization

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To stay in touch with PRQL:
 - [pyprql Docs](https://pyprql.readthedocs.io) — the pyprql documentation, the
   Python bindings to PRQL, including Jupyter magic.
 - [PRQL VS Code extension](https://marketplace.visualstudio.com/items?itemName=prql-lang.prql-vscode)
-- [prqlc-js](https://www.npmjs.com/package/prqlc-js) — JavaScript bindings for
+- [prqlc-js](https://www.npmjs.com/package/prqlc) — JavaScript bindings for
   PRQL.
 
 ## Repo organization

--- a/prqlc/Taskfile.yaml
+++ b/prqlc/Taskfile.yaml
@@ -8,7 +8,7 @@ includes:
 vars:
   packages_core: -p prqlc-ast -p prqlc-parser -p prqlc
   packages_addon: -p prql-compiler-macros -p compile-files
-  packages_bindings: -p prql -p prql-java -p prql-js -p prqlc-c -p prqlc-python
+  packages_bindings: -p prql -p prql-java -p prqlc-js -p prqlc-c -p prqlc-python
 
 tasks:
   fmt:

--- a/prqlc/bindings/js/Cargo.toml
+++ b/prqlc/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "Javascript bindings for prqlc"
-name = "prql-js"
+name = "prqlc-js"
 publish = false
 
 edition.workspace = true
@@ -11,9 +11,9 @@ version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+doc = false
 doctest = false
 test = false
-doc = false
 
 [features]
 default = ["console_error_panic_hook"]
@@ -27,9 +27,9 @@ wasm-bindgen = "0.2.92"
 # for development, but requires all the `std::fmt` and `std::panicking`
 # infrastructure, so isn't great for code size when deploying.", on testing with
 # `--no-default-features`,
-# `prql/target/wasm32-unknown-unknown/release/prql_js.wasm` is 7.416MB vs
+# `prql/target/wasm32-unknown-unknown/release/prqlc_js.wasm` is 7.416MB vs
 # 7.408MB. Maybe because we're already including lots of that with other library
-# features? Even running `wasm-opt prql_js.wasm` makes similarly sized files of
+# features? Even running `wasm-opt prqlc_js.wasm` makes similarly sized files of
 # 5.7M. Feel free to try removing this as part of reducing code size (would be
 # good to have a much smaller code size...).
 console_error_panic_hook = {version = "0.1.7", optional = true}
@@ -55,7 +55,7 @@ exactly = 2
 file = "package-lock.json"
 replace = '$1"{{version}}"'
 search = '''
-(\s+"prql-js",
+(\s+"prqlc-js",
 \s+"version": )"[\d\.]+"'''
 
 [[package.metadata.release.pre-release-replacements]]

--- a/prqlc/bindings/js/Cargo.toml
+++ b/prqlc/bindings/js/Cargo.toml
@@ -55,7 +55,7 @@ exactly = 2
 file = "package-lock.json"
 replace = '$1"{{version}}"'
 search = '''
-(\s+"prqlc-js",
+(\s+"prqlc",
 \s+"version": )"[\d\.]+"'''
 
 [[package.metadata.release.pre-release-replacements]]

--- a/prqlc/bindings/js/README.md
+++ b/prqlc/bindings/js/README.md
@@ -1,11 +1,11 @@
-# prql-js
+# prqlc-js
 
 JavaScript bindings for [`prqlc`](https://github.com/PRQL/prql/).
 
 ## Installation
 
 ```sh
-npm install prql-js
+npm install prqlc-js
 ```
 
 ## Usage
@@ -29,29 +29,29 @@ function rq_to_sql(rq_json: string): string;
 Direct usage
 
 ```javascript
-const prqljs = require("prql-js");
+const prqlc = require("prqlc-js");
 
-const sql = prqljs.compile(`from employees | select first_name`);
+const sql = prqlc.compile(`from employees | select first_name`);
 console.log(sql);
 ```
 
 Options
 
 ```javascript
-const opts = new prql.CompileOptions();
+const opts = new prqlc.CompileOptions();
 opts.target = "sql.mssql";
 opts.format = false;
 opts.signature_comment = false;
 
-const sql = prqljs.compile(`from employees | take 10`, opts);
+const sql = prqlc.compile(`from employees | take 10`, opts);
 console.log(sql);
 ```
 
 Template literal
 
 ```javascript
-const prqljs = require("prql-js");
-const prql = (string) => prqljs.compile(string[0] || "");
+const prqlc = require("prqlc-js");
+const prql = (string) => prqlc.compile(string[0] || "");
 
 const sql = prql`from employees | select first_name`;
 console.log(sql);
@@ -60,8 +60,8 @@ console.log(sql);
 Template literal with newlines
 
 ```javascript
-const prqljs = require("prql-js");
-const prql = (string) => prqljs.compile(string[0] || "");
+const prqlc = require("prqlc-js");
+const prql = (string) => prqlc.compile(string[0] || "");
 
 const sql = prql`
     from employees
@@ -91,7 +91,7 @@ console.log(sql);
 ### From a framework or a bundler
 
 ```typescript
-import compile from "prql-js/dist/bundler";
+import compile from "prqlc-js/dist/bundler";
 
 const sql = compile(`from employees | select first_name`);
 console.log(sql);
@@ -165,7 +165,7 @@ code hasn't changed, which can be slow. For a lower-latency dev loop, pass
 `--profile=dev` to `npm install` for a faster, less optimized build.
 
 ```sh
-npm install prql-js --profile=dev
+npm install prqlc-js --profile=dev
 ```
 
 ## Notes

--- a/prqlc/bindings/js/README.md
+++ b/prqlc/bindings/js/README.md
@@ -5,7 +5,7 @@ JavaScript bindings for [`prqlc`](https://github.com/PRQL/prql/).
 ## Installation
 
 ```sh
-npm install prqlc-js
+npm install prqlc
 ```
 
 ## Usage
@@ -29,7 +29,7 @@ function rq_to_sql(rq_json: string): string;
 Direct usage
 
 ```javascript
-const prqlc = require("prqlc-js");
+const prqlc = require("prqlc");
 
 const sql = prqlc.compile(`from employees | select first_name`);
 console.log(sql);
@@ -50,7 +50,7 @@ console.log(sql);
 Template literal
 
 ```javascript
-const prqlc = require("prqlc-js");
+const prqlc = require("prqlc");
 const prql = (string) => prqlc.compile(string[0] || "");
 
 const sql = prql`from employees | select first_name`;
@@ -60,7 +60,7 @@ console.log(sql);
 Template literal with newlines
 
 ```javascript
-const prqlc = require("prqlc-js");
+const prqlc = require("prqlc");
 const prql = (string) => prqlc.compile(string[0] || "");
 
 const sql = prql`
@@ -91,7 +91,7 @@ console.log(sql);
 ### From a framework or a bundler
 
 ```typescript
-import compile from "prqlc-js/dist/bundler";
+import compile from "prqlc/dist/bundler";
 
 const sql = compile(`from employees | select first_name`);
 console.log(sql);
@@ -165,7 +165,7 @@ code hasn't changed, which can be slow. For a lower-latency dev loop, pass
 `--profile=dev` to `npm install` for a faster, less optimized build.
 
 ```sh
-npm install prqlc-js --profile=dev
+npm install prqlc --profile=dev
 ```
 
 ## Notes

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "prql-js",
+  "name": "prqlc-js",
   "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "prql-js",
+      "name": "prqlc-js",
       "version": "0.12.2",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "prqlc-js",
+  "name": "prqlc",
   "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "prqlc-js",
+      "name": "prqlc",
       "version": "0.12.2",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -1,5 +1,5 @@
 {
-  "browser": "dist/web/prql_js.js",
+  "browser": "dist/web/prqlc_js.js",
   "description": "JavaScript bindings for prqlc",
   "devDependencies": {
     "chai": "^5.0.0",
@@ -12,8 +12,8 @@
   ],
   "license": "Apache-2.0",
   "author": "PRQL team",
-  "main": "dist/node/prql_js.js",
-  "name": "prql-js",
+  "main": "dist/node/prqlc_js.js",
+  "name": "prqlc-js",
   "bugs": {
     "url": "https://github.com/PRQL/prql/issues"
   },
@@ -34,6 +34,6 @@
     "prepare": "npm run build",
     "test": "mocha tests"
   },
-  "types": "dist/node/prql_js.d.ts",
+  "types": "dist/node/prqlc_js.d.ts",
   "version": "0.12.2"
 }

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "author": "PRQL team",
   "main": "dist/node/prqlc_js.js",
-  "name": "prqlc-js",
+  "name": "prqlc",
   "bugs": {
     "url": "https://github.com/PRQL/prql/issues"
   },

--- a/prqlc/bindings/js/tests/test_all.mjs
+++ b/prqlc/bindings/js/tests/test_all.mjs
@@ -30,13 +30,13 @@ describe("prqlc-js", () => {
       const sql = prqlc.compile(employee_prql);
       assert(
         sql.trim().toLowerCase().startsWith("with") ||
-          sql.trim().toLowerCase().startsWith("select")
+          sql.trim().toLowerCase().startsWith("select"),
       );
     });
 
     it("should throw an error on invalid prql", () => {
       expect(() =>
-        prqlc.compile("Mississippi has four Ss and four Is.")
+        prqlc.compile("Mississippi has four Ss and four Is."),
       ).to.throw("Error");
     });
 
@@ -49,7 +49,7 @@ describe("prqlc-js", () => {
       const res = prqlc.compile("from a | take 10", opts);
       assert.equal(
         res,
-        "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY"
+        "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY",
       );
     });
 
@@ -61,12 +61,12 @@ describe("prqlc-js", () => {
 
       const res = prqlc.compile(
         "prql target:sql.sqlite\nfrom a | take 10",
-        opts
+        opts,
       );
       assert(
         res.includes(
-          "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY"
-        )
+          "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY",
+        ),
       );
       assert(res.includes("target:sql.mssql"));
     });

--- a/prqlc/bindings/js/tests/test_all.mjs
+++ b/prqlc/bindings/js/tests/test_all.mjs
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { expect } from "chai";
-import prql from "../dist/node/prql_js.js";
+import prqlc from "../dist/node/prqlc_js.js";
 
 const employee_prql = `from employees
 join salaries (==emp_no)
@@ -24,49 +24,49 @@ join managers=employees (==emp_no)
 derive mng_name = s"managers.first_name || ' ' || managers.last_name"
 select {mng_name, managers.gender, salary_avg, salary_sd}`;
 
-describe("prql-js", () => {
+describe("prqlc-js", () => {
   describe("compile", () => {
     it("should return valid sql from valid prql", () => {
-      const sql = prql.compile(employee_prql);
+      const sql = prqlc.compile(employee_prql);
       assert(
         sql.trim().toLowerCase().startsWith("with") ||
-          sql.trim().toLowerCase().startsWith("select"),
+          sql.trim().toLowerCase().startsWith("select")
       );
     });
 
     it("should throw an error on invalid prql", () => {
       expect(() =>
-        prql.compile("Mississippi has four Ss and four Is."),
+        prqlc.compile("Mississippi has four Ss and four Is.")
       ).to.throw("Error");
     });
 
     it("should compile to dialect", () => {
-      const opts = new prql.CompileOptions();
+      const opts = new prqlc.CompileOptions();
       opts.target = "sql.mssql";
       opts.format = false;
       opts.signature_comment = false;
 
-      const res = prql.compile("from a | take 10", opts);
+      const res = prqlc.compile("from a | take 10", opts);
       assert.equal(
         res,
-        "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY",
+        "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY"
       );
     });
 
     it("CompileOptions should be preferred and should ignore target in header", () => {
-      const opts = new prql.CompileOptions();
+      const opts = new prqlc.CompileOptions();
       opts.target = "sql.mssql";
       opts.format = false;
       opts.signature_comment = true;
 
-      const res = prql.compile(
+      const res = prqlc.compile(
         "prql target:sql.sqlite\nfrom a | take 10",
-        opts,
+        opts
       );
       assert(
         res.includes(
-          "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY",
-        ),
+          "SELECT * FROM a ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY"
+        )
       );
       assert(res.includes("target:sql.mssql"));
     });
@@ -74,34 +74,34 @@ describe("prql-js", () => {
 
   describe("prql_to_pl", () => {
     it("should return valid json from valid prql", () => {
-      JSON.parse(prql.prql_to_pl(employee_prql));
+      JSON.parse(prqlc.prql_to_pl(employee_prql));
     });
 
     it("should throw an error on invalid prql", () => {
-      expect(() => prql.prql_to_pl("Answer: T-H-A-T!")).to.throw("Error");
+      expect(() => prqlc.prql_to_pl("Answer: T-H-A-T!")).to.throw("Error");
     });
   });
 
   describe("CompileOptions", () => {
     it("should be able to create from constructor", () => {
-      const opts = new prql.CompileOptions();
+      const opts = new prqlc.CompileOptions();
 
       opts.target = "sql.sqlite";
       assert.equal(opts.target, "sql.sqlite");
     });
 
     it("should fallback to the target in header", () => {
-      const opts = new prql.CompileOptions();
+      const opts = new prqlc.CompileOptions();
 
       opts.target = "sql.any";
-      const res = prql.compile("prql target:sql.mssql\nfrom a | take 1", opts);
+      const res = prqlc.compile("prql target:sql.mssql\nfrom a | take 1", opts);
       assert(res.includes("1 ROWS ONLY"));
     });
   });
 
   describe("get_targets", () => {
     it("return a list of targets", () => {
-      const targets = new prql.get_targets();
+      const targets = new prqlc.get_targets();
       assert(targets.length > 0);
       assert(targets.includes("sql.sqlite"));
     });
@@ -110,7 +110,7 @@ describe("prql-js", () => {
   describe("compile error", () => {
     it("should contain json", () => {
       try {
-        prql.compile("from x | select a | select b");
+        prqlc.compile("from x | select a | select b");
       } catch (error) {
         const errorMessages = JSON.parse(error.message).inner;
 
@@ -122,7 +122,7 @@ describe("prql-js", () => {
 
     it("should contain error code", () => {
       try {
-        prql.compile("let a = (from x)");
+        prqlc.compile("let a = (from x)");
       } catch (error) {
         const errorMessages = JSON.parse(error.message).inner;
 

--- a/prqlc/prqlc/README.md
+++ b/prqlc/prqlc/README.md
@@ -28,7 +28,7 @@ WHERE
   has_dog
 ```
 
-A PRQL query can be executed with CLI tools compatible with SQL,, such as
+A PRQL query can be executed with CLI tools compatible with SQL, such as
 [DuckDB CLI](https://duckdb.org/docs/api/cli.html).
 
 ```sh

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -14,7 +14,7 @@
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.0",
         "monaco-editor": "^0.49.0",
-        "prqlc-js": "file:../../prqlc/bindings/js",
+        "prqlc": "file:../../prqlc/bindings/js",
         "react": "^18.2.0",
         "react-dom": "^18.3.0",
         "react-syntax-highlighter": "^15.5.0",
@@ -29,7 +29,7 @@
       }
     },
     "../../prqlc/bindings/js": {
-      "name": "prqlc-js",
+      "name": "prqlc",
       "version": "0.12.2",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -6629,7 +6629,7 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/prqlc-js": {
+    "node_modules/prqlc": {
       "resolved": "../../prqlc/bindings/js",
       "link": true
     },

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -14,7 +14,7 @@
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.0",
         "monaco-editor": "^0.49.0",
-        "prql-js": "file:../../prqlc/bindings/js",
+        "prqlc-js": "file:../../prqlc/bindings/js",
         "react": "^18.2.0",
         "react-dom": "^18.3.0",
         "react-syntax-highlighter": "^15.5.0",
@@ -29,7 +29,7 @@
       }
     },
     "../../prqlc/bindings/js": {
-      "name": "prql-js",
+      "name": "prqlc-js",
       "version": "0.12.2",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -6629,7 +6629,7 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/prql-js": {
+    "node_modules/prqlc-js": {
       "resolved": "../../prqlc/bindings/js",
       "link": true
     },

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -18,7 +18,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.0",
     "monaco-editor": "^0.49.0",
-    "prqlc-js": "file:../../prqlc/bindings/js",
+    "prqlc": "file:../../prqlc/bindings/js",
     "react": "^18.2.0",
     "react-dom": "^18.3.0",
     "react-syntax-highlighter": "^15.5.0",

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -18,7 +18,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.0",
     "monaco-editor": "^0.49.0",
-    "prql-js": "file:../../prqlc/bindings/js",
+    "prqlc-js": "file:../../prqlc/bindings/js",
     "react": "^18.2.0",
     "react-dom": "^18.3.0",
     "react-syntax-highlighter": "^15.5.0",

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -1,6 +1,6 @@
 import "./Workbench.css";
 
-import * as prql from "prqlc-js/dist/bundler";
+import * as prql from "prqlc/dist/bundler";
 import React from "react";
 import YAML from "yaml";
 

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -95,7 +95,7 @@ class Workbench extends React.Component {
       this.monaco.editor.setModelMarkers(
         this.editor.getModel(),
         "prql",
-        monacoErrors
+        monacoErrors,
       );
       return;
     }

--- a/web/playground/src/workbench/Workbench.jsx
+++ b/web/playground/src/workbench/Workbench.jsx
@@ -1,6 +1,6 @@
 import "./Workbench.css";
 
-import * as prql from "prql-js/dist/bundler";
+import * as prql from "prqlc-js/dist/bundler";
 import React from "react";
 import YAML from "yaml";
 
@@ -95,7 +95,7 @@ class Workbench extends React.Component {
       this.monaco.editor.setModelMarkers(
         this.editor.getModel(),
         "prql",
-        monacoErrors,
+        monacoErrors
       );
       return;
     }

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -219,8 +219,8 @@ bindings_section:
       label: "prqlc-python"
       text: Python bindings for prqlc.
 
-    - link: https://www.npmjs.com/package/prql-js
-      label: "prql-js"
+    - link: https://www.npmjs.com/package/prqlc-js
+      label: "prqlc-js"
       text: "JavaScript bindings for prqlc."
 
     - link: https://CRAN.R-project.org/package=prqlr

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -219,7 +219,7 @@ bindings_section:
       label: "prqlc-python"
       text: Python bindings for prqlc.
 
-    - link: https://www.npmjs.com/package/prqlc-js
+    - link: https://www.npmjs.com/package/prqlc
       label: "prqlc-js"
       text: "JavaScript bindings for prqlc."
 


### PR DESCRIPTION
But I'd like to find a way of getting the npm upload to be `prqlc`, rather than `prqlc-js`. We manage this in python...
