### PR TITLE
feat: add pl_to_prql Python binding

### DIFF
--- a/prqlc/bindings/prqlc-python/README.md
+++ b/prqlc/bindings/prqlc-python/README.md
@@ -1,14 +1,13 @@
 # PRQL - Python Bindings
 
-Python bindings for [PRQL](https://github.com/PRQL/prql), the
-Pipelined Relational Query Language. 
+Python bindings for [PRQL](https://github.com/PRQL/prql), the Pipelined
+Relational Query Language.
 
-PRQL is a modern language for transforming data — a simple, powerful,
-pipelined SQL replacement. Like SQL, it's readable, explicit and
-declarative. Unlike SQL, it forms a logical pipeline of
-transformations, and supports abstractions such as variables and
-functions. It can be used with any database that uses SQL, since it
-compiles to SQL.
+PRQL is a modern language for transforming data — a simple, powerful, pipelined
+SQL replacement. Like SQL, it's readable, explicit and declarative. Unlike SQL,
+it forms a logical pipeline of transformations, and supports abstractions such
+as variables and functions. It can be used with any database that uses SQL,
+since it compiles to SQL.
 
 PRQL can be as simple as:
 
@@ -61,16 +60,16 @@ def compile(prql_query: str, options: Optional[CompileOptions] = None) -> str:
 def prql_to_pl(prql_query: str) -> str:
     """Converts a PRQL query to PL AST in JSON format."""
     ...
-    
+
 def pl_to_prql(pl_json: str) -> str:
     """Converts PL AST as a JSON string into a formatted PRQL string."""
     ...
-    
+
 def pl_to_rq(pl_json: str) -> str:
     """Resolves and lowers PL AST (JSON) into RQ AST (JSON)."""
     ...
-    
-def rq_to_sql(rq_json: str, options: Optional[ComplieOptions] = None) -> str:
+
+def rq_to_sql(rq_json: str, options: Optional[CompileOptions] = None) -> str:
     """Converts RQ AST (JSON) into a SQL query."""
     ...
 
@@ -81,9 +80,9 @@ class CompileOptions:
         format: bool = True,
         target: str = "sql.any",
         signature_comment: bool = True,
-    ) -> None: 
+    ) -> None:
     """Compilation options for SQL backend of the compiler.
-    
+
     Args:
         format (bool): Pass generated SQL string through a formatter that splits
             it into multiple lines and prettifies indentation and spacing.
@@ -94,10 +93,10 @@ class CompileOptions:
             function.
         signature_comment (bool): Emits the compiler signature as a comment after
             the generated SQL. Defaults to True.
-    
+
     """
     ...
-    
+
 def get_targets() -> list[str]:
     """List available target dialects for compilation."""
     ...
@@ -105,18 +104,18 @@ def get_targets() -> list[str]:
 
 ### Debugging functions
 
-The following functions are available within the `prqlc.debug` module.
-They are for experimental purposes and may be unstable.
+The following functions are available within the `prqlc.debug` module. They are
+for experimental purposes and may be unstable.
 
 ```python
 def prql_lineage(prql_query: str) -> str:
     """Computes a column-level lineage graph from a PRQL query.
-    
-    Returns JSON-formatted string. See the docs for the `prqlc debug lineage` 
+
+    Returns JSON-formatted string. See the docs for the `prqlc debug lineage`
     CLI command for more details.
     """
     ...
-    
+
 def pl_to_lineage(pl_json: str) -> str:
     """Computes a column-level lineage graph from PL AST (JSON)."""
     ...
@@ -124,10 +123,9 @@ def pl_to_lineage(pl_json: str) -> str:
 
 ## Notes
 
-These bindings are in a crate named `prqlc-python` and published to a
-Python package on PyPI named `prqlc`, available at
-<https://pypi.org/project/prqlc>. This crate is not published to
-crates.io.
+These bindings are in a crate named `prqlc-python` and published to a Python
+package on PyPI named `prqlc`, available at <https://pypi.org/project/prqlc>.
+This crate is not published to crates.io.
 
 The package is consumed by [pyprql](https://github.com/prql/pyprql) &
 [dbt-prql](https://github.com/prql/dbt-prql).

--- a/prqlc/bindings/prqlc-python/README.md
+++ b/prqlc/bindings/prqlc-python/README.md
@@ -1,21 +1,34 @@
-# Python bindings to `prqlc`
+# PRQL - Python Bindings
 
-The `prqlc-python` crate offer Rust bindings to the `prqlc` Rust library,
-published to a python package named `prqlc`.
+Python bindings for [PRQL](https://github.com/PRQL/prql), the
+Pipelined Relational Query Language. 
 
-The main entry point is a Python method `prqlc.compile(query: str) -> str`.
+PRQL is a modern language for transforming data — a simple, powerful,
+pipelined SQL replacement. Like SQL, it's readable, explicit and
+declarative. Unlike SQL, it forms a logical pipeline of
+transformations, and supports abstractions such as variables and
+functions. It can be used with any database that uses SQL, since it
+compiles to SQL.
 
-The package is consumed by [pyprql](https://github.com/prql/pyprql) &
-[dbt-prql](https://github.com/prql/dbt-prql).
+PRQL can be as simple as:
 
-The crate is not published to crates.io; only to PyPI at
-<https://pypi.org/project/prqlc/>.
+```
+from tracks
+filter artist == "Bob Marley"     # Each line transforms the previous result
+aggregate {                       # `aggregate` reduces each column to a value
+  plays    = sum plays,
+  longest  = max length,
+  shortest = min length,          # Trailing commas are allowed
+}
+```
 
 ## Installation
 
 `pip install prqlc`
 
 ## Usage
+
+Basic usage:
 
 ```python
 import prqlc
@@ -37,5 +50,86 @@ options = prqlc.CompileOptions(
 sql = prqlc.compile(prql_query)
 sql_postgres = prqlc.compile(prql_query, options)
 ```
+
+The following functions and classes are exposed:
+
+```python
+def compile(prql_query: str, options: Optional[CompileOptions] = None) -> str:
+    """Compiles a PRQL query into SQL."""
+    ...
+
+def prql_to_pl(prql_query: str) -> str:
+    """Converts a PRQL query to PL AST in JSON format."""
+    ...
+    
+def pl_to_prql(pl_json: str) -> str:
+    """Converts PL AST as a JSON string into a formatted PRQL string."""
+    ...
+    
+def pl_to_rq(pl_json: str) -> str:
+    """Resolves and lowers PL AST (JSON) into RQ AST (JSON)."""
+    ...
+    
+def rq_to_sql(rq_json: str, options: Optional[ComplieOptions] = None) -> str:
+    """Converts RQ AST (JSON) into a SQL query."""
+    ...
+
+class CompileOptions:
+    def __init__(
+        self,
+        *,
+        format: bool = True,
+        target: str = "sql.any",
+        signature_comment: bool = True,
+    ) -> None: 
+    """Compilation options for SQL backend of the compiler.
+    
+    Args:
+        format (bool): Pass generated SQL string through a formatter that splits
+            it into multiple lines and prettifies indentation and spacing.
+            Defaults to True.
+        target (str): Target dialect to compile to. Defaults to "sql.any", which
+            uses the 'target' argument from the query header to determine the
+            SQL dialect. Other targets are available by calling the `get_targets`
+            function.
+        signature_comment (bool): Emits the compiler signature as a comment after
+            the generated SQL. Defaults to True.
+    
+    """
+    ...
+    
+def get_targets() -> list[str]:
+    """List available target dialects for compilation."""
+    ...
+```
+
+### Debugging functions
+
+The following functions are available within the `prqlc.debug` module.
+They are for experimental purposes and may be unstable.
+
+```python
+def prql_lineage(prql_query: str) -> str:
+    """Computes a column-level lineage graph from a PRQL query.
+    
+    Returns JSON-formatted string. See the docs for the `prqlc debug lineage` 
+    CLI command for more details.
+    """
+    ...
+    
+def pl_to_lineage(pl_json: str) -> str:
+    """Computes a column-level lineage graph from PL AST (JSON)."""
+    ...
+```
+
+## Notes
+
+These bindings are in a crate named `prqlc-python` and published to a
+Python package on PyPI named `prqlc`, available at
+<https://pypi.org/project/prqlc>. This crate is not published to
+crates.io.
+
+The package is consumed by [pyprql](https://github.com/prql/pyprql) &
+[dbt-prql](https://github.com/prql/dbt-prql).
 
 Relies on [pyo3](https://github.com/PyO3/pyo3) for all the magic.

--- a/prqlc/bindings/prqlc-python/src/lib.rs
+++ b/prqlc/bindings/prqlc-python/src/lib.rs
@@ -221,6 +221,17 @@ mod test {
     }
 
     #[test]
+    fn prql_pl_prql_roundtrip() {
+        let prql = r#"from artists | select {name, id} | filter (id | in [1, 2, 3])"#;
+        assert_snapshot!(
+             prql_to_pl(prql).and_then(|x| pl_to_prql(x.as_str())).unwrap(), @r###"
+        from artists
+        select {name, id}
+        filter (id | in [1, 2, 3])
+        "###);
+    }
+
+    #[test]
     fn debug_prql_lineage() {
         assert_snapshot!(
             debug::prql_lineage(r#"from a"#).unwrap(),

--- a/prqlc/bindings/prqlc-python/src/lib.rs
+++ b/prqlc/bindings/prqlc-python/src/lib.rs
@@ -28,6 +28,13 @@ pub fn prql_to_pl(prql_query: &str) -> PyResult<String> {
 }
 
 #[pyfunction]
+pub fn pl_to_prql(pl_json: &str) -> PyResult<String> {
+    prqlc_lib::json::to_pl(pl_json)
+        .and_then(|x| prqlc_lib::pl_to_prql(&x))
+        .map_err(|err| (PyErr::new::<exceptions::PyValueError, _>(err.to_json())))
+}
+
+#[pyfunction]
 pub fn pl_to_rq(pl_json: &str) -> PyResult<String> {
     prqlc_lib::json::to_pl(pl_json)
         .and_then(prqlc_lib::pl_to_rq)
@@ -74,6 +81,7 @@ mod debug {
 fn prqlc(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compile, m)?)?;
     m.add_function(wrap_pyfunction!(prql_to_pl, m)?)?;
+    m.add_function(wrap_pyfunction!(pl_to_prql, m)?)?;
     m.add_function(wrap_pyfunction!(pl_to_rq, m)?)?;
     m.add_function(wrap_pyfunction!(rq_to_sql, m)?)?;
     m.add_function(wrap_pyfunction!(get_targets, m)?)?;


### PR DESCRIPTION
Expose the `pl_to_prql` function via the Python binding.

Also refreshes the Python binding README with more documentation. This should make the the [PyPI project page](https://pypi.org/project/prqlc/) look more appealing (and hopefully reduce some of the confusion around the vast array of "prql/prqlc/preql/prql-python/prequel" Python packages on there...)