### PR TITLE
fix: better testing of lineage, and fix small bug with lineage tracking

### DIFF
--- a/prqlc/bindings/prqlc-python/src/lib.rs
+++ b/prqlc/bindings/prqlc-python/src/lib.rs
@@ -215,16 +215,16 @@ mod test {
     #[test]
     fn debug_prql_lineage() {
         assert_snapshot!(
-            debug::prql_lineage(r#"from a"#).unwrap(),
-            @r#"{"frames":[],"nodes":[{"id":115,"kind":"Ident","span":"1:0-6","ident":{"Ident":["default_db","a"]}}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"a"}]}}},"span":"1:0-6"}]}}"#
+            debug::prql_lineage(r#"from a | select { beta, gamma }"#).unwrap(),
+            @r###"{"frames":[["1:9-31",{"columns":[{"Single":{"name":["a","beta"],"target_id":120,"target_name":null}},{"Single":{"name":["a","gamma"],"target_id":121,"target_name":null}}],"inputs":[{"id":118,"name":"a","table":["default_db","a"]}]}]],"nodes":[{"id":118,"kind":"Ident","span":"1:0-6","ident":{"Ident":["default_db","a"]},"parent":123},{"id":120,"kind":"Ident","span":"1:18-22","ident":{"Ident":["this","a","beta"]},"targets":[118],"parent":122},{"id":121,"kind":"Ident","span":"1:24-29","ident":{"Ident":["this","a","gamma"]},"targets":[118],"parent":122},{"id":122,"kind":"Tuple","span":"1:16-31","children":[120,121],"parent":123},{"id":123,"kind":"TransformCall: Select","span":"1:9-31","children":[118,122]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"a"}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"beta"},{"Ident":"gamma"}]}]}}]}}},"span":"1:0-31"}]}}"###
         );
     }
 
     #[test]
     fn debug_pl_to_lineage() {
         assert_snapshot!(
-            prql_to_pl(r#"from a"#).and_then(|x| debug::pl_to_lineage(&x)).unwrap(),
-            @r#"{"frames":[],"nodes":[{"id":115,"kind":"Ident","ident":{"Ident":["default_db","a"]}}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"a"}]}}},"span":"1:0-6"}]}}"#
+            prql_to_pl(r#"from a | select { beta, gamma }"#).and_then(|x| debug::pl_to_lineage(&x)).unwrap(),
+            @r###"{"frames":[[null,{"columns":[{"Single":{"name":["a","beta"],"target_id":120,"target_name":null}},{"Single":{"name":["a","gamma"],"target_id":121,"target_name":null}}],"inputs":[{"id":118,"name":"a","table":["default_db","a"]}]}]],"nodes":[{"id":118,"kind":"Ident","ident":{"Ident":["default_db","a"]},"parent":123},{"id":120,"kind":"Ident","ident":{"Ident":["this","a","beta"]},"targets":[118],"parent":122},{"id":121,"kind":"Ident","ident":{"Ident":["this","a","gamma"]},"targets":[118],"parent":122},{"id":122,"kind":"Tuple","children":[120,121],"parent":123},{"id":123,"kind":"TransformCall: Select","children":[118,122]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"a"}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"beta"},{"Ident":"gamma"}]}]}}]}}},"span":"1:0-31"}]}}"###
         );
     }
 }

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -634,7 +634,7 @@ fn read_files(input: &mut clio::ClioPath) -> Result<SourceTree> {
     Ok(SourceTree::new(sources, Some(root.to_path_buf())))
 }
 
-fn combine_prql_and_frames(source: &str, frames: Vec<(Span, Lineage)>) -> String {
+fn combine_prql_and_frames(source: &str, frames: Vec<(Option<Span>, Lineage)>) -> String {
     let source = Source::from(source);
     let lines = source.lines().collect_vec();
     let width = lines.iter().map(|l| l.len()).max().unwrap_or(0);
@@ -646,34 +646,36 @@ fn combine_prql_and_frames(source: &str, frames: Vec<(Span, Lineage)>) -> String
     let mut printed_lines_count = 0;
     let mut result = Vec::new();
     for (span, frame) in frames {
-        let line_len = source.get_line_range(&Range::from(span)).end - 1;
+        if let Some(span) = span {
+            let line_len = source.get_line_range(&Range::from(span)).end - 1;
 
-        while printed_lines_count < line_len {
-            result.push(
-                source
-                    .get_line_text(source.line(printed_lines_count).unwrap())
-                    .unwrap()
-                    // Ariadne 0.4.1 added a line break at the end of the line, so we
-                    // trim it.
-                    .trim_end()
-                    .to_string(),
-            );
+            while printed_lines_count < line_len {
+                result.push(
+                    source
+                        .get_line_text(source.line(printed_lines_count).unwrap())
+                        .unwrap()
+                        // Ariadne 0.4.1 added a line break at the end of the line, so we
+                        // trim it.
+                        .trim_end()
+                        .to_string(),
+                );
+                printed_lines_count += 1;
+            }
+
+            if printed_lines_count >= lines.len() {
+                break;
+            }
+            let chars: String = source
+                .get_line_text(source.line(printed_lines_count).unwrap())
+                .unwrap()
+                // Ariadne 0.4.1 added a line break at the end of the line, so we
+                // trim it.
+                .trim_end()
+                .to_string();
             printed_lines_count += 1;
-        }
 
-        if printed_lines_count >= lines.len() {
-            break;
+            result.push(format!("{chars:width$} # {frame}"));
         }
-        let chars: String = source
-            .get_line_text(source.line(printed_lines_count).unwrap())
-            .unwrap()
-            // Ariadne 0.4.1 added a line break at the end of the line, so we
-            // trim it.
-            .trim_end()
-            .to_string();
-        printed_lines_count += 1;
-
-        result.push(format!("{chars:width$} # {frame}"));
     }
     for line in lines.iter().skip(printed_lines_count) {
         result.push(source.get_line_text(line.to_owned()).unwrap().to_string());

--- a/prqlc/prqlc/src/semantic/reporting.rs
+++ b/prqlc/prqlc/src/semantic/reporting.rs
@@ -199,7 +199,7 @@ pub struct FrameCollector {
     /// Each transformation step in the main pipeline corresponds to a single
     /// frame. This holds the output columns at each frame, as well as the span
     /// position of the frame.
-    pub frames: Vec<(Span, Lineage)>,
+    pub frames: Vec<(Option<Span>, Lineage)>,
 
     /// A mapping of expression graph node IDs to their node definitions.
     pub nodes: Vec<ExprGraphNode>,
@@ -320,11 +320,9 @@ impl PlFold for FrameCollector {
         self.nodes.dedup();
 
         if matches!(expr.kind, ExprKind::TransformCall(_)) {
-            if let Some(span) = expr.span {
-                let lineage = expr.lineage.clone();
-                if let Some(lineage) = lineage {
-                    self.frames.push((span, lineage));
-                }
+            let lineage = expr.lineage.clone();
+            if let Some(lineage) = lineage {
+                self.frames.push((expr.span, lineage));
             }
         }
 

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -614,6 +614,10 @@ impl Resolver<'_> {
 
         let mut pipeline = self.fold_expr(pipeline)?;
 
+        // attach the span to the TransformCall, as this is what will
+        // be preserved after resolving is complete
+        pipeline.span = pipeline.span.or(span);
+
         self.root_mod.module.stack_pop(NS_PARAM).unwrap();
 
         // now, we need wrap the result into a closure and replace

--- a/prqlc/prqlc/tests/integration/bad_error_messages.rs
+++ b/prqlc/prqlc/tests/integration/bad_error_messages.rs
@@ -192,13 +192,13 @@ fn nested_groups() {
     )
     "###).unwrap_err(), @r###"
     Error:
-        ╭─[:2:5]
+        ╭─[:9:9]
         │
-      2 │ ╭─▶     from invoices
+      9 │ ╭─▶         aggregate {
         ┆ ┆
-     13 │ ├─▶     )
+     11 │ ├─▶         }
         │ │
-        │ ╰─────────── internal compiler error; tracked at https://github.com/PRQL/prql/issues/3870
+        │ ╰─────────────── internal compiler error; tracked at https://github.com/PRQL/prql/issues/3870
     ────╯
     "###);
 }

--- a/prqlc/prqlc/tests/integration/queries.rs
+++ b/prqlc/prqlc/tests/integration/queries.rs
@@ -80,7 +80,7 @@ mod debug_lineage {
         let pl = prqlc::prql_to_pl(&prql).unwrap();
         let fc = prqlc::debug::pl_to_lineage(pl).unwrap();
 
-        let lineage = prqlc::debug::json::from_lineage(&fc).unwrap();
+        let lineage = serde_yaml::to_string(&fc).unwrap();
 
         with_settings!({ input_file => prql_path }, {
             assert_snapshot!(test_name, &lineage, &prql)

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__aggregation.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__aggregation.snap
@@ -3,4 +3,258 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:skip\n# mysql:skip\n# clickhouse:skip\n# glaredb:skip (the string_agg function is not supported)\nfrom tracks\nfilter genre_id == 100\nderive empty_name = name == ''\naggregate {sum track_id, concat_array name, all empty_name, any empty_name}\n"
 input_file: prqlc/prqlc/tests/integration/queries/aggregation.prql
 ---
-{"frames":[["1:114-136",{"columns":[{"All":{"input_id":124,"except":[]}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:137-167",{"columns":[{"All":{"input_id":124,"except":[]}},{"Single":{"name":["empty_name"],"target_id":131,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:168-243",{"columns":[{"Single":{"name":null,"target_id":137,"target_name":null}},{"Single":{"name":null,"target_id":140,"target_name":null}},{"Single":{"name":null,"target_id":143,"target_name":null}},{"Single":{"name":null,"target_id":146,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":124,"kind":"Ident","span":"1:102-113","ident":{"Ident":["default_db","tracks"]},"parent":130},{"id":126,"kind":"RqOperator","span":"1:121-136","targets":[128,129],"parent":130},{"id":128,"kind":"Ident","span":"1:121-129","ident":{"Ident":["this","tracks","genre_id"]},"targets":[124]},{"id":129,"kind":"Literal","span":"1:133-136"},{"id":130,"kind":"TransformCall: Filter","span":"1:114-136","children":[124,126],"parent":136},{"id":131,"kind":"RqOperator","span":"1:157-167","alias":"empty_name","targets":[133,134],"parent":135},{"id":133,"kind":"Ident","span":"1:157-161","ident":{"Ident":["this","tracks","name"]},"targets":[124]},{"id":134,"kind":"Literal","span":"1:165-167"},{"id":135,"kind":"Tuple","span":"1:157-167","children":[131],"parent":136},{"id":136,"kind":"TransformCall: Derive","span":"1:137-167","children":[130,135],"parent":150},{"id":137,"kind":"RqOperator","span":"1:179-191","targets":[139],"parent":149},{"id":139,"kind":"Ident","span":"1:183-191","ident":{"Ident":["this","tracks","track_id"]},"targets":[124]},{"id":140,"kind":"RqOperator","span":"1:193-210","targets":[142],"parent":149},{"id":142,"kind":"Ident","span":"1:206-210","ident":{"Ident":["this","tracks","name"]},"targets":[124]},{"id":143,"kind":"RqOperator","span":"1:212-226","targets":[145],"parent":149},{"id":145,"kind":"Ident","span":"1:216-226","ident":{"Ident":["this","empty_name"]},"targets":[131]},{"id":146,"kind":"RqOperator","span":"1:228-242","targets":[148],"parent":149},{"id":148,"kind":"Ident","span":"1:232-242","ident":{"Ident":["this","empty_name"]},"targets":[131]},{"id":149,"kind":"Tuple","span":"1:178-243","children":[137,140,143,146],"parent":150},{"id":150,"kind":"TransformCall: Aggregate","span":"1:168-243","children":[136,149]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Binary":{"left":{"Ident":"genre_id"},"op":"Eq","right":{"Literal":{"Integer":100}}}}]}},{"FuncCall":{"name":{"Ident":"derive"},"args":[{"Binary":{"left":{"Ident":"name"},"op":"Eq","right":{"Literal":{"String":""}}},"alias":"empty_name"}]}},{"FuncCall":{"name":{"Ident":"aggregate"},"args":[{"Tuple":[{"FuncCall":{"name":{"Ident":"sum"},"args":[{"Ident":"track_id"}]}},{"FuncCall":{"name":{"Ident":"concat_array"},"args":[{"Ident":"name"}]}},{"FuncCall":{"name":{"Ident":"all"},"args":[{"Ident":"empty_name"}]}},{"FuncCall":{"name":{"Ident":"any"},"args":[{"Ident":"empty_name"}]}}]}]}}]}}},"span":"1:102-244"}]}}
+frames:
+- - 1:114-136
+  - columns:
+    - !All
+      input_id: 124
+      except: []
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:137-167
+  - columns:
+    - !All
+      input_id: 124
+      except: []
+    - !Single
+      name:
+      - empty_name
+      target_id: 131
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:168-243
+  - columns:
+    - !Single
+      name: null
+      target_id: 137
+      target_name: null
+    - !Single
+      name: null
+      target_id: 140
+      target_name: null
+    - !Single
+      name: null
+      target_id: 143
+      target_name: null
+    - !Single
+      name: null
+      target_id: 146
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 124
+  kind: Ident
+  span: 1:102-113
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 130
+- id: 126
+  kind: RqOperator
+  span: 1:121-136
+  targets:
+  - 128
+  - 129
+  parent: 130
+- id: 128
+  kind: Ident
+  span: 1:121-129
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 124
+- id: 129
+  kind: Literal
+  span: 1:133-136
+- id: 130
+  kind: 'TransformCall: Filter'
+  span: 1:114-136
+  children:
+  - 124
+  - 126
+  parent: 136
+- id: 131
+  kind: RqOperator
+  span: 1:157-167
+  alias: empty_name
+  targets:
+  - 133
+  - 134
+  parent: 135
+- id: 133
+  kind: Ident
+  span: 1:157-161
+  ident: !Ident
+  - this
+  - tracks
+  - name
+  targets:
+  - 124
+- id: 134
+  kind: Literal
+  span: 1:165-167
+- id: 135
+  kind: Tuple
+  span: 1:157-167
+  children:
+  - 131
+  parent: 136
+- id: 136
+  kind: 'TransformCall: Derive'
+  span: 1:137-167
+  children:
+  - 130
+  - 135
+  parent: 150
+- id: 137
+  kind: RqOperator
+  span: 1:179-191
+  targets:
+  - 139
+  parent: 149
+- id: 139
+  kind: Ident
+  span: 1:183-191
+  ident: !Ident
+  - this
+  - tracks
+  - track_id
+  targets:
+  - 124
+- id: 140
+  kind: RqOperator
+  span: 1:193-210
+  targets:
+  - 142
+  parent: 149
+- id: 142
+  kind: Ident
+  span: 1:206-210
+  ident: !Ident
+  - this
+  - tracks
+  - name
+  targets:
+  - 124
+- id: 143
+  kind: RqOperator
+  span: 1:212-226
+  targets:
+  - 145
+  parent: 149
+- id: 145
+  kind: Ident
+  span: 1:216-226
+  ident: !Ident
+  - this
+  - empty_name
+  targets:
+  - 131
+- id: 146
+  kind: RqOperator
+  span: 1:228-242
+  targets:
+  - 148
+  parent: 149
+- id: 148
+  kind: Ident
+  span: 1:232-242
+  ident: !Ident
+  - this
+  - empty_name
+  targets:
+  - 131
+- id: 149
+  kind: Tuple
+  span: 1:178-243
+  children:
+  - 137
+  - 140
+  - 143
+  - 146
+  parent: 150
+- id: 150
+  kind: 'TransformCall: Aggregate'
+  span: 1:168-243
+  children:
+  - 136
+  - 149
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Binary:
+                  left:
+                    Ident: genre_id
+                  op: Eq
+                  right:
+                    Literal:
+                      Integer: 100
+          - FuncCall:
+              name:
+                Ident: derive
+              args:
+              - Binary:
+                  left:
+                    Ident: name
+                  op: Eq
+                  right:
+                    Literal:
+                      String: ''
+                alias: empty_name
+          - FuncCall:
+              name:
+                Ident: aggregate
+              args:
+              - Tuple:
+                - FuncCall:
+                    name:
+                      Ident: sum
+                    args:
+                    - Ident: track_id
+                - FuncCall:
+                    name:
+                      Ident: concat_array
+                    args:
+                    - Ident: name
+                - FuncCall:
+                    name:
+                      Ident: all
+                    args:
+                    - Ident: empty_name
+                - FuncCall:
+                    name:
+                      Ident: any
+                    args:
+                    - Ident: empty_name
+    span: 1:102-244

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__arithmetic.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__arithmetic.snap
@@ -3,4 +3,1159 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom [\n    { id = 1, x_int =  13, x_float =  13.0, k_int =  5, k_float =  5.0 },\n    { id = 2, x_int = -13, x_float = -13.0, k_int =  5, k_float =  5.0 },\n    { id = 3, x_int =  13, x_float =  13.0, k_int = -5, k_float = -5.0 },\n    { id = 4, x_int = -13, x_float = -13.0, k_int = -5, k_float = -5.0 },\n]\nselect {\n    id,\n\n    x_int / k_int,\n    x_int / k_float,\n    x_float / k_int,\n    x_float / k_float,\n\n    q_ii = x_int // k_int,\n    q_if = x_int // k_float,\n    q_fi = x_float // k_int,\n    q_ff = x_float // k_float,\n\n    r_ii = x_int % k_int,\n    r_if = x_int % k_float,\n    r_fi = x_float % k_int,\n    r_ff = x_float % k_float,\n\n    (q_ii * k_int + r_ii | math.round 0),\n    (q_if * k_float + r_if | math.round 0),\n    (q_fi * k_int + r_fi | math.round 0),\n    (q_ff * k_float + r_ff | math.round 0),\n}\nsort id\n"
 input_file: prqlc/prqlc/tests/integration/queries/arithmetic.prql
 ---
-{"frames":[["1:318-824",{"columns":[{"Single":{"name":["_literal_121","id"],"target_id":163,"target_name":null}},{"Single":{"name":null,"target_id":164,"target_name":null}},{"Single":{"name":null,"target_id":168,"target_name":null}},{"Single":{"name":null,"target_id":172,"target_name":null}},{"Single":{"name":null,"target_id":176,"target_name":null}},{"Single":{"name":["q_ii"],"target_id":180,"target_name":null}},{"Single":{"name":["q_if"],"target_id":184,"target_name":null}},{"Single":{"name":["q_fi"],"target_id":188,"target_name":null}},{"Single":{"name":["q_ff"],"target_id":192,"target_name":null}},{"Single":{"name":["r_ii"],"target_id":196,"target_name":null}},{"Single":{"name":["r_if"],"target_id":200,"target_name":null}},{"Single":{"name":["r_fi"],"target_id":204,"target_name":null}},{"Single":{"name":["r_ff"],"target_id":208,"target_name":null}},{"Single":{"name":null,"target_id":212,"target_name":null}},{"Single":{"name":null,"target_id":223,"target_name":null}},{"Single":{"name":null,"target_id":234,"target_name":null}},{"Single":{"name":null,"target_id":245,"target_name":null}}],"inputs":[{"id":121,"name":"_literal_121","table":["default_db","_literal_121"]}]}],["1:825-832",{"columns":[{"Single":{"name":["_literal_121","id"],"target_id":163,"target_name":null}},{"Single":{"name":null,"target_id":164,"target_name":null}},{"Single":{"name":null,"target_id":168,"target_name":null}},{"Single":{"name":null,"target_id":172,"target_name":null}},{"Single":{"name":null,"target_id":176,"target_name":null}},{"Single":{"name":["q_ii"],"target_id":180,"target_name":null}},{"Single":{"name":["q_if"],"target_id":184,"target_name":null}},{"Single":{"name":["q_fi"],"target_id":188,"target_name":null}},{"Single":{"name":["q_ff"],"target_id":192,"target_name":null}},{"Single":{"name":["r_ii"],"target_id":196,"target_name":null}},{"Single":{"name":["r_if"],"target_id":200,"target_name":null}},{"Single":{"name":["r_fi"],"target_id":204,"target_name":null}},{"Single":{"name":["r_ff"],"target_id":208,"target_name":null}},{"Single":{"name":null,"target_id":212,"target_name":null}},{"Single":{"name":null,"target_id":223,"target_name":null}},{"Single":{"name":null,"target_id":234,"target_name":null}},{"Single":{"name":null,"target_id":245,"target_name":null}}],"inputs":[{"id":121,"name":"_literal_121","table":["default_db","_literal_121"]}]}]],"nodes":[{"id":121,"kind":"Array","span":"1:13-317","children":[122,128,138,148],"parent":257},{"id":122,"kind":"Tuple","span":"1:24-92","children":[123,124,125,126,127],"parent":121},{"id":123,"kind":"Literal","span":"1:31-32","alias":"id","parent":122},{"id":124,"kind":"Literal","span":"1:43-45","alias":"x_int","parent":122},{"id":125,"kind":"Literal","span":"1:58-62","alias":"x_float","parent":122},{"id":126,"kind":"Literal","span":"1:73-74","alias":"k_int","parent":122},{"id":127,"kind":"Literal","span":"1:87-90","alias":"k_float","parent":122},{"id":128,"kind":"Tuple","span":"1:98-166","children":[129,130,133,136,137],"parent":121},{"id":129,"kind":"Literal","span":"1:105-106","alias":"id","parent":128},{"id":130,"kind":"Literal","span":"1:116-119","alias":"x_int","parent":128},{"id":133,"kind":"Literal","span":"1:131-136","alias":"x_float","parent":128},{"id":136,"kind":"Literal","span":"1:147-148","alias":"k_int","parent":128},{"id":137,"kind":"Literal","span":"1:161-164","alias":"k_float","parent":128},{"id":138,"kind":"Tuple","span":"1:172-240","children":[139,140,141,142,145],"parent":121},{"id":139,"kind":"Literal","span":"1:179-180","alias":"id","parent":138},{"id":140,"kind":"Literal","span":"1:191-193","alias":"x_int","parent":138},{"id":141,"kind":"Literal","span":"1:206-210","alias":"x_float","parent":138},{"id":142,"kind":"Literal","span":"1:220-222","alias":"k_int","parent":138},{"id":145,"kind":"Literal","span":"1:234-238","alias":"k_float","parent":138},{"id":148,"kind":"Tuple","span":"1:246-314","children":[149,150,153,156,159],"parent":121},{"id":149,"kind":"Literal","span":"1:253-254","alias":"id","parent":148},{"id":150,"kind":"Literal","span":"1:264-267","alias":"x_int","parent":148},{"id":153,"kind":"Literal","span":"1:279-284","alias":"x_float","parent":148},{"id":156,"kind":"Literal","span":"1:294-296","alias":"k_int","parent":148},{"id":159,"kind":"Literal","span":"1:308-312","alias":"k_float","parent":148},{"id":163,"kind":"Ident","span":"1:331-333","ident":{"Ident":["this","_literal_121","id"]},"targets":[121],"parent":256},{"id":164,"kind":"RqOperator","span":"1:340-353","targets":[166,167],"parent":256},{"id":166,"kind":"Ident","span":"1:340-345","ident":{"Ident":["this","_literal_121","x_int"]},"targets":[121]},{"id":167,"kind":"Ident","span":"1:348-353","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":168,"kind":"RqOperator","span":"1:359-374","targets":[170,171],"parent":256},{"id":170,"kind":"Ident","span":"1:359-364","ident":{"Ident":["this","_literal_121","x_int"]},"targets":[121]},{"id":171,"kind":"Ident","span":"1:367-374","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":172,"kind":"RqOperator","span":"1:380-395","targets":[174,175],"parent":256},{"id":174,"kind":"Ident","span":"1:380-387","ident":{"Ident":["this","_literal_121","x_float"]},"targets":[121]},{"id":175,"kind":"Ident","span":"1:390-395","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":176,"kind":"RqOperator","span":"1:401-418","targets":[178,179],"parent":256},{"id":178,"kind":"Ident","span":"1:401-408","ident":{"Ident":["this","_literal_121","x_float"]},"targets":[121]},{"id":179,"kind":"Ident","span":"1:411-418","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":180,"kind":"RqOperator","span":"1:432-446","alias":"q_ii","targets":[182,183],"parent":256},{"id":182,"kind":"Ident","span":"1:432-437","ident":{"Ident":["this","_literal_121","x_int"]},"targets":[121]},{"id":183,"kind":"Ident","span":"1:441-446","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":184,"kind":"RqOperator","span":"1:459-475","alias":"q_if","targets":[186,187],"parent":256},{"id":186,"kind":"Ident","span":"1:459-464","ident":{"Ident":["this","_literal_121","x_int"]},"targets":[121]},{"id":187,"kind":"Ident","span":"1:468-475","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":188,"kind":"RqOperator","span":"1:488-504","alias":"q_fi","targets":[190,191],"parent":256},{"id":190,"kind":"Ident","span":"1:488-495","ident":{"Ident":["this","_literal_121","x_float"]},"targets":[121]},{"id":191,"kind":"Ident","span":"1:499-504","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":192,"kind":"RqOperator","span":"1:517-535","alias":"q_ff","targets":[194,195],"parent":256},{"id":194,"kind":"Ident","span":"1:517-524","ident":{"Ident":["this","_literal_121","x_float"]},"targets":[121]},{"id":195,"kind":"Ident","span":"1:528-535","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":196,"kind":"RqOperator","span":"1:549-562","alias":"r_ii","targets":[198,199],"parent":256},{"id":198,"kind":"Ident","span":"1:549-554","ident":{"Ident":["this","_literal_121","x_int"]},"targets":[121]},{"id":199,"kind":"Ident","span":"1:557-562","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":200,"kind":"RqOperator","span":"1:575-590","alias":"r_if","targets":[202,203],"parent":256},{"id":202,"kind":"Ident","span":"1:575-580","ident":{"Ident":["this","_literal_121","x_int"]},"targets":[121]},{"id":203,"kind":"Ident","span":"1:583-590","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":204,"kind":"RqOperator","span":"1:603-618","alias":"r_fi","targets":[206,207],"parent":256},{"id":206,"kind":"Ident","span":"1:603-610","ident":{"Ident":["this","_literal_121","x_float"]},"targets":[121]},{"id":207,"kind":"Ident","span":"1:613-618","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":208,"kind":"RqOperator","span":"1:631-648","alias":"r_ff","targets":[210,211],"parent":256},{"id":210,"kind":"Ident","span":"1:631-638","ident":{"Ident":["this","_literal_121","x_float"]},"targets":[121]},{"id":211,"kind":"Ident","span":"1:641-648","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":212,"kind":"RqOperator","span":"1:678-690","targets":[215,216],"parent":256},{"id":215,"kind":"Literal","span":"1:689-690"},{"id":216,"kind":"RqOperator","span":"1:656-675","targets":[218,222]},{"id":218,"kind":"RqOperator","span":"1:656-668","targets":[220,221]},{"id":220,"kind":"Ident","span":"1:656-660","ident":{"Ident":["this","q_ii"]},"targets":[180]},{"id":221,"kind":"Ident","span":"1:663-668","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":222,"kind":"Ident","span":"1:671-675","ident":{"Ident":["this","r_ii"]},"targets":[196]},{"id":223,"kind":"RqOperator","span":"1:722-734","targets":[226,227],"parent":256},{"id":226,"kind":"Literal","span":"1:733-734"},{"id":227,"kind":"RqOperator","span":"1:698-719","targets":[229,233]},{"id":229,"kind":"RqOperator","span":"1:698-712","targets":[231,232]},{"id":231,"kind":"Ident","span":"1:698-702","ident":{"Ident":["this","q_if"]},"targets":[184]},{"id":232,"kind":"Ident","span":"1:705-712","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":233,"kind":"Ident","span":"1:715-719","ident":{"Ident":["this","r_if"]},"targets":[200]},{"id":234,"kind":"RqOperator","span":"1:764-776","targets":[237,238],"parent":256},{"id":237,"kind":"Literal","span":"1:775-776"},{"id":238,"kind":"RqOperator","span":"1:742-761","targets":[240,244]},{"id":240,"kind":"RqOperator","span":"1:742-754","targets":[242,243]},{"id":242,"kind":"Ident","span":"1:742-746","ident":{"Ident":["this","q_fi"]},"targets":[188]},{"id":243,"kind":"Ident","span":"1:749-754","ident":{"Ident":["this","_literal_121","k_int"]},"targets":[121]},{"id":244,"kind":"Ident","span":"1:757-761","ident":{"Ident":["this","r_fi"]},"targets":[204]},{"id":245,"kind":"RqOperator","span":"1:808-820","targets":[248,249],"parent":256},{"id":248,"kind":"Literal","span":"1:819-820"},{"id":249,"kind":"RqOperator","span":"1:784-805","targets":[251,255]},{"id":251,"kind":"RqOperator","span":"1:784-798","targets":[253,254]},{"id":253,"kind":"Ident","span":"1:784-788","ident":{"Ident":["this","q_ff"]},"targets":[192]},{"id":254,"kind":"Ident","span":"1:791-798","ident":{"Ident":["this","_literal_121","k_float"]},"targets":[121]},{"id":255,"kind":"Ident","span":"1:801-805","ident":{"Ident":["this","r_ff"]},"targets":[208]},{"id":256,"kind":"Tuple","span":"1:325-824","children":[163,164,168,172,176,180,184,188,192,196,200,204,208,212,223,234,245],"parent":257},{"id":257,"kind":"TransformCall: Select","span":"1:318-824","children":[121,256],"parent":260},{"id":258,"kind":"Ident","span":"1:830-832","ident":{"Ident":["this","_literal_121","id"]},"targets":[163],"parent":260},{"id":260,"kind":"TransformCall: Sort","span":"1:825-832","children":[257,258]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Array":[{"Tuple":[{"Literal":{"Integer":1},"alias":"id"},{"Literal":{"Integer":13},"alias":"x_int"},{"Literal":{"Float":13.0},"alias":"x_float"},{"Literal":{"Integer":5},"alias":"k_int"},{"Literal":{"Float":5.0},"alias":"k_float"}]},{"Tuple":[{"Literal":{"Integer":2},"alias":"id"},{"Unary":{"op":"Neg","expr":{"Literal":{"Integer":13}}},"alias":"x_int"},{"Unary":{"op":"Neg","expr":{"Literal":{"Float":13.0}}},"alias":"x_float"},{"Literal":{"Integer":5},"alias":"k_int"},{"Literal":{"Float":5.0},"alias":"k_float"}]},{"Tuple":[{"Literal":{"Integer":3},"alias":"id"},{"Literal":{"Integer":13},"alias":"x_int"},{"Literal":{"Float":13.0},"alias":"x_float"},{"Unary":{"op":"Neg","expr":{"Literal":{"Integer":5}}},"alias":"k_int"},{"Unary":{"op":"Neg","expr":{"Literal":{"Float":5.0}}},"alias":"k_float"}]},{"Tuple":[{"Literal":{"Integer":4},"alias":"id"},{"Unary":{"op":"Neg","expr":{"Literal":{"Integer":13}}},"alias":"x_int"},{"Unary":{"op":"Neg","expr":{"Literal":{"Float":13.0}}},"alias":"x_float"},{"Unary":{"op":"Neg","expr":{"Literal":{"Integer":5}}},"alias":"k_int"},{"Unary":{"op":"Neg","expr":{"Literal":{"Float":5.0}}},"alias":"k_float"}]}]}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"id"},{"Binary":{"left":{"Ident":"x_int"},"op":"DivFloat","right":{"Ident":"k_int"}}},{"Binary":{"left":{"Ident":"x_int"},"op":"DivFloat","right":{"Ident":"k_float"}}},{"Binary":{"left":{"Ident":"x_float"},"op":"DivFloat","right":{"Ident":"k_int"}}},{"Binary":{"left":{"Ident":"x_float"},"op":"DivFloat","right":{"Ident":"k_float"}}},{"Binary":{"left":{"Ident":"x_int"},"op":"DivInt","right":{"Ident":"k_int"}},"alias":"q_ii"},{"Binary":{"left":{"Ident":"x_int"},"op":"DivInt","right":{"Ident":"k_float"}},"alias":"q_if"},{"Binary":{"left":{"Ident":"x_float"},"op":"DivInt","right":{"Ident":"k_int"}},"alias":"q_fi"},{"Binary":{"left":{"Ident":"x_float"},"op":"DivInt","right":{"Ident":"k_float"}},"alias":"q_ff"},{"Binary":{"left":{"Ident":"x_int"},"op":"Mod","right":{"Ident":"k_int"}},"alias":"r_ii"},{"Binary":{"left":{"Ident":"x_int"},"op":"Mod","right":{"Ident":"k_float"}},"alias":"r_if"},{"Binary":{"left":{"Ident":"x_float"},"op":"Mod","right":{"Ident":"k_int"}},"alias":"r_fi"},{"Binary":{"left":{"Ident":"x_float"},"op":"Mod","right":{"Ident":"k_float"}},"alias":"r_ff"},{"Pipeline":{"exprs":[{"Binary":{"left":{"Binary":{"left":{"Ident":"q_ii"},"op":"Mul","right":{"Ident":"k_int"}}},"op":"Add","right":{"Ident":"r_ii"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":0}}]}}]}},{"Pipeline":{"exprs":[{"Binary":{"left":{"Binary":{"left":{"Ident":"q_if"},"op":"Mul","right":{"Ident":"k_float"}}},"op":"Add","right":{"Ident":"r_if"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":0}}]}}]}},{"Pipeline":{"exprs":[{"Binary":{"left":{"Binary":{"left":{"Ident":"q_fi"},"op":"Mul","right":{"Ident":"k_int"}}},"op":"Add","right":{"Ident":"r_fi"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":0}}]}}]}},{"Pipeline":{"exprs":[{"Binary":{"left":{"Binary":{"left":{"Ident":"q_ff"},"op":"Mul","right":{"Ident":"k_float"}}},"op":"Add","right":{"Ident":"r_ff"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":0}}]}}]}}]}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"id"}]}}]}}},"span":"1:13-833"}]}}
+frames:
+- - 1:318-824
+  - columns:
+    - !Single
+      name:
+      - _literal_121
+      - id
+      target_id: 163
+      target_name: null
+    - !Single
+      name: null
+      target_id: 164
+      target_name: null
+    - !Single
+      name: null
+      target_id: 168
+      target_name: null
+    - !Single
+      name: null
+      target_id: 172
+      target_name: null
+    - !Single
+      name: null
+      target_id: 176
+      target_name: null
+    - !Single
+      name:
+      - q_ii
+      target_id: 180
+      target_name: null
+    - !Single
+      name:
+      - q_if
+      target_id: 184
+      target_name: null
+    - !Single
+      name:
+      - q_fi
+      target_id: 188
+      target_name: null
+    - !Single
+      name:
+      - q_ff
+      target_id: 192
+      target_name: null
+    - !Single
+      name:
+      - r_ii
+      target_id: 196
+      target_name: null
+    - !Single
+      name:
+      - r_if
+      target_id: 200
+      target_name: null
+    - !Single
+      name:
+      - r_fi
+      target_id: 204
+      target_name: null
+    - !Single
+      name:
+      - r_ff
+      target_id: 208
+      target_name: null
+    - !Single
+      name: null
+      target_id: 212
+      target_name: null
+    - !Single
+      name: null
+      target_id: 223
+      target_name: null
+    - !Single
+      name: null
+      target_id: 234
+      target_name: null
+    - !Single
+      name: null
+      target_id: 245
+      target_name: null
+    inputs:
+    - id: 121
+      name: _literal_121
+      table:
+      - default_db
+      - _literal_121
+- - 1:825-832
+  - columns:
+    - !Single
+      name:
+      - _literal_121
+      - id
+      target_id: 163
+      target_name: null
+    - !Single
+      name: null
+      target_id: 164
+      target_name: null
+    - !Single
+      name: null
+      target_id: 168
+      target_name: null
+    - !Single
+      name: null
+      target_id: 172
+      target_name: null
+    - !Single
+      name: null
+      target_id: 176
+      target_name: null
+    - !Single
+      name:
+      - q_ii
+      target_id: 180
+      target_name: null
+    - !Single
+      name:
+      - q_if
+      target_id: 184
+      target_name: null
+    - !Single
+      name:
+      - q_fi
+      target_id: 188
+      target_name: null
+    - !Single
+      name:
+      - q_ff
+      target_id: 192
+      target_name: null
+    - !Single
+      name:
+      - r_ii
+      target_id: 196
+      target_name: null
+    - !Single
+      name:
+      - r_if
+      target_id: 200
+      target_name: null
+    - !Single
+      name:
+      - r_fi
+      target_id: 204
+      target_name: null
+    - !Single
+      name:
+      - r_ff
+      target_id: 208
+      target_name: null
+    - !Single
+      name: null
+      target_id: 212
+      target_name: null
+    - !Single
+      name: null
+      target_id: 223
+      target_name: null
+    - !Single
+      name: null
+      target_id: 234
+      target_name: null
+    - !Single
+      name: null
+      target_id: 245
+      target_name: null
+    inputs:
+    - id: 121
+      name: _literal_121
+      table:
+      - default_db
+      - _literal_121
+nodes:
+- id: 121
+  kind: Array
+  span: 1:13-317
+  children:
+  - 122
+  - 128
+  - 138
+  - 148
+  parent: 257
+- id: 122
+  kind: Tuple
+  span: 1:24-92
+  children:
+  - 123
+  - 124
+  - 125
+  - 126
+  - 127
+  parent: 121
+- id: 123
+  kind: Literal
+  span: 1:31-32
+  alias: id
+  parent: 122
+- id: 124
+  kind: Literal
+  span: 1:43-45
+  alias: x_int
+  parent: 122
+- id: 125
+  kind: Literal
+  span: 1:58-62
+  alias: x_float
+  parent: 122
+- id: 126
+  kind: Literal
+  span: 1:73-74
+  alias: k_int
+  parent: 122
+- id: 127
+  kind: Literal
+  span: 1:87-90
+  alias: k_float
+  parent: 122
+- id: 128
+  kind: Tuple
+  span: 1:98-166
+  children:
+  - 129
+  - 130
+  - 133
+  - 136
+  - 137
+  parent: 121
+- id: 129
+  kind: Literal
+  span: 1:105-106
+  alias: id
+  parent: 128
+- id: 130
+  kind: Literal
+  span: 1:116-119
+  alias: x_int
+  parent: 128
+- id: 133
+  kind: Literal
+  span: 1:131-136
+  alias: x_float
+  parent: 128
+- id: 136
+  kind: Literal
+  span: 1:147-148
+  alias: k_int
+  parent: 128
+- id: 137
+  kind: Literal
+  span: 1:161-164
+  alias: k_float
+  parent: 128
+- id: 138
+  kind: Tuple
+  span: 1:172-240
+  children:
+  - 139
+  - 140
+  - 141
+  - 142
+  - 145
+  parent: 121
+- id: 139
+  kind: Literal
+  span: 1:179-180
+  alias: id
+  parent: 138
+- id: 140
+  kind: Literal
+  span: 1:191-193
+  alias: x_int
+  parent: 138
+- id: 141
+  kind: Literal
+  span: 1:206-210
+  alias: x_float
+  parent: 138
+- id: 142
+  kind: Literal
+  span: 1:220-222
+  alias: k_int
+  parent: 138
+- id: 145
+  kind: Literal
+  span: 1:234-238
+  alias: k_float
+  parent: 138
+- id: 148
+  kind: Tuple
+  span: 1:246-314
+  children:
+  - 149
+  - 150
+  - 153
+  - 156
+  - 159
+  parent: 121
+- id: 149
+  kind: Literal
+  span: 1:253-254
+  alias: id
+  parent: 148
+- id: 150
+  kind: Literal
+  span: 1:264-267
+  alias: x_int
+  parent: 148
+- id: 153
+  kind: Literal
+  span: 1:279-284
+  alias: x_float
+  parent: 148
+- id: 156
+  kind: Literal
+  span: 1:294-296
+  alias: k_int
+  parent: 148
+- id: 159
+  kind: Literal
+  span: 1:308-312
+  alias: k_float
+  parent: 148
+- id: 163
+  kind: Ident
+  span: 1:331-333
+  ident: !Ident
+  - this
+  - _literal_121
+  - id
+  targets:
+  - 121
+  parent: 256
+- id: 164
+  kind: RqOperator
+  span: 1:340-353
+  targets:
+  - 166
+  - 167
+  parent: 256
+- id: 166
+  kind: Ident
+  span: 1:340-345
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_int
+  targets:
+  - 121
+- id: 167
+  kind: Ident
+  span: 1:348-353
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 168
+  kind: RqOperator
+  span: 1:359-374
+  targets:
+  - 170
+  - 171
+  parent: 256
+- id: 170
+  kind: Ident
+  span: 1:359-364
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_int
+  targets:
+  - 121
+- id: 171
+  kind: Ident
+  span: 1:367-374
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 172
+  kind: RqOperator
+  span: 1:380-395
+  targets:
+  - 174
+  - 175
+  parent: 256
+- id: 174
+  kind: Ident
+  span: 1:380-387
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_float
+  targets:
+  - 121
+- id: 175
+  kind: Ident
+  span: 1:390-395
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 176
+  kind: RqOperator
+  span: 1:401-418
+  targets:
+  - 178
+  - 179
+  parent: 256
+- id: 178
+  kind: Ident
+  span: 1:401-408
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_float
+  targets:
+  - 121
+- id: 179
+  kind: Ident
+  span: 1:411-418
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 180
+  kind: RqOperator
+  span: 1:432-446
+  alias: q_ii
+  targets:
+  - 182
+  - 183
+  parent: 256
+- id: 182
+  kind: Ident
+  span: 1:432-437
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_int
+  targets:
+  - 121
+- id: 183
+  kind: Ident
+  span: 1:441-446
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 184
+  kind: RqOperator
+  span: 1:459-475
+  alias: q_if
+  targets:
+  - 186
+  - 187
+  parent: 256
+- id: 186
+  kind: Ident
+  span: 1:459-464
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_int
+  targets:
+  - 121
+- id: 187
+  kind: Ident
+  span: 1:468-475
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 188
+  kind: RqOperator
+  span: 1:488-504
+  alias: q_fi
+  targets:
+  - 190
+  - 191
+  parent: 256
+- id: 190
+  kind: Ident
+  span: 1:488-495
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_float
+  targets:
+  - 121
+- id: 191
+  kind: Ident
+  span: 1:499-504
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 192
+  kind: RqOperator
+  span: 1:517-535
+  alias: q_ff
+  targets:
+  - 194
+  - 195
+  parent: 256
+- id: 194
+  kind: Ident
+  span: 1:517-524
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_float
+  targets:
+  - 121
+- id: 195
+  kind: Ident
+  span: 1:528-535
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 196
+  kind: RqOperator
+  span: 1:549-562
+  alias: r_ii
+  targets:
+  - 198
+  - 199
+  parent: 256
+- id: 198
+  kind: Ident
+  span: 1:549-554
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_int
+  targets:
+  - 121
+- id: 199
+  kind: Ident
+  span: 1:557-562
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 200
+  kind: RqOperator
+  span: 1:575-590
+  alias: r_if
+  targets:
+  - 202
+  - 203
+  parent: 256
+- id: 202
+  kind: Ident
+  span: 1:575-580
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_int
+  targets:
+  - 121
+- id: 203
+  kind: Ident
+  span: 1:583-590
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 204
+  kind: RqOperator
+  span: 1:603-618
+  alias: r_fi
+  targets:
+  - 206
+  - 207
+  parent: 256
+- id: 206
+  kind: Ident
+  span: 1:603-610
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_float
+  targets:
+  - 121
+- id: 207
+  kind: Ident
+  span: 1:613-618
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 208
+  kind: RqOperator
+  span: 1:631-648
+  alias: r_ff
+  targets:
+  - 210
+  - 211
+  parent: 256
+- id: 210
+  kind: Ident
+  span: 1:631-638
+  ident: !Ident
+  - this
+  - _literal_121
+  - x_float
+  targets:
+  - 121
+- id: 211
+  kind: Ident
+  span: 1:641-648
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 212
+  kind: RqOperator
+  span: 1:678-690
+  targets:
+  - 215
+  - 216
+  parent: 256
+- id: 215
+  kind: Literal
+  span: 1:689-690
+- id: 216
+  kind: RqOperator
+  span: 1:656-675
+  targets:
+  - 218
+  - 222
+- id: 218
+  kind: RqOperator
+  span: 1:656-668
+  targets:
+  - 220
+  - 221
+- id: 220
+  kind: Ident
+  span: 1:656-660
+  ident: !Ident
+  - this
+  - q_ii
+  targets:
+  - 180
+- id: 221
+  kind: Ident
+  span: 1:663-668
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 222
+  kind: Ident
+  span: 1:671-675
+  ident: !Ident
+  - this
+  - r_ii
+  targets:
+  - 196
+- id: 223
+  kind: RqOperator
+  span: 1:722-734
+  targets:
+  - 226
+  - 227
+  parent: 256
+- id: 226
+  kind: Literal
+  span: 1:733-734
+- id: 227
+  kind: RqOperator
+  span: 1:698-719
+  targets:
+  - 229
+  - 233
+- id: 229
+  kind: RqOperator
+  span: 1:698-712
+  targets:
+  - 231
+  - 232
+- id: 231
+  kind: Ident
+  span: 1:698-702
+  ident: !Ident
+  - this
+  - q_if
+  targets:
+  - 184
+- id: 232
+  kind: Ident
+  span: 1:705-712
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 233
+  kind: Ident
+  span: 1:715-719
+  ident: !Ident
+  - this
+  - r_if
+  targets:
+  - 200
+- id: 234
+  kind: RqOperator
+  span: 1:764-776
+  targets:
+  - 237
+  - 238
+  parent: 256
+- id: 237
+  kind: Literal
+  span: 1:775-776
+- id: 238
+  kind: RqOperator
+  span: 1:742-761
+  targets:
+  - 240
+  - 244
+- id: 240
+  kind: RqOperator
+  span: 1:742-754
+  targets:
+  - 242
+  - 243
+- id: 242
+  kind: Ident
+  span: 1:742-746
+  ident: !Ident
+  - this
+  - q_fi
+  targets:
+  - 188
+- id: 243
+  kind: Ident
+  span: 1:749-754
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_int
+  targets:
+  - 121
+- id: 244
+  kind: Ident
+  span: 1:757-761
+  ident: !Ident
+  - this
+  - r_fi
+  targets:
+  - 204
+- id: 245
+  kind: RqOperator
+  span: 1:808-820
+  targets:
+  - 248
+  - 249
+  parent: 256
+- id: 248
+  kind: Literal
+  span: 1:819-820
+- id: 249
+  kind: RqOperator
+  span: 1:784-805
+  targets:
+  - 251
+  - 255
+- id: 251
+  kind: RqOperator
+  span: 1:784-798
+  targets:
+  - 253
+  - 254
+- id: 253
+  kind: Ident
+  span: 1:784-788
+  ident: !Ident
+  - this
+  - q_ff
+  targets:
+  - 192
+- id: 254
+  kind: Ident
+  span: 1:791-798
+  ident: !Ident
+  - this
+  - _literal_121
+  - k_float
+  targets:
+  - 121
+- id: 255
+  kind: Ident
+  span: 1:801-805
+  ident: !Ident
+  - this
+  - r_ff
+  targets:
+  - 208
+- id: 256
+  kind: Tuple
+  span: 1:325-824
+  children:
+  - 163
+  - 164
+  - 168
+  - 172
+  - 176
+  - 180
+  - 184
+  - 188
+  - 192
+  - 196
+  - 200
+  - 204
+  - 208
+  - 212
+  - 223
+  - 234
+  - 245
+  parent: 257
+- id: 257
+  kind: 'TransformCall: Select'
+  span: 1:318-824
+  children:
+  - 121
+  - 256
+  parent: 260
+- id: 258
+  kind: Ident
+  span: 1:830-832
+  ident: !Ident
+  - this
+  - _literal_121
+  - id
+  targets:
+  - 163
+  parent: 260
+- id: 260
+  kind: 'TransformCall: Sort'
+  span: 1:825-832
+  children:
+  - 257
+  - 258
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Array:
+                - Tuple:
+                  - Literal:
+                      Integer: 1
+                    alias: id
+                  - Literal:
+                      Integer: 13
+                    alias: x_int
+                  - Literal:
+                      Float: 13.0
+                    alias: x_float
+                  - Literal:
+                      Integer: 5
+                    alias: k_int
+                  - Literal:
+                      Float: 5.0
+                    alias: k_float
+                - Tuple:
+                  - Literal:
+                      Integer: 2
+                    alias: id
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Integer: 13
+                    alias: x_int
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Float: 13.0
+                    alias: x_float
+                  - Literal:
+                      Integer: 5
+                    alias: k_int
+                  - Literal:
+                      Float: 5.0
+                    alias: k_float
+                - Tuple:
+                  - Literal:
+                      Integer: 3
+                    alias: id
+                  - Literal:
+                      Integer: 13
+                    alias: x_int
+                  - Literal:
+                      Float: 13.0
+                    alias: x_float
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Integer: 5
+                    alias: k_int
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Float: 5.0
+                    alias: k_float
+                - Tuple:
+                  - Literal:
+                      Integer: 4
+                    alias: id
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Integer: 13
+                    alias: x_int
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Float: 13.0
+                    alias: x_float
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Integer: 5
+                    alias: k_int
+                  - Unary:
+                      op: Neg
+                      expr:
+                        Literal:
+                          Float: 5.0
+                    alias: k_float
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: id
+                - Binary:
+                    left:
+                      Ident: x_int
+                    op: DivFloat
+                    right:
+                      Ident: k_int
+                - Binary:
+                    left:
+                      Ident: x_int
+                    op: DivFloat
+                    right:
+                      Ident: k_float
+                - Binary:
+                    left:
+                      Ident: x_float
+                    op: DivFloat
+                    right:
+                      Ident: k_int
+                - Binary:
+                    left:
+                      Ident: x_float
+                    op: DivFloat
+                    right:
+                      Ident: k_float
+                - Binary:
+                    left:
+                      Ident: x_int
+                    op: DivInt
+                    right:
+                      Ident: k_int
+                  alias: q_ii
+                - Binary:
+                    left:
+                      Ident: x_int
+                    op: DivInt
+                    right:
+                      Ident: k_float
+                  alias: q_if
+                - Binary:
+                    left:
+                      Ident: x_float
+                    op: DivInt
+                    right:
+                      Ident: k_int
+                  alias: q_fi
+                - Binary:
+                    left:
+                      Ident: x_float
+                    op: DivInt
+                    right:
+                      Ident: k_float
+                  alias: q_ff
+                - Binary:
+                    left:
+                      Ident: x_int
+                    op: Mod
+                    right:
+                      Ident: k_int
+                  alias: r_ii
+                - Binary:
+                    left:
+                      Ident: x_int
+                    op: Mod
+                    right:
+                      Ident: k_float
+                  alias: r_if
+                - Binary:
+                    left:
+                      Ident: x_float
+                    op: Mod
+                    right:
+                      Ident: k_int
+                  alias: r_fi
+                - Binary:
+                    left:
+                      Ident: x_float
+                    op: Mod
+                    right:
+                      Ident: k_float
+                  alias: r_ff
+                - Pipeline:
+                    exprs:
+                    - Binary:
+                        left:
+                          Binary:
+                            left:
+                              Ident: q_ii
+                            op: Mul
+                            right:
+                              Ident: k_int
+                        op: Add
+                        right:
+                          Ident: r_ii
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 0
+                - Pipeline:
+                    exprs:
+                    - Binary:
+                        left:
+                          Binary:
+                            left:
+                              Ident: q_if
+                            op: Mul
+                            right:
+                              Ident: k_float
+                        op: Add
+                        right:
+                          Ident: r_if
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 0
+                - Pipeline:
+                    exprs:
+                    - Binary:
+                        left:
+                          Binary:
+                            left:
+                              Ident: q_fi
+                            op: Mul
+                            right:
+                              Ident: k_int
+                        op: Add
+                        right:
+                          Ident: r_fi
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 0
+                - Pipeline:
+                    exprs:
+                    - Binary:
+                        left:
+                          Binary:
+                            left:
+                              Ident: q_ff
+                            op: Mul
+                            right:
+                              Ident: k_float
+                        op: Add
+                        right:
+                          Ident: r_ff
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 0
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: id
+    span: 1:13-833

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__cast.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__cast.snap
@@ -3,4 +3,187 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom tracks\nsort {-bytes}\nselect {\n    name,\n    bin = ((album_id | as REAL) * 99)\n}\ntake 20\n"
 input_file: prqlc/prqlc/tests/integration/queries/cast.prql
 ---
-{"frames":[["1:25-38",{"columns":[{"All":{"input_id":124,"except":[]}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:39-97",{"columns":[{"Single":{"name":["tracks","name"],"target_id":131,"target_name":null}},{"Single":{"name":["bin"],"target_id":132,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:98-105",{"columns":[{"Single":{"name":["tracks","name"],"target_id":131,"target_name":null}},{"Single":{"name":["bin"],"target_id":132,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":124,"kind":"Ident","span":"1:13-24","ident":{"Ident":["default_db","tracks"]},"parent":130},{"id":128,"kind":"Ident","span":"1:32-37","ident":{"Ident":["this","tracks","bytes"]},"targets":[124],"parent":130},{"id":130,"kind":"TransformCall: Sort","span":"1:25-38","children":[124,128],"parent":140},{"id":131,"kind":"Ident","span":"1:52-56","ident":{"Ident":["this","tracks","name"]},"targets":[124],"parent":139},{"id":132,"kind":"RqOperator","span":"1:68-95","alias":"bin","targets":[134,138],"parent":139},{"id":134,"kind":"RqOperator","span":"1:81-88","targets":[137]},{"id":137,"kind":"Ident","span":"1:70-78","ident":{"Ident":["this","tracks","album_id"]},"targets":[124]},{"id":138,"kind":"Literal","span":"1:92-94"},{"id":139,"kind":"Tuple","span":"1:46-97","children":[131,132],"parent":140},{"id":140,"kind":"TransformCall: Select","span":"1:39-97","children":[130,139],"parent":142},{"id":142,"kind":"TransformCall: Take","span":"1:98-105","children":[140,143]},{"id":143,"kind":"Literal","parent":142}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Unary":{"op":"Neg","expr":{"Ident":"bytes"}}}]}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"name"},{"Binary":{"left":{"Pipeline":{"exprs":[{"Ident":"album_id"},{"FuncCall":{"name":{"Ident":"as"},"args":[{"Ident":"REAL"}]}}]}},"op":"Mul","right":{"Literal":{"Integer":99}}},"alias":"bin"}]}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":20}}]}}]}}},"span":"1:13-106"}]}}
+frames:
+- - 1:25-38
+  - columns:
+    - !All
+      input_id: 124
+      except: []
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:39-97
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - name
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - bin
+      target_id: 132
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:98-105
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - name
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - bin
+      target_id: 132
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 124
+  kind: Ident
+  span: 1:13-24
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 130
+- id: 128
+  kind: Ident
+  span: 1:32-37
+  ident: !Ident
+  - this
+  - tracks
+  - bytes
+  targets:
+  - 124
+  parent: 130
+- id: 130
+  kind: 'TransformCall: Sort'
+  span: 1:25-38
+  children:
+  - 124
+  - 128
+  parent: 140
+- id: 131
+  kind: Ident
+  span: 1:52-56
+  ident: !Ident
+  - this
+  - tracks
+  - name
+  targets:
+  - 124
+  parent: 139
+- id: 132
+  kind: RqOperator
+  span: 1:68-95
+  alias: bin
+  targets:
+  - 134
+  - 138
+  parent: 139
+- id: 134
+  kind: RqOperator
+  span: 1:81-88
+  targets:
+  - 137
+- id: 137
+  kind: Ident
+  span: 1:70-78
+  ident: !Ident
+  - this
+  - tracks
+  - album_id
+  targets:
+  - 124
+- id: 138
+  kind: Literal
+  span: 1:92-94
+- id: 139
+  kind: Tuple
+  span: 1:46-97
+  children:
+  - 131
+  - 132
+  parent: 140
+- id: 140
+  kind: 'TransformCall: Select'
+  span: 1:39-97
+  children:
+  - 130
+  - 139
+  parent: 142
+- id: 142
+  kind: 'TransformCall: Take'
+  span: 1:98-105
+  children:
+  - 140
+  - 143
+- id: 143
+  kind: Literal
+  parent: 142
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Unary:
+                    op: Neg
+                    expr:
+                      Ident: bytes
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: name
+                - Binary:
+                    left:
+                      Pipeline:
+                        exprs:
+                        - Ident: album_id
+                        - FuncCall:
+                            name:
+                              Ident: as
+                            args:
+                            - Ident: REAL
+                    op: Mul
+                    right:
+                      Literal:
+                        Integer: 99
+                  alias: bin
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 20
+    span: 1:13-106

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__constants_only.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__constants_only.snap
@@ -3,4 +3,174 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "from genres\ntake 10\nfilter true\ntake 20\nfilter true\nselect d = 10\n"
 input_file: prqlc/prqlc/tests/integration/queries/constants_only.prql
 ---
-{"frames":[["1:12-19",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"genres","table":["default_db","genres"]}]}],["1:20-31",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"genres","table":["default_db","genres"]}]}],["1:32-39",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"genres","table":["default_db","genres"]}]}],["1:40-51",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"genres","table":["default_db","genres"]}]}],["1:52-65",{"columns":[{"Single":{"name":["d"],"target_id":142,"target_name":null}}],"inputs":[{"id":130,"name":"genres","table":["default_db","genres"]}]}]],"nodes":[{"id":130,"kind":"Ident","span":"1:0-11","ident":{"Ident":["default_db","genres"]},"parent":133},{"id":133,"kind":"TransformCall: Take","span":"1:12-19","children":[130,134],"parent":136},{"id":134,"kind":"Literal","parent":133},{"id":135,"kind":"Literal","span":"1:27-31","parent":136},{"id":136,"kind":"TransformCall: Filter","span":"1:20-31","children":[133,135],"parent":138},{"id":138,"kind":"TransformCall: Take","span":"1:32-39","children":[136,139],"parent":141},{"id":139,"kind":"Literal","parent":138},{"id":140,"kind":"Literal","span":"1:47-51","parent":141},{"id":141,"kind":"TransformCall: Filter","span":"1:40-51","children":[138,140],"parent":144},{"id":142,"kind":"Literal","span":"1:63-65","alias":"d","parent":143},{"id":143,"kind":"Tuple","span":"1:63-65","children":[142],"parent":144},{"id":144,"kind":"TransformCall: Select","span":"1:52-65","children":[141,143]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"genres"}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":10}}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Literal":{"Boolean":true}}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":20}}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Literal":{"Boolean":true}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Literal":{"Integer":10},"alias":"d"}]}}]}}},"span":"1:0-66"}]}}
+frames:
+- - 1:12-19
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: genres
+      table:
+      - default_db
+      - genres
+- - 1:20-31
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: genres
+      table:
+      - default_db
+      - genres
+- - 1:32-39
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: genres
+      table:
+      - default_db
+      - genres
+- - 1:40-51
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: genres
+      table:
+      - default_db
+      - genres
+- - 1:52-65
+  - columns:
+    - !Single
+      name:
+      - d
+      target_id: 142
+      target_name: null
+    inputs:
+    - id: 130
+      name: genres
+      table:
+      - default_db
+      - genres
+nodes:
+- id: 130
+  kind: Ident
+  span: 1:0-11
+  ident: !Ident
+  - default_db
+  - genres
+  parent: 133
+- id: 133
+  kind: 'TransformCall: Take'
+  span: 1:12-19
+  children:
+  - 130
+  - 134
+  parent: 136
+- id: 134
+  kind: Literal
+  parent: 133
+- id: 135
+  kind: Literal
+  span: 1:27-31
+  parent: 136
+- id: 136
+  kind: 'TransformCall: Filter'
+  span: 1:20-31
+  children:
+  - 133
+  - 135
+  parent: 138
+- id: 138
+  kind: 'TransformCall: Take'
+  span: 1:32-39
+  children:
+  - 136
+  - 139
+  parent: 141
+- id: 139
+  kind: Literal
+  parent: 138
+- id: 140
+  kind: Literal
+  span: 1:47-51
+  parent: 141
+- id: 141
+  kind: 'TransformCall: Filter'
+  span: 1:40-51
+  children:
+  - 138
+  - 140
+  parent: 144
+- id: 142
+  kind: Literal
+  span: 1:63-65
+  alias: d
+  parent: 143
+- id: 143
+  kind: Tuple
+  span: 1:63-65
+  children:
+  - 142
+  parent: 144
+- id: 144
+  kind: 'TransformCall: Select'
+  span: 1:52-65
+  children:
+  - 141
+  - 143
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: genres
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 10
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Literal:
+                  Boolean: true
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 20
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Literal:
+                  Boolean: true
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Literal:
+                  Integer: 10
+                alias: d
+    span: 1:0-66

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__date_to_text.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__date_to_text.snap
@@ -3,4 +3,546 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# generic:skip\n# glaredb:skip\n# sqlite:skip\n# mssql:test\nfrom invoices\ntake 20\nselect {\n    d1 = (invoice_date | date.to_text \"%Y/%m/%d\"),\n    d2 = (invoice_date | date.to_text \"%F\"),\n    d3 = (invoice_date | date.to_text \"%D\"),\n    d4 = (invoice_date | date.to_text \"%H:%M:%S.%f\"),\n    d5 = (invoice_date | date.to_text \"%r\"),\n    d6 = (invoice_date | date.to_text \"%A %B %-d %Y\"),\n    d7 = (invoice_date | date.to_text \"%a, %-d %b %Y at %I:%M:%S %p\"),\n    d8 = (invoice_date | date.to_text \"%+\"),\n    d9 = (invoice_date | date.to_text \"%-d/%-m/%y\"),\n    d10 = (invoice_date | date.to_text \"%-Hh %Mmin\"),\n    d11 = (invoice_date | date.to_text \"%M'%S\\\"\"),\n    d12 = (invoice_date | date.to_text \"100%% in %d days\"),\n}\n"
 input_file: prqlc/prqlc/tests/integration/queries/date_to_text.prql
 ---
-{"frames":[["1:71-78",{"columns":[{"All":{"input_id":121,"except":[]}}],"inputs":[{"id":121,"name":"invoices","table":["default_db","invoices"]}]}],["1:79-718",{"columns":[{"Single":{"name":["d1"],"target_id":126,"target_name":null}},{"Single":{"name":["d2"],"target_id":131,"target_name":null}},{"Single":{"name":["d3"],"target_id":136,"target_name":null}},{"Single":{"name":["d4"],"target_id":141,"target_name":null}},{"Single":{"name":["d5"],"target_id":146,"target_name":null}},{"Single":{"name":["d6"],"target_id":151,"target_name":null}},{"Single":{"name":["d7"],"target_id":156,"target_name":null}},{"Single":{"name":["d8"],"target_id":161,"target_name":null}},{"Single":{"name":["d9"],"target_id":166,"target_name":null}},{"Single":{"name":["d10"],"target_id":171,"target_name":null}},{"Single":{"name":["d11"],"target_id":176,"target_name":null}},{"Single":{"name":["d12"],"target_id":181,"target_name":null}}],"inputs":[{"id":121,"name":"invoices","table":["default_db","invoices"]}]}]],"nodes":[{"id":121,"kind":"Ident","span":"1:57-70","ident":{"Ident":["default_db","invoices"]},"parent":124},{"id":124,"kind":"TransformCall: Take","span":"1:71-78","children":[121,125],"parent":187},{"id":125,"kind":"Literal","parent":124},{"id":126,"kind":"RqOperator","span":"1:113-136","alias":"d1","targets":[129,130],"parent":186},{"id":129,"kind":"Literal","span":"1:126-136"},{"id":130,"kind":"Ident","span":"1:98-110","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":131,"kind":"RqOperator","span":"1:164-181","alias":"d2","targets":[134,135],"parent":186},{"id":134,"kind":"Literal","span":"1:177-181"},{"id":135,"kind":"Ident","span":"1:149-161","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":136,"kind":"RqOperator","span":"1:209-226","alias":"d3","targets":[139,140],"parent":186},{"id":139,"kind":"Literal","span":"1:222-226"},{"id":140,"kind":"Ident","span":"1:194-206","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":141,"kind":"RqOperator","span":"1:254-280","alias":"d4","targets":[144,145],"parent":186},{"id":144,"kind":"Literal","span":"1:267-280"},{"id":145,"kind":"Ident","span":"1:239-251","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":146,"kind":"RqOperator","span":"1:308-325","alias":"d5","targets":[149,150],"parent":186},{"id":149,"kind":"Literal","span":"1:321-325"},{"id":150,"kind":"Ident","span":"1:293-305","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":151,"kind":"RqOperator","span":"1:353-380","alias":"d6","targets":[154,155],"parent":186},{"id":154,"kind":"Literal","span":"1:366-380"},{"id":155,"kind":"Ident","span":"1:338-350","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":156,"kind":"RqOperator","span":"1:408-451","alias":"d7","targets":[159,160],"parent":186},{"id":159,"kind":"Literal","span":"1:421-451"},{"id":160,"kind":"Ident","span":"1:393-405","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":161,"kind":"RqOperator","span":"1:479-496","alias":"d8","targets":[164,165],"parent":186},{"id":164,"kind":"Literal","span":"1:492-496"},{"id":165,"kind":"Ident","span":"1:464-476","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":166,"kind":"RqOperator","span":"1:524-549","alias":"d9","targets":[169,170],"parent":186},{"id":169,"kind":"Literal","span":"1:537-549"},{"id":170,"kind":"Ident","span":"1:509-521","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":171,"kind":"RqOperator","span":"1:578-603","alias":"d10","targets":[174,175],"parent":186},{"id":174,"kind":"Literal","span":"1:591-603"},{"id":175,"kind":"Ident","span":"1:563-575","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":176,"kind":"RqOperator","span":"1:632-654","alias":"d11","targets":[179,180],"parent":186},{"id":179,"kind":"Literal","span":"1:645-654"},{"id":180,"kind":"Ident","span":"1:617-629","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":181,"kind":"RqOperator","span":"1:683-714","alias":"d12","targets":[184,185],"parent":186},{"id":184,"kind":"Literal","span":"1:696-714"},{"id":185,"kind":"Ident","span":"1:668-680","ident":{"Ident":["this","invoices","invoice_date"]},"targets":[121]},{"id":186,"kind":"Tuple","span":"1:86-718","children":[126,131,136,141,146,151,156,161,166,171,176,181],"parent":187},{"id":187,"kind":"TransformCall: Select","span":"1:79-718","children":[124,186]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"invoices"}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":20}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%Y/%m/%d"}}]}}]},"alias":"d1"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%F"}}]}}]},"alias":"d2"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%D"}}]}}]},"alias":"d3"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%H:%M:%S.%f"}}]}}]},"alias":"d4"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%r"}}]}}]},"alias":"d5"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%A %B %-d %Y"}}]}}]},"alias":"d6"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%a, %-d %b %Y at %I:%M:%S %p"}}]}}]},"alias":"d7"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%+"}}]}}]},"alias":"d8"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%-d/%-m/%y"}}]}}]},"alias":"d9"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%-Hh %Mmin"}}]}}]},"alias":"d10"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"%M'%S\""}}]}}]},"alias":"d11"},{"Pipeline":{"exprs":[{"Ident":"invoice_date"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"date"},"field":{"Name":"to_text"}}},"args":[{"Literal":{"String":"100%% in %d days"}}]}}]},"alias":"d12"}]}]}}]}}},"span":"1:57-719"}]}}
+frames:
+- - 1:71-78
+  - columns:
+    - !All
+      input_id: 121
+      except: []
+    inputs:
+    - id: 121
+      name: invoices
+      table:
+      - default_db
+      - invoices
+- - 1:79-718
+  - columns:
+    - !Single
+      name:
+      - d1
+      target_id: 126
+      target_name: null
+    - !Single
+      name:
+      - d2
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - d3
+      target_id: 136
+      target_name: null
+    - !Single
+      name:
+      - d4
+      target_id: 141
+      target_name: null
+    - !Single
+      name:
+      - d5
+      target_id: 146
+      target_name: null
+    - !Single
+      name:
+      - d6
+      target_id: 151
+      target_name: null
+    - !Single
+      name:
+      - d7
+      target_id: 156
+      target_name: null
+    - !Single
+      name:
+      - d8
+      target_id: 161
+      target_name: null
+    - !Single
+      name:
+      - d9
+      target_id: 166
+      target_name: null
+    - !Single
+      name:
+      - d10
+      target_id: 171
+      target_name: null
+    - !Single
+      name:
+      - d11
+      target_id: 176
+      target_name: null
+    - !Single
+      name:
+      - d12
+      target_id: 181
+      target_name: null
+    inputs:
+    - id: 121
+      name: invoices
+      table:
+      - default_db
+      - invoices
+nodes:
+- id: 121
+  kind: Ident
+  span: 1:57-70
+  ident: !Ident
+  - default_db
+  - invoices
+  parent: 124
+- id: 124
+  kind: 'TransformCall: Take'
+  span: 1:71-78
+  children:
+  - 121
+  - 125
+  parent: 187
+- id: 125
+  kind: Literal
+  parent: 124
+- id: 126
+  kind: RqOperator
+  span: 1:113-136
+  alias: d1
+  targets:
+  - 129
+  - 130
+  parent: 186
+- id: 129
+  kind: Literal
+  span: 1:126-136
+- id: 130
+  kind: Ident
+  span: 1:98-110
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 131
+  kind: RqOperator
+  span: 1:164-181
+  alias: d2
+  targets:
+  - 134
+  - 135
+  parent: 186
+- id: 134
+  kind: Literal
+  span: 1:177-181
+- id: 135
+  kind: Ident
+  span: 1:149-161
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 136
+  kind: RqOperator
+  span: 1:209-226
+  alias: d3
+  targets:
+  - 139
+  - 140
+  parent: 186
+- id: 139
+  kind: Literal
+  span: 1:222-226
+- id: 140
+  kind: Ident
+  span: 1:194-206
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 141
+  kind: RqOperator
+  span: 1:254-280
+  alias: d4
+  targets:
+  - 144
+  - 145
+  parent: 186
+- id: 144
+  kind: Literal
+  span: 1:267-280
+- id: 145
+  kind: Ident
+  span: 1:239-251
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 146
+  kind: RqOperator
+  span: 1:308-325
+  alias: d5
+  targets:
+  - 149
+  - 150
+  parent: 186
+- id: 149
+  kind: Literal
+  span: 1:321-325
+- id: 150
+  kind: Ident
+  span: 1:293-305
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 151
+  kind: RqOperator
+  span: 1:353-380
+  alias: d6
+  targets:
+  - 154
+  - 155
+  parent: 186
+- id: 154
+  kind: Literal
+  span: 1:366-380
+- id: 155
+  kind: Ident
+  span: 1:338-350
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 156
+  kind: RqOperator
+  span: 1:408-451
+  alias: d7
+  targets:
+  - 159
+  - 160
+  parent: 186
+- id: 159
+  kind: Literal
+  span: 1:421-451
+- id: 160
+  kind: Ident
+  span: 1:393-405
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 161
+  kind: RqOperator
+  span: 1:479-496
+  alias: d8
+  targets:
+  - 164
+  - 165
+  parent: 186
+- id: 164
+  kind: Literal
+  span: 1:492-496
+- id: 165
+  kind: Ident
+  span: 1:464-476
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 166
+  kind: RqOperator
+  span: 1:524-549
+  alias: d9
+  targets:
+  - 169
+  - 170
+  parent: 186
+- id: 169
+  kind: Literal
+  span: 1:537-549
+- id: 170
+  kind: Ident
+  span: 1:509-521
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 171
+  kind: RqOperator
+  span: 1:578-603
+  alias: d10
+  targets:
+  - 174
+  - 175
+  parent: 186
+- id: 174
+  kind: Literal
+  span: 1:591-603
+- id: 175
+  kind: Ident
+  span: 1:563-575
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 176
+  kind: RqOperator
+  span: 1:632-654
+  alias: d11
+  targets:
+  - 179
+  - 180
+  parent: 186
+- id: 179
+  kind: Literal
+  span: 1:645-654
+- id: 180
+  kind: Ident
+  span: 1:617-629
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 181
+  kind: RqOperator
+  span: 1:683-714
+  alias: d12
+  targets:
+  - 184
+  - 185
+  parent: 186
+- id: 184
+  kind: Literal
+  span: 1:696-714
+- id: 185
+  kind: Ident
+  span: 1:668-680
+  ident: !Ident
+  - this
+  - invoices
+  - invoice_date
+  targets:
+  - 121
+- id: 186
+  kind: Tuple
+  span: 1:86-718
+  children:
+  - 126
+  - 131
+  - 136
+  - 141
+  - 146
+  - 151
+  - 156
+  - 161
+  - 166
+  - 171
+  - 176
+  - 181
+  parent: 187
+- id: 187
+  kind: 'TransformCall: Select'
+  span: 1:79-718
+  children:
+  - 124
+  - 186
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: invoices
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 20
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%Y/%m/%d'
+                  alias: d1
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%F'
+                  alias: d2
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%D'
+                  alias: d3
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%H:%M:%S.%f'
+                  alias: d4
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%r'
+                  alias: d5
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%A %B %-d %Y'
+                  alias: d6
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%a, %-d %b %Y at %I:%M:%S %p'
+                  alias: d7
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%+'
+                  alias: d8
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%-d/%-m/%y'
+                  alias: d9
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%-Hh %Mmin'
+                  alias: d10
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: '%M''%S"'
+                  alias: d11
+                - Pipeline:
+                    exprs:
+                    - Ident: invoice_date
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: date
+                            field: !Name to_text
+                        args:
+                        - Literal:
+                            String: 100%% in %d days
+                  alias: d12
+    span: 1:57-719

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__distinct.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__distinct.snap
@@ -3,4 +3,209 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom tracks\nselect {album_id, genre_id}\ngroup tracks.* (take 1)\nsort tracks.*\n"
 input_file: prqlc/prqlc/tests/integration/queries/distinct.prql
 ---
-{"frames":[["1:25-52",{"columns":[{"Single":{"name":["tracks","album_id"],"target_id":126,"target_name":null}},{"Single":{"name":["tracks","genre_id"],"target_id":127,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:77-90",{"columns":[{"Single":{"name":["tracks","album_id"],"target_id":131,"target_name":null}},{"Single":{"name":["tracks","genre_id"],"target_id":132,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":124,"kind":"Ident","span":"1:13-24","ident":{"Ident":["default_db","tracks"]},"parent":129},{"id":126,"kind":"Ident","span":"1:33-41","ident":{"Ident":["this","tracks","album_id"]},"targets":[124],"parent":128},{"id":127,"kind":"Ident","span":"1:43-51","ident":{"Ident":["this","tracks","genre_id"]},"targets":[124],"parent":128},{"id":128,"kind":"Tuple","span":"1:32-52","children":[126,127],"parent":129},{"id":129,"kind":"TransformCall: Select","span":"1:25-52","children":[124,128],"parent":150},{"id":131,"kind":"Ident","ident":{"Ident":["this","tracks","album_id"]},"targets":[126],"parent":133},{"id":132,"kind":"Ident","ident":{"Ident":["this","tracks","genre_id"]},"targets":[127],"parent":133},{"id":133,"kind":"Tuple","span":"1:65-67","children":[131,132]},{"id":150,"kind":"TransformCall: Take","children":[129,151],"parent":158},{"id":151,"kind":"Literal","parent":150},{"id":155,"kind":"Ident","ident":{"Ident":["this","tracks","album_id"]},"targets":[131],"parent":158},{"id":156,"kind":"Ident","ident":{"Ident":["this","tracks","genre_id"]},"targets":[132],"parent":158},{"id":158,"kind":"TransformCall: Sort","span":"1:77-90","children":[150,155,156]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"album_id"},{"Ident":"genre_id"}]}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Indirection":{"base":{"Ident":"tracks"},"field":"Star"}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":1}}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Indirection":{"base":{"Ident":"tracks"},"field":"Star"}}]}}]}}},"span":"1:13-91"}]}}
+frames:
+- - 1:25-52
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - album_id
+      target_id: 126
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 127
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:69-75
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - album_id
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 132
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:77-90
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - album_id
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 132
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 124
+  kind: Ident
+  span: 1:13-24
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 129
+- id: 126
+  kind: Ident
+  span: 1:33-41
+  ident: !Ident
+  - this
+  - tracks
+  - album_id
+  targets:
+  - 124
+  parent: 128
+- id: 127
+  kind: Ident
+  span: 1:43-51
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 124
+  parent: 128
+- id: 128
+  kind: Tuple
+  span: 1:32-52
+  children:
+  - 126
+  - 127
+  parent: 129
+- id: 129
+  kind: 'TransformCall: Select'
+  span: 1:25-52
+  children:
+  - 124
+  - 128
+  parent: 150
+- id: 131
+  kind: Ident
+  ident: !Ident
+  - this
+  - tracks
+  - album_id
+  targets:
+  - 126
+  parent: 133
+- id: 132
+  kind: Ident
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 127
+  parent: 133
+- id: 133
+  kind: Tuple
+  span: 1:65-67
+  children:
+  - 131
+  - 132
+- id: 150
+  kind: 'TransformCall: Take'
+  span: 1:69-75
+  children:
+  - 129
+  - 151
+  parent: 158
+- id: 151
+  kind: Literal
+  parent: 150
+- id: 155
+  kind: Ident
+  ident: !Ident
+  - this
+  - tracks
+  - album_id
+  targets:
+  - 131
+  parent: 158
+- id: 156
+  kind: Ident
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 132
+  parent: 158
+- id: 158
+  kind: 'TransformCall: Sort'
+  span: 1:77-90
+  children:
+  - 150
+  - 155
+  - 156
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: album_id
+                - Ident: genre_id
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Indirection:
+                  base:
+                    Ident: tracks
+                  field: Star
+              - FuncCall:
+                  name:
+                    Ident: take
+                  args:
+                  - Literal:
+                      Integer: 1
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Indirection:
+                  base:
+                    Ident: tracks
+                  field: Star
+    span: 1:13-91

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__distinct_on.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__distinct_on.snap
@@ -3,4 +3,264 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom tracks\nselect {genre_id, media_type_id, album_id}\ngroup {genre_id, media_type_id} (sort {-album_id} | take 1)\nsort {-genre_id, media_type_id}\n"
 input_file: prqlc/prqlc/tests/integration/queries/distinct_on.prql
 ---
-{"frames":[["1:25-67",{"columns":[{"Single":{"name":["tracks","genre_id"],"target_id":126,"target_name":null}},{"Single":{"name":["tracks","media_type_id"],"target_id":127,"target_name":null}},{"Single":{"name":["tracks","album_id"],"target_id":128,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:128-159",{"columns":[{"Single":{"name":["tracks","genre_id"],"target_id":131,"target_name":null}},{"Single":{"name":["tracks","media_type_id"],"target_id":132,"target_name":null}},{"Single":{"name":["tracks","album_id"],"target_id":128,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":124,"kind":"Ident","span":"1:13-24","ident":{"Ident":["default_db","tracks"]},"parent":130},{"id":126,"kind":"Ident","span":"1:33-41","ident":{"Ident":["this","tracks","genre_id"]},"targets":[124],"parent":129},{"id":127,"kind":"Ident","span":"1:43-56","ident":{"Ident":["this","tracks","media_type_id"]},"targets":[124],"parent":129},{"id":128,"kind":"Ident","span":"1:58-66","ident":{"Ident":["this","tracks","album_id"]},"targets":[124],"parent":129},{"id":129,"kind":"Tuple","span":"1:32-67","children":[126,127,128],"parent":130},{"id":130,"kind":"TransformCall: Select","span":"1:25-67","children":[124,129],"parent":162},{"id":131,"kind":"Ident","span":"1:75-83","ident":{"Ident":["this","tracks","genre_id"]},"targets":[126],"parent":133},{"id":132,"kind":"Ident","span":"1:85-98","ident":{"Ident":["this","tracks","media_type_id"]},"targets":[127],"parent":133},{"id":133,"kind":"Tuple","span":"1:74-99","children":[131,132]},{"id":158,"kind":"Ident","span":"1:108-116","ident":{"Ident":["this","tracks","album_id"]},"targets":[128]},{"id":162,"kind":"TransformCall: Take","children":[130,163],"parent":171},{"id":163,"kind":"Literal","parent":162},{"id":168,"kind":"Ident","span":"1:135-143","ident":{"Ident":["this","tracks","genre_id"]},"targets":[131],"parent":171},{"id":169,"kind":"Ident","span":"1:145-158","ident":{"Ident":["this","tracks","media_type_id"]},"targets":[132],"parent":171},{"id":171,"kind":"TransformCall: Sort","span":"1:128-159","children":[162,168,169]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"genre_id"},{"Ident":"media_type_id"},{"Ident":"album_id"}]}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Tuple":[{"Ident":"genre_id"},{"Ident":"media_type_id"}]},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Unary":{"op":"Neg","expr":{"Ident":"album_id"}}}]}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":1}}]}}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Unary":{"op":"Neg","expr":{"Ident":"genre_id"}}},{"Ident":"media_type_id"}]}]}}]}}},"span":"1:13-160"}]}}
+frames:
+- - 1:25-67
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 126
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - media_type_id
+      target_id: 127
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - album_id
+      target_id: 128
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:120-126
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - media_type_id
+      target_id: 132
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - album_id
+      target_id: 128
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:128-159
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - media_type_id
+      target_id: 132
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - album_id
+      target_id: 128
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 124
+  kind: Ident
+  span: 1:13-24
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 130
+- id: 126
+  kind: Ident
+  span: 1:33-41
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 124
+  parent: 129
+- id: 127
+  kind: Ident
+  span: 1:43-56
+  ident: !Ident
+  - this
+  - tracks
+  - media_type_id
+  targets:
+  - 124
+  parent: 129
+- id: 128
+  kind: Ident
+  span: 1:58-66
+  ident: !Ident
+  - this
+  - tracks
+  - album_id
+  targets:
+  - 124
+  parent: 129
+- id: 129
+  kind: Tuple
+  span: 1:32-67
+  children:
+  - 126
+  - 127
+  - 128
+  parent: 130
+- id: 130
+  kind: 'TransformCall: Select'
+  span: 1:25-67
+  children:
+  - 124
+  - 129
+  parent: 162
+- id: 131
+  kind: Ident
+  span: 1:75-83
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 126
+  parent: 133
+- id: 132
+  kind: Ident
+  span: 1:85-98
+  ident: !Ident
+  - this
+  - tracks
+  - media_type_id
+  targets:
+  - 127
+  parent: 133
+- id: 133
+  kind: Tuple
+  span: 1:74-99
+  children:
+  - 131
+  - 132
+- id: 158
+  kind: Ident
+  span: 1:108-116
+  ident: !Ident
+  - this
+  - tracks
+  - album_id
+  targets:
+  - 128
+- id: 162
+  kind: 'TransformCall: Take'
+  span: 1:120-126
+  children:
+  - 130
+  - 163
+  parent: 171
+- id: 163
+  kind: Literal
+  parent: 162
+- id: 168
+  kind: Ident
+  span: 1:135-143
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 131
+  parent: 171
+- id: 169
+  kind: Ident
+  span: 1:145-158
+  ident: !Ident
+  - this
+  - tracks
+  - media_type_id
+  targets:
+  - 132
+  parent: 171
+- id: 171
+  kind: 'TransformCall: Sort'
+  span: 1:128-159
+  children:
+  - 162
+  - 168
+  - 169
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: genre_id
+                - Ident: media_type_id
+                - Ident: album_id
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Tuple:
+                - Ident: genre_id
+                - Ident: media_type_id
+              - Pipeline:
+                  exprs:
+                  - FuncCall:
+                      name:
+                        Ident: sort
+                      args:
+                      - Tuple:
+                        - Unary:
+                            op: Neg
+                            expr:
+                              Ident: album_id
+                  - FuncCall:
+                      name:
+                        Ident: take
+                      args:
+                      - Literal:
+                          Integer: 1
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Unary:
+                    op: Neg
+                    expr:
+                      Ident: genre_id
+                - Ident: media_type_id
+    span: 1:13-160

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__genre_counts.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__genre_counts.snap
@@ -3,4 +3,148 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# clickhouse:skip (ClickHouse prefers aliases to column names https://github.com/PRQL/prql/issues/2827)\n# mssql:test\nlet genre_count = (\n    from genres\n    aggregate {a = count name}\n)\n\nfrom genre_count\nfilter a > 0\nselect a = -a\n"
 input_file: prqlc/prqlc/tests/integration/queries/genre_counts.prql
 ---
-{"frames":[["1:204-216",{"columns":[{"Single":{"name":["genre_count","a"],"target_id":136,"target_name":"a"}}],"inputs":[{"id":136,"name":"genre_count","table":["genre_count"]}]}],["1:217-230",{"columns":[{"Single":{"name":["a"],"target_id":143,"target_name":null}}],"inputs":[{"id":136,"name":"genre_count","table":["genre_count"]}]}]],"nodes":[{"id":136,"kind":"Ident","span":"1:187-203","ident":{"Ident":["genre_count"]},"parent":142},{"id":138,"kind":"RqOperator","span":"1:211-216","targets":[140,141],"parent":142},{"id":140,"kind":"Ident","span":"1:211-212","ident":{"Ident":["this","genre_count","a"]},"targets":[136]},{"id":141,"kind":"Literal","span":"1:215-216"},{"id":142,"kind":"TransformCall: Filter","span":"1:204-216","children":[136,138],"parent":147},{"id":143,"kind":"RqOperator","span":"1:228-230","alias":"a","targets":[145],"parent":146},{"id":145,"kind":"Ident","span":"1:229-230","ident":{"Ident":["this","genre_count","a"]},"targets":[136]},{"id":146,"kind":"Tuple","span":"1:228-230","children":[143],"parent":147},{"id":147,"kind":"TransformCall: Select","span":"1:217-230","children":[142,146]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Let","name":"genre_count","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"genres"}]}},{"FuncCall":{"name":{"Ident":"aggregate"},"args":[{"Tuple":[{"FuncCall":{"name":{"Ident":"count"},"args":[{"Ident":"name"}]},"alias":"a"}]}]}}]}}},"span":"1:117-185"},{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"genre_count"}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Binary":{"left":{"Ident":"a"},"op":"Gt","right":{"Literal":{"Integer":0}}}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Unary":{"op":"Neg","expr":{"Ident":"a"}},"alias":"a"}]}}]}}},"span":"1:187-231"}]}}
+frames:
+- - 1:204-216
+  - columns:
+    - !Single
+      name:
+      - genre_count
+      - a
+      target_id: 136
+      target_name: a
+    inputs:
+    - id: 136
+      name: genre_count
+      table:
+      - genre_count
+- - 1:217-230
+  - columns:
+    - !Single
+      name:
+      - a
+      target_id: 143
+      target_name: null
+    inputs:
+    - id: 136
+      name: genre_count
+      table:
+      - genre_count
+nodes:
+- id: 136
+  kind: Ident
+  span: 1:187-203
+  ident: !Ident
+  - genre_count
+  parent: 142
+- id: 138
+  kind: RqOperator
+  span: 1:211-216
+  targets:
+  - 140
+  - 141
+  parent: 142
+- id: 140
+  kind: Ident
+  span: 1:211-212
+  ident: !Ident
+  - this
+  - genre_count
+  - a
+  targets:
+  - 136
+- id: 141
+  kind: Literal
+  span: 1:215-216
+- id: 142
+  kind: 'TransformCall: Filter'
+  span: 1:204-216
+  children:
+  - 136
+  - 138
+  parent: 147
+- id: 143
+  kind: RqOperator
+  span: 1:228-230
+  alias: a
+  targets:
+  - 145
+  parent: 146
+- id: 145
+  kind: Ident
+  span: 1:229-230
+  ident: !Ident
+  - this
+  - genre_count
+  - a
+  targets:
+  - 136
+- id: 146
+  kind: Tuple
+  span: 1:228-230
+  children:
+  - 143
+  parent: 147
+- id: 147
+  kind: 'TransformCall: Select'
+  span: 1:217-230
+  children:
+  - 142
+  - 146
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Let
+      name: genre_count
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: genres
+          - FuncCall:
+              name:
+                Ident: aggregate
+              args:
+              - Tuple:
+                - FuncCall:
+                    name:
+                      Ident: count
+                    args:
+                    - Ident: name
+                  alias: a
+    span: 1:117-185
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: genre_count
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Binary:
+                  left:
+                    Ident: a
+                  op: Gt
+                  right:
+                    Literal:
+                      Integer: 0
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Unary:
+                  op: Neg
+                  expr:
+                    Ident: a
+                alias: a
+    span: 1:187-231

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_all.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_all.snap
@@ -3,4 +3,307 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom a=albums\ntake 10\njoin tracks (==album_id)\ngroup {a.album_id, a.title} (aggregate price = (sum tracks.unit_price | math.round 2))\nsort album_id\n"
 input_file: prqlc/prqlc/tests/integration/queries/group_all.prql
 ---
-{"frames":[["1:27-34",{"columns":[{"All":{"input_id":128,"except":[]}}],"inputs":[{"id":128,"name":"a","table":["default_db","albums"]}]}],["1:35-59",{"columns":[{"All":{"input_id":128,"except":[]}},{"All":{"input_id":122,"except":[]}}],"inputs":[{"id":128,"name":"a","table":["default_db","albums"]},{"id":122,"name":"tracks","table":["default_db","tracks"]}]}],["1:147-160",{"columns":[{"Single":{"name":["a","album_id"],"target_id":138,"target_name":null}},{"Single":{"name":["a","title"],"target_id":139,"target_name":null}},{"Single":{"name":["price"],"target_id":157,"target_name":null}}],"inputs":[{"id":128,"name":"a","table":["default_db","albums"]},{"id":122,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":122,"kind":"Ident","span":"1:40-46","ident":{"Ident":["default_db","tracks"]},"parent":137},{"id":128,"kind":"Ident","span":"1:13-26","ident":{"Ident":["default_db","albums"]},"parent":131},{"id":131,"kind":"TransformCall: Take","span":"1:27-34","children":[128,132],"parent":137},{"id":132,"kind":"Literal","parent":131},{"id":133,"kind":"RqOperator","span":"1:48-58","targets":[135,136],"parent":137},{"id":135,"kind":"Ident","span":"1:50-58","ident":{"Ident":["this","a","album_id"]},"targets":[128]},{"id":136,"kind":"Ident","span":"1:50-58","ident":{"Ident":["that","tracks","album_id"]},"targets":[122]},{"id":137,"kind":"TransformCall: Join","span":"1:35-59","children":[131,122,133],"parent":165},{"id":138,"kind":"Ident","span":"1:67-77","ident":{"Ident":["this","a","album_id"]},"targets":[128],"parent":140},{"id":139,"kind":"Ident","span":"1:79-86","ident":{"Ident":["this","a","title"]},"targets":[128],"parent":140},{"id":140,"kind":"Tuple","span":"1:66-87","children":[138,139],"parent":165},{"id":157,"kind":"RqOperator","span":"1:132-144","alias":"price","targets":[160,161],"parent":164},{"id":160,"kind":"Literal","span":"1:143-144"},{"id":161,"kind":"RqOperator","span":"1:108-129","targets":[163]},{"id":163,"kind":"Ident","span":"1:118-129","ident":{"Ident":["this","tracks","unit_price"]},"targets":[122]},{"id":164,"kind":"Tuple","span":"1:132-144","children":[157],"parent":165},{"id":165,"kind":"TransformCall: Aggregate","children":[137,164,140],"parent":170},{"id":168,"kind":"Ident","span":"1:152-160","ident":{"Ident":["this","a","album_id"]},"targets":[138],"parent":170},{"id":170,"kind":"TransformCall: Sort","span":"1:147-160","children":[165,168]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"albums","alias":"a"}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":10}}]}},{"FuncCall":{"name":{"Ident":"join"},"args":[{"Ident":"tracks"},{"Unary":{"op":"EqSelf","expr":{"Ident":"album_id"}}}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Tuple":[{"Indirection":{"base":{"Ident":"a"},"field":{"Name":"album_id"}}},{"Indirection":{"base":{"Ident":"a"},"field":{"Name":"title"}}}]},{"FuncCall":{"name":{"Ident":"aggregate"},"args":[{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"sum"},"args":[{"Indirection":{"base":{"Ident":"tracks"},"field":{"Name":"unit_price"}}}]}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"price"}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"album_id"}]}}]}}},"span":"1:13-161"}]}}
+frames:
+- - 1:27-34
+  - columns:
+    - !All
+      input_id: 128
+      except: []
+    inputs:
+    - id: 128
+      name: a
+      table:
+      - default_db
+      - albums
+- - 1:35-59
+  - columns:
+    - !All
+      input_id: 128
+      except: []
+    - !All
+      input_id: 122
+      except: []
+    inputs:
+    - id: 128
+      name: a
+      table:
+      - default_db
+      - albums
+    - id: 122
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:89-145
+  - columns:
+    - !Single
+      name:
+      - a
+      - album_id
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - a
+      - title
+      target_id: 139
+      target_name: null
+    - !Single
+      name:
+      - price
+      target_id: 157
+      target_name: null
+    inputs:
+    - id: 128
+      name: a
+      table:
+      - default_db
+      - albums
+    - id: 122
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:147-160
+  - columns:
+    - !Single
+      name:
+      - a
+      - album_id
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - a
+      - title
+      target_id: 139
+      target_name: null
+    - !Single
+      name:
+      - price
+      target_id: 157
+      target_name: null
+    inputs:
+    - id: 128
+      name: a
+      table:
+      - default_db
+      - albums
+    - id: 122
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 122
+  kind: Ident
+  span: 1:40-46
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 137
+- id: 128
+  kind: Ident
+  span: 1:13-26
+  ident: !Ident
+  - default_db
+  - albums
+  parent: 131
+- id: 131
+  kind: 'TransformCall: Take'
+  span: 1:27-34
+  children:
+  - 128
+  - 132
+  parent: 137
+- id: 132
+  kind: Literal
+  parent: 131
+- id: 133
+  kind: RqOperator
+  span: 1:48-58
+  targets:
+  - 135
+  - 136
+  parent: 137
+- id: 135
+  kind: Ident
+  span: 1:50-58
+  ident: !Ident
+  - this
+  - a
+  - album_id
+  targets:
+  - 128
+- id: 136
+  kind: Ident
+  span: 1:50-58
+  ident: !Ident
+  - that
+  - tracks
+  - album_id
+  targets:
+  - 122
+- id: 137
+  kind: 'TransformCall: Join'
+  span: 1:35-59
+  children:
+  - 131
+  - 122
+  - 133
+  parent: 165
+- id: 138
+  kind: Ident
+  span: 1:67-77
+  ident: !Ident
+  - this
+  - a
+  - album_id
+  targets:
+  - 128
+  parent: 140
+- id: 139
+  kind: Ident
+  span: 1:79-86
+  ident: !Ident
+  - this
+  - a
+  - title
+  targets:
+  - 128
+  parent: 140
+- id: 140
+  kind: Tuple
+  span: 1:66-87
+  children:
+  - 138
+  - 139
+  parent: 165
+- id: 157
+  kind: RqOperator
+  span: 1:132-144
+  alias: price
+  targets:
+  - 160
+  - 161
+  parent: 164
+- id: 160
+  kind: Literal
+  span: 1:143-144
+- id: 161
+  kind: RqOperator
+  span: 1:108-129
+  targets:
+  - 163
+- id: 163
+  kind: Ident
+  span: 1:118-129
+  ident: !Ident
+  - this
+  - tracks
+  - unit_price
+  targets:
+  - 122
+- id: 164
+  kind: Tuple
+  span: 1:132-144
+  children:
+  - 157
+  parent: 165
+- id: 165
+  kind: 'TransformCall: Aggregate'
+  span: 1:89-145
+  children:
+  - 137
+  - 164
+  - 140
+  parent: 170
+- id: 168
+  kind: Ident
+  span: 1:152-160
+  ident: !Ident
+  - this
+  - a
+  - album_id
+  targets:
+  - 138
+  parent: 170
+- id: 170
+  kind: 'TransformCall: Sort'
+  span: 1:147-160
+  children:
+  - 165
+  - 168
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: albums
+                alias: a
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 10
+          - FuncCall:
+              name:
+                Ident: join
+              args:
+              - Ident: tracks
+              - Unary:
+                  op: EqSelf
+                  expr:
+                    Ident: album_id
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Tuple:
+                - Indirection:
+                    base:
+                      Ident: a
+                    field: !Name album_id
+                - Indirection:
+                    base:
+                      Ident: a
+                    field: !Name title
+              - FuncCall:
+                  name:
+                    Ident: aggregate
+                  args:
+                  - Pipeline:
+                      exprs:
+                      - FuncCall:
+                          name:
+                            Ident: sum
+                          args:
+                          - Indirection:
+                              base:
+                                Ident: tracks
+                              field: !Name unit_price
+                      - FuncCall:
+                          name:
+                            Indirection:
+                              base:
+                                Ident: math
+                              field: !Name round
+                          args:
+                          - Literal:
+                              Integer: 2
+                    alias: price
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: album_id
+    span: 1:13-161

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_sort.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_sort.snap
@@ -3,4 +3,297 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom tracks\nderive d = album_id + 1\ngroup d (\n    aggregate {\n        n1 = (track_id | sum),\n    }\n)\nsort d\ntake 10\nselect { d1 = d, n1 }\n"
 input_file: prqlc/prqlc/tests/integration/queries/group_sort.prql
 ---
-{"frames":[["1:25-48",{"columns":[{"All":{"input_id":130,"except":[]}},{"Single":{"name":["d"],"target_id":132,"target_name":null}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}],["1:114-120",{"columns":[{"Single":{"name":["d"],"target_id":138,"target_name":null}},{"Single":{"name":["n1"],"target_id":155,"target_name":null}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}],["1:121-128",{"columns":[{"Single":{"name":["d"],"target_id":138,"target_name":null}},{"Single":{"name":["n1"],"target_id":155,"target_name":null}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}],["1:129-150",{"columns":[{"Single":{"name":["d1"],"target_id":168,"target_name":null}},{"Single":{"name":["n1"],"target_id":169,"target_name":null}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":130,"kind":"Ident","span":"1:13-24","ident":{"Ident":["default_db","tracks"]},"parent":137},{"id":132,"kind":"RqOperator","span":"1:36-48","alias":"d","targets":[134,135],"parent":136},{"id":134,"kind":"Ident","span":"1:36-44","ident":{"Ident":["this","tracks","album_id"]},"targets":[130]},{"id":135,"kind":"Literal","span":"1:47-48"},{"id":136,"kind":"Tuple","span":"1:36-48","children":[132],"parent":137},{"id":137,"kind":"TransformCall: Derive","span":"1:25-48","children":[130,136],"parent":159},{"id":138,"kind":"Ident","span":"1:55-56","ident":{"Ident":["this","d"]},"targets":[132],"parent":141},{"id":141,"kind":"Tuple","span":"1:55-56","children":[138],"parent":159},{"id":155,"kind":"RqOperator","span":"1:100-103","alias":"n1","targets":[157],"parent":158},{"id":157,"kind":"Ident","span":"1:89-97","ident":{"Ident":["this","tracks","track_id"]},"targets":[130]},{"id":158,"kind":"Tuple","span":"1:73-111","children":[155],"parent":159},{"id":159,"kind":"TransformCall: Aggregate","children":[137,158,141],"parent":164},{"id":162,"kind":"Ident","span":"1:119-120","ident":{"Ident":["this","d"]},"targets":[138],"parent":164},{"id":164,"kind":"TransformCall: Sort","span":"1:114-120","children":[159,162],"parent":166},{"id":166,"kind":"TransformCall: Take","span":"1:121-128","children":[164,167],"parent":171},{"id":167,"kind":"Literal","parent":166},{"id":168,"kind":"Ident","span":"1:143-144","alias":"d1","ident":{"Ident":["this","d"]},"targets":[138],"parent":170},{"id":169,"kind":"Ident","span":"1:146-148","ident":{"Ident":["this","n1"]},"targets":[155],"parent":170},{"id":170,"kind":"Tuple","span":"1:136-150","children":[168,169],"parent":171},{"id":171,"kind":"TransformCall: Select","span":"1:129-150","children":[166,170]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"derive"},"args":[{"Binary":{"left":{"Ident":"album_id"},"op":"Add","right":{"Literal":{"Integer":1}}},"alias":"d"}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Ident":"d"},{"FuncCall":{"name":{"Ident":"aggregate"},"args":[{"Tuple":[{"Pipeline":{"exprs":[{"Ident":"track_id"},{"Ident":"sum"}]},"alias":"n1"}]}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"d"}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":10}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"d","alias":"d1"},{"Ident":"n1"}]}]}}]}}},"span":"1:13-151"}]}}
+frames:
+- - 1:25-48
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    - !Single
+      name:
+      - d
+      target_id: 132
+      target_name: null
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:63-111
+  - columns:
+    - !Single
+      name:
+      - d
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - n1
+      target_id: 155
+      target_name: null
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:114-120
+  - columns:
+    - !Single
+      name:
+      - d
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - n1
+      target_id: 155
+      target_name: null
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:121-128
+  - columns:
+    - !Single
+      name:
+      - d
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - n1
+      target_id: 155
+      target_name: null
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:129-150
+  - columns:
+    - !Single
+      name:
+      - d1
+      target_id: 168
+      target_name: null
+    - !Single
+      name:
+      - n1
+      target_id: 169
+      target_name: null
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 130
+  kind: Ident
+  span: 1:13-24
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 137
+- id: 132
+  kind: RqOperator
+  span: 1:36-48
+  alias: d
+  targets:
+  - 134
+  - 135
+  parent: 136
+- id: 134
+  kind: Ident
+  span: 1:36-44
+  ident: !Ident
+  - this
+  - tracks
+  - album_id
+  targets:
+  - 130
+- id: 135
+  kind: Literal
+  span: 1:47-48
+- id: 136
+  kind: Tuple
+  span: 1:36-48
+  children:
+  - 132
+  parent: 137
+- id: 137
+  kind: 'TransformCall: Derive'
+  span: 1:25-48
+  children:
+  - 130
+  - 136
+  parent: 159
+- id: 138
+  kind: Ident
+  span: 1:55-56
+  ident: !Ident
+  - this
+  - d
+  targets:
+  - 132
+  parent: 141
+- id: 141
+  kind: Tuple
+  span: 1:55-56
+  children:
+  - 138
+  parent: 159
+- id: 155
+  kind: RqOperator
+  span: 1:100-103
+  alias: n1
+  targets:
+  - 157
+  parent: 158
+- id: 157
+  kind: Ident
+  span: 1:89-97
+  ident: !Ident
+  - this
+  - tracks
+  - track_id
+  targets:
+  - 130
+- id: 158
+  kind: Tuple
+  span: 1:73-111
+  children:
+  - 155
+  parent: 159
+- id: 159
+  kind: 'TransformCall: Aggregate'
+  span: 1:63-111
+  children:
+  - 137
+  - 158
+  - 141
+  parent: 164
+- id: 162
+  kind: Ident
+  span: 1:119-120
+  ident: !Ident
+  - this
+  - d
+  targets:
+  - 138
+  parent: 164
+- id: 164
+  kind: 'TransformCall: Sort'
+  span: 1:114-120
+  children:
+  - 159
+  - 162
+  parent: 166
+- id: 166
+  kind: 'TransformCall: Take'
+  span: 1:121-128
+  children:
+  - 164
+  - 167
+  parent: 171
+- id: 167
+  kind: Literal
+  parent: 166
+- id: 168
+  kind: Ident
+  span: 1:143-144
+  alias: d1
+  ident: !Ident
+  - this
+  - d
+  targets:
+  - 138
+  parent: 170
+- id: 169
+  kind: Ident
+  span: 1:146-148
+  ident: !Ident
+  - this
+  - n1
+  targets:
+  - 155
+  parent: 170
+- id: 170
+  kind: Tuple
+  span: 1:136-150
+  children:
+  - 168
+  - 169
+  parent: 171
+- id: 171
+  kind: 'TransformCall: Select'
+  span: 1:129-150
+  children:
+  - 166
+  - 170
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: derive
+              args:
+              - Binary:
+                  left:
+                    Ident: album_id
+                  op: Add
+                  right:
+                    Literal:
+                      Integer: 1
+                alias: d
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Ident: d
+              - FuncCall:
+                  name:
+                    Ident: aggregate
+                  args:
+                  - Tuple:
+                    - Pipeline:
+                        exprs:
+                        - Ident: track_id
+                        - Ident: sum
+                      alias: n1
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: d
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 10
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: d
+                  alias: d1
+                - Ident: n1
+    span: 1:13-151

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_sort_limit_take.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_sort_limit_take.snap
@@ -3,4 +3,373 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# Compute the 3 longest songs for each genre and sort by genre\n# mssql:test\nfrom tracks\nselect {genre_id,milliseconds}\ngroup {genre_id} (\n  sort {-milliseconds}\n  take 3\n)\njoin genres (==genre_id)\nselect {name, milliseconds}\nsort {+name,-milliseconds}\n"
 input_file: prqlc/prqlc/tests/integration/queries/group_sort_limit_take.prql
 ---
-{"frames":[["1:88-118",{"columns":[{"Single":{"name":["tracks","genre_id"],"target_id":133,"target_name":null}},{"Single":{"name":["tracks","milliseconds"],"target_id":134,"target_name":null}}],"inputs":[{"id":131,"name":"tracks","table":["default_db","tracks"]}]}],["1:172-196",{"columns":[{"Single":{"name":["tracks","genre_id"],"target_id":137,"target_name":null}},{"Single":{"name":["tracks","milliseconds"],"target_id":134,"target_name":null}},{"All":{"input_id":122,"except":[]}}],"inputs":[{"id":131,"name":"tracks","table":["default_db","tracks"]},{"id":122,"name":"genres","table":["default_db","genres"]}]}],["1:197-224",{"columns":[{"Single":{"name":["genres","name"],"target_id":175,"target_name":null}},{"Single":{"name":["tracks","milliseconds"],"target_id":176,"target_name":null}}],"inputs":[{"id":131,"name":"tracks","table":["default_db","tracks"]},{"id":122,"name":"genres","table":["default_db","genres"]}]}],["1:225-251",{"columns":[{"Single":{"name":["genres","name"],"target_id":175,"target_name":null}},{"Single":{"name":["tracks","milliseconds"],"target_id":176,"target_name":null}}],"inputs":[{"id":131,"name":"tracks","table":["default_db","tracks"]},{"id":122,"name":"genres","table":["default_db","genres"]}]}]],"nodes":[{"id":122,"kind":"Ident","span":"1:177-183","ident":{"Ident":["default_db","genres"]},"parent":174},{"id":131,"kind":"Ident","span":"1:76-87","ident":{"Ident":["default_db","tracks"]},"parent":136},{"id":133,"kind":"Ident","span":"1:96-104","ident":{"Ident":["this","tracks","genre_id"]},"targets":[131],"parent":135},{"id":134,"kind":"Ident","span":"1:105-117","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[131],"parent":135},{"id":135,"kind":"Tuple","span":"1:95-118","children":[133,134],"parent":136},{"id":136,"kind":"TransformCall: Select","span":"1:88-118","children":[131,135],"parent":166},{"id":137,"kind":"Ident","span":"1:126-134","ident":{"Ident":["this","tracks","genre_id"]},"targets":[133],"parent":138},{"id":138,"kind":"Tuple","span":"1:125-135","children":[137]},{"id":162,"kind":"Ident","span":"1:147-159","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[134]},{"id":166,"kind":"TransformCall: Take","children":[136,167],"parent":174},{"id":167,"kind":"Literal","parent":166},{"id":170,"kind":"RqOperator","span":"1:185-195","targets":[172,173],"parent":174},{"id":172,"kind":"Ident","span":"1:187-195","ident":{"Ident":["this","tracks","genre_id"]},"targets":[137]},{"id":173,"kind":"Ident","span":"1:187-195","ident":{"Ident":["that","genres","genre_id"]},"targets":[122]},{"id":174,"kind":"TransformCall: Join","span":"1:172-196","children":[166,122,170],"parent":178},{"id":175,"kind":"Ident","span":"1:205-209","ident":{"Ident":["this","genres","name"]},"targets":[122],"parent":177},{"id":176,"kind":"Ident","span":"1:211-223","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[134],"parent":177},{"id":177,"kind":"Tuple","span":"1:204-224","children":[175,176],"parent":178},{"id":178,"kind":"TransformCall: Select","span":"1:197-224","children":[174,177],"parent":184},{"id":179,"kind":"Ident","span":"1:231-236","ident":{"Ident":["this","genres","name"]},"targets":[175],"parent":184},{"id":182,"kind":"Ident","span":"1:238-250","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[176],"parent":184},{"id":184,"kind":"TransformCall: Sort","span":"1:225-251","children":[178,179,182]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"genre_id"},{"Ident":"milliseconds"}]}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Tuple":[{"Ident":"genre_id"}]},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Unary":{"op":"Neg","expr":{"Ident":"milliseconds"}}}]}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":3}}]}}]}}]}},{"FuncCall":{"name":{"Ident":"join"},"args":[{"Ident":"genres"},{"Unary":{"op":"EqSelf","expr":{"Ident":"genre_id"}}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"name"},{"Ident":"milliseconds"}]}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Unary":{"op":"Add","expr":{"Ident":"name"}}},{"Unary":{"op":"Neg","expr":{"Ident":"milliseconds"}}}]}]}}]}}},"span":"1:76-252"}]}}
+frames:
+- - 1:88-118
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 133
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - milliseconds
+      target_id: 134
+      target_name: null
+    inputs:
+    - id: 131
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:163-169
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 137
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - milliseconds
+      target_id: 134
+      target_name: null
+    inputs:
+    - id: 131
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:172-196
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 137
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - milliseconds
+      target_id: 134
+      target_name: null
+    - !All
+      input_id: 122
+      except: []
+    inputs:
+    - id: 131
+      name: tracks
+      table:
+      - default_db
+      - tracks
+    - id: 122
+      name: genres
+      table:
+      - default_db
+      - genres
+- - 1:197-224
+  - columns:
+    - !Single
+      name:
+      - genres
+      - name
+      target_id: 175
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - milliseconds
+      target_id: 176
+      target_name: null
+    inputs:
+    - id: 131
+      name: tracks
+      table:
+      - default_db
+      - tracks
+    - id: 122
+      name: genres
+      table:
+      - default_db
+      - genres
+- - 1:225-251
+  - columns:
+    - !Single
+      name:
+      - genres
+      - name
+      target_id: 175
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - milliseconds
+      target_id: 176
+      target_name: null
+    inputs:
+    - id: 131
+      name: tracks
+      table:
+      - default_db
+      - tracks
+    - id: 122
+      name: genres
+      table:
+      - default_db
+      - genres
+nodes:
+- id: 122
+  kind: Ident
+  span: 1:177-183
+  ident: !Ident
+  - default_db
+  - genres
+  parent: 174
+- id: 131
+  kind: Ident
+  span: 1:76-87
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 136
+- id: 133
+  kind: Ident
+  span: 1:96-104
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 131
+  parent: 135
+- id: 134
+  kind: Ident
+  span: 1:105-117
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 131
+  parent: 135
+- id: 135
+  kind: Tuple
+  span: 1:95-118
+  children:
+  - 133
+  - 134
+  parent: 136
+- id: 136
+  kind: 'TransformCall: Select'
+  span: 1:88-118
+  children:
+  - 131
+  - 135
+  parent: 166
+- id: 137
+  kind: Ident
+  span: 1:126-134
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 133
+  parent: 138
+- id: 138
+  kind: Tuple
+  span: 1:125-135
+  children:
+  - 137
+- id: 162
+  kind: Ident
+  span: 1:147-159
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 134
+- id: 166
+  kind: 'TransformCall: Take'
+  span: 1:163-169
+  children:
+  - 136
+  - 167
+  parent: 174
+- id: 167
+  kind: Literal
+  parent: 166
+- id: 170
+  kind: RqOperator
+  span: 1:185-195
+  targets:
+  - 172
+  - 173
+  parent: 174
+- id: 172
+  kind: Ident
+  span: 1:187-195
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 137
+- id: 173
+  kind: Ident
+  span: 1:187-195
+  ident: !Ident
+  - that
+  - genres
+  - genre_id
+  targets:
+  - 122
+- id: 174
+  kind: 'TransformCall: Join'
+  span: 1:172-196
+  children:
+  - 166
+  - 122
+  - 170
+  parent: 178
+- id: 175
+  kind: Ident
+  span: 1:205-209
+  ident: !Ident
+  - this
+  - genres
+  - name
+  targets:
+  - 122
+  parent: 177
+- id: 176
+  kind: Ident
+  span: 1:211-223
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 134
+  parent: 177
+- id: 177
+  kind: Tuple
+  span: 1:204-224
+  children:
+  - 175
+  - 176
+  parent: 178
+- id: 178
+  kind: 'TransformCall: Select'
+  span: 1:197-224
+  children:
+  - 174
+  - 177
+  parent: 184
+- id: 179
+  kind: Ident
+  span: 1:231-236
+  ident: !Ident
+  - this
+  - genres
+  - name
+  targets:
+  - 175
+  parent: 184
+- id: 182
+  kind: Ident
+  span: 1:238-250
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 176
+  parent: 184
+- id: 184
+  kind: 'TransformCall: Sort'
+  span: 1:225-251
+  children:
+  - 178
+  - 179
+  - 182
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: genre_id
+                - Ident: milliseconds
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Tuple:
+                - Ident: genre_id
+              - Pipeline:
+                  exprs:
+                  - FuncCall:
+                      name:
+                        Ident: sort
+                      args:
+                      - Tuple:
+                        - Unary:
+                            op: Neg
+                            expr:
+                              Ident: milliseconds
+                  - FuncCall:
+                      name:
+                        Ident: take
+                      args:
+                      - Literal:
+                          Integer: 3
+          - FuncCall:
+              name:
+                Ident: join
+              args:
+              - Ident: genres
+              - Unary:
+                  op: EqSelf
+                  expr:
+                    Ident: genre_id
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: name
+                - Ident: milliseconds
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Unary:
+                    op: Add
+                    expr:
+                      Ident: name
+                - Unary:
+                    op: Neg
+                    expr:
+                      Ident: milliseconds
+    span: 1:76-252

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__invoice_totals.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__invoice_totals.snap
@@ -3,4 +3,901 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# clickhouse:skip (clickhouse doesn't have lag function)\n\n#! Calculate a number of metrics about the sales of tracks in each city.\nfrom i=invoices\njoin ii=invoice_items (==invoice_id)\nderive {\n    city = i.billing_city,\n    street = i.billing_address,\n}\ngroup {city, street} (\n    derive total = ii.unit_price * ii.quantity\n    aggregate {\n        num_orders = count_distinct i.invoice_id,\n        num_tracks = sum ii.quantity,\n        total_price = sum total,\n    }\n)\ngroup {city} (\n    sort street\n    window expanding:true (\n        derive {running_total_num_tracks = sum num_tracks}\n    )\n)\nsort {city, street}\nderive {num_tracks_last_week = lag 7 num_tracks}\nselect {\n    city,\n    street,\n    num_orders,\n    num_tracks,\n    running_total_num_tracks,\n    num_tracks_last_week\n}\ntake 20\n"
 input_file: prqlc/prqlc/tests/integration/queries/invoice_totals.prql
 ---
-{"frames":[["1:147-183",{"columns":[{"All":{"input_id":140,"except":[]}},{"All":{"input_id":137,"except":[]}}],"inputs":[{"id":140,"name":"i","table":["default_db","invoices"]},{"id":137,"name":"ii","table":["default_db","invoice_items"]}]}],["1:184-253",{"columns":[{"All":{"input_id":140,"except":[]}},{"All":{"input_id":137,"except":[]}},{"Single":{"name":["city"],"target_id":147,"target_name":null}},{"Single":{"name":["street"],"target_id":148,"target_name":null}}],"inputs":[{"id":140,"name":"i","table":["default_db","invoices"]},{"id":137,"name":"ii","table":["default_db","invoice_items"]}]}],["1:281-323",{"columns":[{"All":{"input_id":140,"except":[]}},{"All":{"input_id":137,"except":[]}},{"Single":{"name":["total"],"target_id":178,"target_name":null}}],"inputs":[{"id":140,"name":"i","table":["default_db","invoices"]},{"id":137,"name":"ii","table":["default_db","invoice_items"]}]}],["1:595-614",{"columns":[{"Single":{"name":["city"],"target_id":197,"target_name":null}},{"Single":{"name":["street"],"target_id":152,"target_name":null}},{"Single":{"name":["num_orders"],"target_id":184,"target_name":null}},{"Single":{"name":["num_tracks"],"target_id":187,"target_name":null}},{"Single":{"name":["total_price"],"target_id":190,"target_name":null}},{"Single":{"name":["running_total_num_tracks"],"target_id":243,"target_name":null}}],"inputs":[{"id":140,"name":"i","table":["default_db","invoices"]},{"id":137,"name":"ii","table":["default_db","invoice_items"]}]}],["1:615-663",{"columns":[{"Single":{"name":["city"],"target_id":197,"target_name":null}},{"Single":{"name":["street"],"target_id":152,"target_name":null}},{"Single":{"name":["num_orders"],"target_id":184,"target_name":null}},{"Single":{"name":["num_tracks"],"target_id":187,"target_name":null}},{"Single":{"name":["total_price"],"target_id":190,"target_name":null}},{"Single":{"name":["running_total_num_tracks"],"target_id":243,"target_name":null}},{"Single":{"name":["num_tracks_last_week"],"target_id":257,"target_name":null}}],"inputs":[{"id":140,"name":"i","table":["default_db","invoices"]},{"id":137,"name":"ii","table":["default_db","invoice_items"]}]}],["1:664-783",{"columns":[{"Single":{"name":["city"],"target_id":263,"target_name":null}},{"Single":{"name":["street"],"target_id":264,"target_name":null}},{"Single":{"name":["num_orders"],"target_id":265,"target_name":null}},{"Single":{"name":["num_tracks"],"target_id":266,"target_name":null}},{"Single":{"name":["running_total_num_tracks"],"target_id":267,"target_name":null}},{"Single":{"name":["num_tracks_last_week"],"target_id":268,"target_name":null}}],"inputs":[{"id":140,"name":"i","table":["default_db","invoices"]},{"id":137,"name":"ii","table":["default_db","invoice_items"]}]}],["1:784-791",{"columns":[{"Single":{"name":["city"],"target_id":263,"target_name":null}},{"Single":{"name":["street"],"target_id":264,"target_name":null}},{"Single":{"name":["num_orders"],"target_id":265,"target_name":null}},{"Single":{"name":["num_tracks"],"target_id":266,"target_name":null}},{"Single":{"name":["running_total_num_tracks"],"target_id":267,"target_name":null}},{"Single":{"name":["num_tracks_last_week"],"target_id":268,"target_name":null}}],"inputs":[{"id":140,"name":"i","table":["default_db","invoices"]},{"id":137,"name":"ii","table":["default_db","invoice_items"]}]}]],"nodes":[{"id":137,"kind":"Ident","span":"1:155-168","ident":{"Ident":["default_db","invoice_items"]},"parent":146},{"id":140,"kind":"Ident","span":"1:131-146","ident":{"Ident":["default_db","invoices"]},"parent":146},{"id":142,"kind":"RqOperator","span":"1:170-182","targets":[144,145],"parent":146},{"id":144,"kind":"Ident","span":"1:172-182","ident":{"Ident":["this","i","invoice_id"]},"targets":[140]},{"id":145,"kind":"Ident","span":"1:172-182","ident":{"Ident":["that","ii","invoice_id"]},"targets":[137]},{"id":146,"kind":"TransformCall: Join","span":"1:147-183","children":[140,137,142],"parent":150},{"id":147,"kind":"Ident","span":"1:204-218","alias":"city","ident":{"Ident":["this","i","billing_city"]},"targets":[140],"parent":149},{"id":148,"kind":"Ident","span":"1:233-250","alias":"street","ident":{"Ident":["this","i","billing_address"]},"targets":[140],"parent":149},{"id":149,"kind":"Tuple","span":"1:191-253","children":[147,148],"parent":150},{"id":150,"kind":"TransformCall: Derive","span":"1:184-253","children":[146,149],"parent":183},{"id":151,"kind":"Ident","span":"1:261-265","ident":{"Ident":["this","city"]},"targets":[147],"parent":153},{"id":152,"kind":"Ident","span":"1:267-273","ident":{"Ident":["this","street"]},"targets":[148],"parent":153},{"id":153,"kind":"Tuple","span":"1:260-274","children":[151,152],"parent":194},{"id":178,"kind":"RqOperator","span":"1:296-323","alias":"total","targets":[180,181],"parent":182},{"id":180,"kind":"Ident","span":"1:298-309","ident":{"Ident":["this","ii","unit_price"]},"targets":[137]},{"id":181,"kind":"Ident","span":"1:314-323","ident":{"Ident":["this","ii","quantity"]},"targets":[137]},{"id":182,"kind":"Tuple","span":"1:296-323","children":[178],"parent":183},{"id":183,"kind":"TransformCall: Derive","span":"1:281-323","children":[150,182],"parent":194},{"id":184,"kind":"RqOperator","span":"1:361-388","alias":"num_orders","targets":[186],"parent":193},{"id":186,"kind":"Ident","span":"1:377-388","ident":{"Ident":["this","i","invoice_id"]},"targets":[140]},{"id":187,"kind":"RqOperator","span":"1:411-426","alias":"num_tracks","targets":[189],"parent":193},{"id":189,"kind":"Ident","span":"1:417-426","ident":{"Ident":["this","ii","quantity"]},"targets":[137]},{"id":190,"kind":"RqOperator","span":"1:450-459","alias":"total_price","targets":[192],"parent":193},{"id":192,"kind":"Ident","span":"1:454-459","ident":{"Ident":["this","total"]},"targets":[178]},{"id":193,"kind":"Tuple","span":"1:338-466","children":[184,187,190],"parent":194},{"id":194,"kind":"TransformCall: Aggregate","children":[183,193,153],"parent":247},{"id":197,"kind":"Ident","span":"1:476-480","ident":{"Ident":["this","city"]},"targets":[151],"parent":198},{"id":198,"kind":"Tuple","span":"1:475-481","children":[197]},{"id":222,"kind":"Ident","span":"1:493-499","ident":{"Ident":["this","street"]},"targets":[152]},{"id":243,"kind":"RqOperator","span":"1:571-585","alias":"running_total_num_tracks","targets":[245],"parent":246},{"id":245,"kind":"Ident","span":"1:575-585","ident":{"Ident":["this","num_tracks"]},"targets":[187]},{"id":246,"kind":"Tuple","span":"1:543-586","children":[243],"parent":247},{"id":247,"kind":"TransformCall: Derive","children":[194,246],"parent":256},{"id":249,"kind":"Literal"},{"id":253,"kind":"Ident","span":"1:601-605","ident":{"Ident":["this","city"]},"targets":[197],"parent":256},{"id":254,"kind":"Ident","span":"1:607-613","ident":{"Ident":["this","street"]},"targets":[152],"parent":256},{"id":256,"kind":"TransformCall: Sort","span":"1:595-614","children":[247,253,254],"parent":262},{"id":257,"kind":"RqOperator","span":"1:646-662","alias":"num_tracks_last_week","targets":[259,260],"parent":261},{"id":259,"kind":"Literal","span":"1:650-651"},{"id":260,"kind":"Ident","span":"1:652-662","ident":{"Ident":["this","num_tracks"]},"targets":[187]},{"id":261,"kind":"Tuple","span":"1:622-663","children":[257],"parent":262},{"id":262,"kind":"TransformCall: Derive","span":"1:615-663","children":[256,261],"parent":270},{"id":263,"kind":"Ident","span":"1:677-681","ident":{"Ident":["this","city"]},"targets":[197],"parent":269},{"id":264,"kind":"Ident","span":"1:687-693","ident":{"Ident":["this","street"]},"targets":[152],"parent":269},{"id":265,"kind":"Ident","span":"1:699-709","ident":{"Ident":["this","num_orders"]},"targets":[184],"parent":269},{"id":266,"kind":"Ident","span":"1:715-725","ident":{"Ident":["this","num_tracks"]},"targets":[187],"parent":269},{"id":267,"kind":"Ident","span":"1:731-755","ident":{"Ident":["this","running_total_num_tracks"]},"targets":[243],"parent":269},{"id":268,"kind":"Ident","span":"1:761-781","ident":{"Ident":["this","num_tracks_last_week"]},"targets":[257],"parent":269},{"id":269,"kind":"Tuple","span":"1:671-783","children":[263,264,265,266,267,268],"parent":270},{"id":270,"kind":"TransformCall: Select","span":"1:664-783","children":[262,269],"parent":272},{"id":272,"kind":"TransformCall: Take","span":"1:784-791","children":[270,273]},{"id":273,"kind":"Literal","parent":272}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"invoices","alias":"i"}]}},{"FuncCall":{"name":{"Ident":"join"},"args":[{"Ident":"invoice_items","alias":"ii"},{"Unary":{"op":"EqSelf","expr":{"Ident":"invoice_id"}}}]}},{"FuncCall":{"name":{"Ident":"derive"},"args":[{"Tuple":[{"Indirection":{"base":{"Ident":"i"},"field":{"Name":"billing_city"}},"alias":"city"},{"Indirection":{"base":{"Ident":"i"},"field":{"Name":"billing_address"}},"alias":"street"}]}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Tuple":[{"Ident":"city"},{"Ident":"street"}]},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"derive"},"args":[{"Binary":{"left":{"Indirection":{"base":{"Ident":"ii"},"field":{"Name":"unit_price"}}},"op":"Mul","right":{"Indirection":{"base":{"Ident":"ii"},"field":{"Name":"quantity"}}}},"alias":"total"}]}},{"FuncCall":{"name":{"Ident":"aggregate"},"args":[{"Tuple":[{"FuncCall":{"name":{"Ident":"count_distinct"},"args":[{"Indirection":{"base":{"Ident":"i"},"field":{"Name":"invoice_id"}}}]},"alias":"num_orders"},{"FuncCall":{"name":{"Ident":"sum"},"args":[{"Indirection":{"base":{"Ident":"ii"},"field":{"Name":"quantity"}}}]},"alias":"num_tracks"},{"FuncCall":{"name":{"Ident":"sum"},"args":[{"Ident":"total"}]},"alias":"total_price"}]}]}}]}}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Tuple":[{"Ident":"city"}]},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"street"}]}},{"FuncCall":{"name":{"Ident":"window"},"args":[{"FuncCall":{"name":{"Ident":"derive"},"args":[{"Tuple":[{"FuncCall":{"name":{"Ident":"sum"},"args":[{"Ident":"num_tracks"}]},"alias":"running_total_num_tracks"}]}]}}],"named_args":{"expanding":{"Literal":{"Boolean":true}}}}}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Ident":"city"},{"Ident":"street"}]}]}},{"FuncCall":{"name":{"Ident":"derive"},"args":[{"Tuple":[{"FuncCall":{"name":{"Ident":"lag"},"args":[{"Literal":{"Integer":7}},{"Ident":"num_tracks"}]},"alias":"num_tracks_last_week"}]}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"city"},{"Ident":"street"},{"Ident":"num_orders"},{"Ident":"num_tracks"},{"Ident":"running_total_num_tracks"},{"Ident":"num_tracks_last_week"}]}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":20}}]}}]}}},"span":"1:131-792"}]}}
+frames:
+- - 1:147-183
+  - columns:
+    - !All
+      input_id: 140
+      except: []
+    - !All
+      input_id: 137
+      except: []
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:184-253
+  - columns:
+    - !All
+      input_id: 140
+      except: []
+    - !All
+      input_id: 137
+      except: []
+    - !Single
+      name:
+      - city
+      target_id: 147
+      target_name: null
+    - !Single
+      name:
+      - street
+      target_id: 148
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:281-323
+  - columns:
+    - !All
+      input_id: 140
+      except: []
+    - !All
+      input_id: 137
+      except: []
+    - !Single
+      name:
+      - total
+      target_id: 178
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:328-466
+  - columns:
+    - !Single
+      name:
+      - city
+      target_id: 151
+      target_name: null
+    - !Single
+      name:
+      - street
+      target_id: 152
+      target_name: null
+    - !Single
+      name:
+      - num_orders
+      target_id: 184
+      target_name: null
+    - !Single
+      name:
+      - num_tracks
+      target_id: 187
+      target_name: null
+    - !Single
+      name:
+      - total_price
+      target_id: 190
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:536-586
+  - columns:
+    - !Single
+      name:
+      - city
+      target_id: 197
+      target_name: null
+    - !Single
+      name:
+      - street
+      target_id: 152
+      target_name: null
+    - !Single
+      name:
+      - num_orders
+      target_id: 184
+      target_name: null
+    - !Single
+      name:
+      - num_tracks
+      target_id: 187
+      target_name: null
+    - !Single
+      name:
+      - total_price
+      target_id: 190
+      target_name: null
+    - !Single
+      name:
+      - running_total_num_tracks
+      target_id: 243
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:595-614
+  - columns:
+    - !Single
+      name:
+      - city
+      target_id: 197
+      target_name: null
+    - !Single
+      name:
+      - street
+      target_id: 152
+      target_name: null
+    - !Single
+      name:
+      - num_orders
+      target_id: 184
+      target_name: null
+    - !Single
+      name:
+      - num_tracks
+      target_id: 187
+      target_name: null
+    - !Single
+      name:
+      - total_price
+      target_id: 190
+      target_name: null
+    - !Single
+      name:
+      - running_total_num_tracks
+      target_id: 243
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:615-663
+  - columns:
+    - !Single
+      name:
+      - city
+      target_id: 197
+      target_name: null
+    - !Single
+      name:
+      - street
+      target_id: 152
+      target_name: null
+    - !Single
+      name:
+      - num_orders
+      target_id: 184
+      target_name: null
+    - !Single
+      name:
+      - num_tracks
+      target_id: 187
+      target_name: null
+    - !Single
+      name:
+      - total_price
+      target_id: 190
+      target_name: null
+    - !Single
+      name:
+      - running_total_num_tracks
+      target_id: 243
+      target_name: null
+    - !Single
+      name:
+      - num_tracks_last_week
+      target_id: 257
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:664-783
+  - columns:
+    - !Single
+      name:
+      - city
+      target_id: 263
+      target_name: null
+    - !Single
+      name:
+      - street
+      target_id: 264
+      target_name: null
+    - !Single
+      name:
+      - num_orders
+      target_id: 265
+      target_name: null
+    - !Single
+      name:
+      - num_tracks
+      target_id: 266
+      target_name: null
+    - !Single
+      name:
+      - running_total_num_tracks
+      target_id: 267
+      target_name: null
+    - !Single
+      name:
+      - num_tracks_last_week
+      target_id: 268
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+- - 1:784-791
+  - columns:
+    - !Single
+      name:
+      - city
+      target_id: 263
+      target_name: null
+    - !Single
+      name:
+      - street
+      target_id: 264
+      target_name: null
+    - !Single
+      name:
+      - num_orders
+      target_id: 265
+      target_name: null
+    - !Single
+      name:
+      - num_tracks
+      target_id: 266
+      target_name: null
+    - !Single
+      name:
+      - running_total_num_tracks
+      target_id: 267
+      target_name: null
+    - !Single
+      name:
+      - num_tracks_last_week
+      target_id: 268
+      target_name: null
+    inputs:
+    - id: 140
+      name: i
+      table:
+      - default_db
+      - invoices
+    - id: 137
+      name: ii
+      table:
+      - default_db
+      - invoice_items
+nodes:
+- id: 137
+  kind: Ident
+  span: 1:155-168
+  ident: !Ident
+  - default_db
+  - invoice_items
+  parent: 146
+- id: 140
+  kind: Ident
+  span: 1:131-146
+  ident: !Ident
+  - default_db
+  - invoices
+  parent: 146
+- id: 142
+  kind: RqOperator
+  span: 1:170-182
+  targets:
+  - 144
+  - 145
+  parent: 146
+- id: 144
+  kind: Ident
+  span: 1:172-182
+  ident: !Ident
+  - this
+  - i
+  - invoice_id
+  targets:
+  - 140
+- id: 145
+  kind: Ident
+  span: 1:172-182
+  ident: !Ident
+  - that
+  - ii
+  - invoice_id
+  targets:
+  - 137
+- id: 146
+  kind: 'TransformCall: Join'
+  span: 1:147-183
+  children:
+  - 140
+  - 137
+  - 142
+  parent: 150
+- id: 147
+  kind: Ident
+  span: 1:204-218
+  alias: city
+  ident: !Ident
+  - this
+  - i
+  - billing_city
+  targets:
+  - 140
+  parent: 149
+- id: 148
+  kind: Ident
+  span: 1:233-250
+  alias: street
+  ident: !Ident
+  - this
+  - i
+  - billing_address
+  targets:
+  - 140
+  parent: 149
+- id: 149
+  kind: Tuple
+  span: 1:191-253
+  children:
+  - 147
+  - 148
+  parent: 150
+- id: 150
+  kind: 'TransformCall: Derive'
+  span: 1:184-253
+  children:
+  - 146
+  - 149
+  parent: 183
+- id: 151
+  kind: Ident
+  span: 1:261-265
+  ident: !Ident
+  - this
+  - city
+  targets:
+  - 147
+  parent: 153
+- id: 152
+  kind: Ident
+  span: 1:267-273
+  ident: !Ident
+  - this
+  - street
+  targets:
+  - 148
+  parent: 153
+- id: 153
+  kind: Tuple
+  span: 1:260-274
+  children:
+  - 151
+  - 152
+  parent: 194
+- id: 178
+  kind: RqOperator
+  span: 1:296-323
+  alias: total
+  targets:
+  - 180
+  - 181
+  parent: 182
+- id: 180
+  kind: Ident
+  span: 1:298-309
+  ident: !Ident
+  - this
+  - ii
+  - unit_price
+  targets:
+  - 137
+- id: 181
+  kind: Ident
+  span: 1:314-323
+  ident: !Ident
+  - this
+  - ii
+  - quantity
+  targets:
+  - 137
+- id: 182
+  kind: Tuple
+  span: 1:296-323
+  children:
+  - 178
+  parent: 183
+- id: 183
+  kind: 'TransformCall: Derive'
+  span: 1:281-323
+  children:
+  - 150
+  - 182
+  parent: 194
+- id: 184
+  kind: RqOperator
+  span: 1:361-388
+  alias: num_orders
+  targets:
+  - 186
+  parent: 193
+- id: 186
+  kind: Ident
+  span: 1:377-388
+  ident: !Ident
+  - this
+  - i
+  - invoice_id
+  targets:
+  - 140
+- id: 187
+  kind: RqOperator
+  span: 1:411-426
+  alias: num_tracks
+  targets:
+  - 189
+  parent: 193
+- id: 189
+  kind: Ident
+  span: 1:417-426
+  ident: !Ident
+  - this
+  - ii
+  - quantity
+  targets:
+  - 137
+- id: 190
+  kind: RqOperator
+  span: 1:450-459
+  alias: total_price
+  targets:
+  - 192
+  parent: 193
+- id: 192
+  kind: Ident
+  span: 1:454-459
+  ident: !Ident
+  - this
+  - total
+  targets:
+  - 178
+- id: 193
+  kind: Tuple
+  span: 1:338-466
+  children:
+  - 184
+  - 187
+  - 190
+  parent: 194
+- id: 194
+  kind: 'TransformCall: Aggregate'
+  span: 1:328-466
+  children:
+  - 183
+  - 193
+  - 153
+  parent: 247
+- id: 197
+  kind: Ident
+  span: 1:476-480
+  ident: !Ident
+  - this
+  - city
+  targets:
+  - 151
+  parent: 198
+- id: 198
+  kind: Tuple
+  span: 1:475-481
+  children:
+  - 197
+- id: 222
+  kind: Ident
+  span: 1:493-499
+  ident: !Ident
+  - this
+  - street
+  targets:
+  - 152
+- id: 243
+  kind: RqOperator
+  span: 1:571-585
+  alias: running_total_num_tracks
+  targets:
+  - 245
+  parent: 246
+- id: 245
+  kind: Ident
+  span: 1:575-585
+  ident: !Ident
+  - this
+  - num_tracks
+  targets:
+  - 187
+- id: 246
+  kind: Tuple
+  span: 1:543-586
+  children:
+  - 243
+  parent: 247
+- id: 247
+  kind: 'TransformCall: Derive'
+  span: 1:536-586
+  children:
+  - 194
+  - 246
+  parent: 256
+- id: 249
+  kind: Literal
+- id: 253
+  kind: Ident
+  span: 1:601-605
+  ident: !Ident
+  - this
+  - city
+  targets:
+  - 197
+  parent: 256
+- id: 254
+  kind: Ident
+  span: 1:607-613
+  ident: !Ident
+  - this
+  - street
+  targets:
+  - 152
+  parent: 256
+- id: 256
+  kind: 'TransformCall: Sort'
+  span: 1:595-614
+  children:
+  - 247
+  - 253
+  - 254
+  parent: 262
+- id: 257
+  kind: RqOperator
+  span: 1:646-662
+  alias: num_tracks_last_week
+  targets:
+  - 259
+  - 260
+  parent: 261
+- id: 259
+  kind: Literal
+  span: 1:650-651
+- id: 260
+  kind: Ident
+  span: 1:652-662
+  ident: !Ident
+  - this
+  - num_tracks
+  targets:
+  - 187
+- id: 261
+  kind: Tuple
+  span: 1:622-663
+  children:
+  - 257
+  parent: 262
+- id: 262
+  kind: 'TransformCall: Derive'
+  span: 1:615-663
+  children:
+  - 256
+  - 261
+  parent: 270
+- id: 263
+  kind: Ident
+  span: 1:677-681
+  ident: !Ident
+  - this
+  - city
+  targets:
+  - 197
+  parent: 269
+- id: 264
+  kind: Ident
+  span: 1:687-693
+  ident: !Ident
+  - this
+  - street
+  targets:
+  - 152
+  parent: 269
+- id: 265
+  kind: Ident
+  span: 1:699-709
+  ident: !Ident
+  - this
+  - num_orders
+  targets:
+  - 184
+  parent: 269
+- id: 266
+  kind: Ident
+  span: 1:715-725
+  ident: !Ident
+  - this
+  - num_tracks
+  targets:
+  - 187
+  parent: 269
+- id: 267
+  kind: Ident
+  span: 1:731-755
+  ident: !Ident
+  - this
+  - running_total_num_tracks
+  targets:
+  - 243
+  parent: 269
+- id: 268
+  kind: Ident
+  span: 1:761-781
+  ident: !Ident
+  - this
+  - num_tracks_last_week
+  targets:
+  - 257
+  parent: 269
+- id: 269
+  kind: Tuple
+  span: 1:671-783
+  children:
+  - 263
+  - 264
+  - 265
+  - 266
+  - 267
+  - 268
+  parent: 270
+- id: 270
+  kind: 'TransformCall: Select'
+  span: 1:664-783
+  children:
+  - 262
+  - 269
+  parent: 272
+- id: 272
+  kind: 'TransformCall: Take'
+  span: 1:784-791
+  children:
+  - 270
+  - 273
+- id: 273
+  kind: Literal
+  parent: 272
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: invoices
+                alias: i
+          - FuncCall:
+              name:
+                Ident: join
+              args:
+              - Ident: invoice_items
+                alias: ii
+              - Unary:
+                  op: EqSelf
+                  expr:
+                    Ident: invoice_id
+          - FuncCall:
+              name:
+                Ident: derive
+              args:
+              - Tuple:
+                - Indirection:
+                    base:
+                      Ident: i
+                    field: !Name billing_city
+                  alias: city
+                - Indirection:
+                    base:
+                      Ident: i
+                    field: !Name billing_address
+                  alias: street
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Tuple:
+                - Ident: city
+                - Ident: street
+              - Pipeline:
+                  exprs:
+                  - FuncCall:
+                      name:
+                        Ident: derive
+                      args:
+                      - Binary:
+                          left:
+                            Indirection:
+                              base:
+                                Ident: ii
+                              field: !Name unit_price
+                          op: Mul
+                          right:
+                            Indirection:
+                              base:
+                                Ident: ii
+                              field: !Name quantity
+                        alias: total
+                  - FuncCall:
+                      name:
+                        Ident: aggregate
+                      args:
+                      - Tuple:
+                        - FuncCall:
+                            name:
+                              Ident: count_distinct
+                            args:
+                            - Indirection:
+                                base:
+                                  Ident: i
+                                field: !Name invoice_id
+                          alias: num_orders
+                        - FuncCall:
+                            name:
+                              Ident: sum
+                            args:
+                            - Indirection:
+                                base:
+                                  Ident: ii
+                                field: !Name quantity
+                          alias: num_tracks
+                        - FuncCall:
+                            name:
+                              Ident: sum
+                            args:
+                            - Ident: total
+                          alias: total_price
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Tuple:
+                - Ident: city
+              - Pipeline:
+                  exprs:
+                  - FuncCall:
+                      name:
+                        Ident: sort
+                      args:
+                      - Ident: street
+                  - FuncCall:
+                      name:
+                        Ident: window
+                      args:
+                      - FuncCall:
+                          name:
+                            Ident: derive
+                          args:
+                          - Tuple:
+                            - FuncCall:
+                                name:
+                                  Ident: sum
+                                args:
+                                - Ident: num_tracks
+                              alias: running_total_num_tracks
+                      named_args:
+                        expanding:
+                          Literal:
+                            Boolean: true
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Ident: city
+                - Ident: street
+          - FuncCall:
+              name:
+                Ident: derive
+              args:
+              - Tuple:
+                - FuncCall:
+                    name:
+                      Ident: lag
+                    args:
+                    - Literal:
+                        Integer: 7
+                    - Ident: num_tracks
+                  alias: num_tracks_last_week
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: city
+                - Ident: street
+                - Ident: num_orders
+                - Ident: num_tracks
+                - Ident: running_total_num_tracks
+                - Ident: num_tracks_last_week
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 20
+    span: 1:131-792

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__loop_01.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__loop_01.snap
@@ -3,4 +3,332 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# clickhouse:skip (DB::Exception: Syntax error)\n# glaredb:skip (DataFusion does not support recursive CTEs https://github.com/apache/arrow-datafusion/issues/462)\nfrom [{n = 1}]\nselect n = n - 2\nloop (filter n < 4 | select n = n + 1)\nselect n = n * 2\nsort n\n"
 input_file: prqlc/prqlc/tests/integration/queries/loop_01.prql
 ---
-{"frames":[["1:177-193",{"columns":[{"Single":{"name":["n"],"target_id":131,"target_name":null}}],"inputs":[{"id":127,"name":"_literal_127","table":["default_db","_literal_127"]}]}],["1:200-212",{"columns":[{"Single":{"name":["n"],"target_id":131,"target_name":null}}],"inputs":[{"id":127,"name":"_literal_127","table":["default_db","_literal_127"]}]}],["1:194-232",{"columns":[{"Single":{"name":["n"],"target_id":131,"target_name":null}}],"inputs":[{"id":127,"name":"_literal_127","table":["default_db","_literal_127"]}]}],["1:233-249",{"columns":[{"Single":{"name":["n"],"target_id":162,"target_name":null}}],"inputs":[{"id":127,"name":"_literal_127","table":["default_db","_literal_127"]}]}],["1:250-256",{"columns":[{"Single":{"name":["n"],"target_id":162,"target_name":null}}],"inputs":[{"id":127,"name":"_literal_127","table":["default_db","_literal_127"]}]}]],"nodes":[{"id":127,"kind":"Array","span":"1:162-176","children":[128],"parent":136},{"id":128,"kind":"Tuple","span":"1:168-175","children":[129],"parent":127},{"id":129,"kind":"Literal","span":"1:173-174","alias":"n","parent":128},{"id":131,"kind":"RqOperator","span":"1:188-193","alias":"n","targets":[133,134],"parent":135},{"id":133,"kind":"Ident","span":"1:188-189","ident":{"Ident":["this","_literal_127","n"]},"targets":[127]},{"id":134,"kind":"Literal","span":"1:192-193"},{"id":135,"kind":"Tuple","span":"1:188-193","children":[131],"parent":136},{"id":136,"kind":"TransformCall: Select","span":"1:177-193","children":[127,135],"parent":160},{"id":145,"kind":"Ident","ident":{"Ident":["_param","_tbl"]},"targets":[142],"parent":153},{"id":149,"kind":"RqOperator","span":"1:207-212","targets":[151,152],"parent":153},{"id":151,"kind":"Ident","span":"1:207-208","ident":{"Ident":["this","n"]},"targets":[131]},{"id":152,"kind":"Literal","span":"1:211-212"},{"id":153,"kind":"TransformCall: Filter","span":"1:200-212","children":[145,149],"parent":159},{"id":154,"kind":"RqOperator","span":"1:226-231","alias":"n","targets":[156,157],"parent":158},{"id":156,"kind":"Ident","span":"1:226-227","ident":{"Ident":["this","n"]},"targets":[131]},{"id":157,"kind":"Literal","span":"1:230-231"},{"id":158,"kind":"Tuple","span":"1:226-231","children":[154],"parent":159},{"id":159,"kind":"TransformCall: Select","children":[153,158]},{"id":160,"kind":"TransformCall: Loop","span":"1:194-232","children":[136,161],"parent":167},{"id":161,"kind":"Func","span":"1:215-231","parent":160},{"id":162,"kind":"RqOperator","span":"1:244-249","alias":"n","targets":[164,165],"parent":166},{"id":164,"kind":"Ident","span":"1:244-245","ident":{"Ident":["this","n"]},"targets":[131]},{"id":165,"kind":"Literal","span":"1:248-249"},{"id":166,"kind":"Tuple","span":"1:244-249","children":[162],"parent":167},{"id":167,"kind":"TransformCall: Select","span":"1:233-249","children":[160,166],"parent":170},{"id":168,"kind":"Ident","span":"1:255-256","ident":{"Ident":["this","n"]},"targets":[162],"parent":170},{"id":170,"kind":"TransformCall: Sort","span":"1:250-256","children":[167,168]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Array":[{"Tuple":[{"Literal":{"Integer":1},"alias":"n"}]}]}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Binary":{"left":{"Ident":"n"},"op":"Sub","right":{"Literal":{"Integer":2}}},"alias":"n"}]}},{"FuncCall":{"name":{"Ident":"loop"},"args":[{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Binary":{"left":{"Ident":"n"},"op":"Lt","right":{"Literal":{"Integer":4}}}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Binary":{"left":{"Ident":"n"},"op":"Add","right":{"Literal":{"Integer":1}}},"alias":"n"}]}}]}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Binary":{"left":{"Ident":"n"},"op":"Mul","right":{"Literal":{"Integer":2}}},"alias":"n"}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"n"}]}}]}}},"span":"1:162-257"}]}}
+frames:
+- - 1:177-193
+  - columns:
+    - !Single
+      name:
+      - n
+      target_id: 131
+      target_name: null
+    inputs:
+    - id: 127
+      name: _literal_127
+      table:
+      - default_db
+      - _literal_127
+- - 1:200-212
+  - columns:
+    - !Single
+      name:
+      - n
+      target_id: 131
+      target_name: null
+    inputs:
+    - id: 127
+      name: _literal_127
+      table:
+      - default_db
+      - _literal_127
+- - 1:215-231
+  - columns:
+    - !Single
+      name:
+      - n
+      target_id: 154
+      target_name: null
+    inputs:
+    - id: 127
+      name: _literal_127
+      table:
+      - default_db
+      - _literal_127
+- - 1:194-232
+  - columns:
+    - !Single
+      name:
+      - n
+      target_id: 131
+      target_name: null
+    inputs:
+    - id: 127
+      name: _literal_127
+      table:
+      - default_db
+      - _literal_127
+- - 1:233-249
+  - columns:
+    - !Single
+      name:
+      - n
+      target_id: 162
+      target_name: null
+    inputs:
+    - id: 127
+      name: _literal_127
+      table:
+      - default_db
+      - _literal_127
+- - 1:250-256
+  - columns:
+    - !Single
+      name:
+      - n
+      target_id: 162
+      target_name: null
+    inputs:
+    - id: 127
+      name: _literal_127
+      table:
+      - default_db
+      - _literal_127
+nodes:
+- id: 127
+  kind: Array
+  span: 1:162-176
+  children:
+  - 128
+  parent: 136
+- id: 128
+  kind: Tuple
+  span: 1:168-175
+  children:
+  - 129
+  parent: 127
+- id: 129
+  kind: Literal
+  span: 1:173-174
+  alias: n
+  parent: 128
+- id: 131
+  kind: RqOperator
+  span: 1:188-193
+  alias: n
+  targets:
+  - 133
+  - 134
+  parent: 135
+- id: 133
+  kind: Ident
+  span: 1:188-189
+  ident: !Ident
+  - this
+  - _literal_127
+  - n
+  targets:
+  - 127
+- id: 134
+  kind: Literal
+  span: 1:192-193
+- id: 135
+  kind: Tuple
+  span: 1:188-193
+  children:
+  - 131
+  parent: 136
+- id: 136
+  kind: 'TransformCall: Select'
+  span: 1:177-193
+  children:
+  - 127
+  - 135
+  parent: 160
+- id: 145
+  kind: Ident
+  ident: !Ident
+  - _param
+  - _tbl
+  targets:
+  - 142
+  parent: 153
+- id: 149
+  kind: RqOperator
+  span: 1:207-212
+  targets:
+  - 151
+  - 152
+  parent: 153
+- id: 151
+  kind: Ident
+  span: 1:207-208
+  ident: !Ident
+  - this
+  - n
+  targets:
+  - 131
+- id: 152
+  kind: Literal
+  span: 1:211-212
+- id: 153
+  kind: 'TransformCall: Filter'
+  span: 1:200-212
+  children:
+  - 145
+  - 149
+  parent: 159
+- id: 154
+  kind: RqOperator
+  span: 1:226-231
+  alias: n
+  targets:
+  - 156
+  - 157
+  parent: 158
+- id: 156
+  kind: Ident
+  span: 1:226-227
+  ident: !Ident
+  - this
+  - n
+  targets:
+  - 131
+- id: 157
+  kind: Literal
+  span: 1:230-231
+- id: 158
+  kind: Tuple
+  span: 1:226-231
+  children:
+  - 154
+  parent: 159
+- id: 159
+  kind: 'TransformCall: Select'
+  span: 1:215-231
+  children:
+  - 153
+  - 158
+- id: 160
+  kind: 'TransformCall: Loop'
+  span: 1:194-232
+  children:
+  - 136
+  - 161
+  parent: 167
+- id: 161
+  kind: Func
+  span: 1:215-231
+  parent: 160
+- id: 162
+  kind: RqOperator
+  span: 1:244-249
+  alias: n
+  targets:
+  - 164
+  - 165
+  parent: 166
+- id: 164
+  kind: Ident
+  span: 1:244-245
+  ident: !Ident
+  - this
+  - n
+  targets:
+  - 131
+- id: 165
+  kind: Literal
+  span: 1:248-249
+- id: 166
+  kind: Tuple
+  span: 1:244-249
+  children:
+  - 162
+  parent: 167
+- id: 167
+  kind: 'TransformCall: Select'
+  span: 1:233-249
+  children:
+  - 160
+  - 166
+  parent: 170
+- id: 168
+  kind: Ident
+  span: 1:255-256
+  ident: !Ident
+  - this
+  - n
+  targets:
+  - 162
+  parent: 170
+- id: 170
+  kind: 'TransformCall: Sort'
+  span: 1:250-256
+  children:
+  - 167
+  - 168
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Array:
+                - Tuple:
+                  - Literal:
+                      Integer: 1
+                    alias: n
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Binary:
+                  left:
+                    Ident: n
+                  op: Sub
+                  right:
+                    Literal:
+                      Integer: 2
+                alias: n
+          - FuncCall:
+              name:
+                Ident: loop
+              args:
+              - Pipeline:
+                  exprs:
+                  - FuncCall:
+                      name:
+                        Ident: filter
+                      args:
+                      - Binary:
+                          left:
+                            Ident: n
+                          op: Lt
+                          right:
+                            Literal:
+                              Integer: 4
+                  - FuncCall:
+                      name:
+                        Ident: select
+                      args:
+                      - Binary:
+                          left:
+                            Ident: n
+                          op: Add
+                          right:
+                            Literal:
+                              Integer: 1
+                        alias: n
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Binary:
+                  left:
+                    Ident: n
+                  op: Mul
+                  right:
+                    Literal:
+                      Integer: 2
+                alias: n
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: n
+    span: 1:162-257

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__math_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__math_module.snap
@@ -3,4 +3,757 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\n# sqlite:skip (see https://github.com/rusqlite/rusqlite/issues/1211)\nfrom invoices\ntake 5\nselect {\n    total_original = total | math.round 2,\n    total_x = math.pi - total | math.round 2 | math.abs,\n    total_floor = math.floor total,\n    total_ceil = math.ceil total,\n    total_log10 = math.log10 total | math.round 3,\n    total_log2 = math.log 2 total | math.round 3,\n    total_sqrt = math.sqrt total | math.round 3,\n    total_ln = math.ln total | math.exp | math.round 2,\n    total_cos = math.cos total | math.acos | math.round 2,\n    total_sin = math.sin total | math.asin | math.round 2,\n    total_tan = math.tan total | math.atan | math.round 2,\n    total_deg = total | math.degrees | math.radians | math.round 2,\n    total_square = total | math.pow 2| math.round 2,\n}\n"
 input_file: prqlc/prqlc/tests/integration/queries/math_module.prql
 ---
-{"frames":[["1:96-102",{"columns":[{"All":{"input_id":121,"except":[]}}],"inputs":[{"id":121,"name":"invoices","table":["default_db","invoices"]}]}],["1:103-787",{"columns":[{"Single":{"name":["total_original"],"target_id":126,"target_name":null}},{"Single":{"name":["total_x"],"target_id":131,"target_name":null}},{"Single":{"name":["total_floor"],"target_id":142,"target_name":null}},{"Single":{"name":["total_ceil"],"target_id":145,"target_name":null}},{"Single":{"name":["total_log10"],"target_id":148,"target_name":null}},{"Single":{"name":["total_log2"],"target_id":155,"target_name":null}},{"Single":{"name":["total_sqrt"],"target_id":163,"target_name":null}},{"Single":{"name":["total_ln"],"target_id":170,"target_name":null}},{"Single":{"name":["total_cos"],"target_id":179,"target_name":null}},{"Single":{"name":["total_sin"],"target_id":188,"target_name":null}},{"Single":{"name":["total_tan"],"target_id":197,"target_name":null}},{"Single":{"name":["total_deg"],"target_id":206,"target_name":null}},{"Single":{"name":["total_square"],"target_id":215,"target_name":null}}],"inputs":[{"id":121,"name":"invoices","table":["default_db","invoices"]}]}]],"nodes":[{"id":121,"kind":"Ident","span":"1:82-95","ident":{"Ident":["default_db","invoices"]},"parent":124},{"id":124,"kind":"TransformCall: Take","span":"1:96-102","children":[121,125],"parent":225},{"id":125,"kind":"Literal","parent":124},{"id":126,"kind":"RqOperator","span":"1:141-153","alias":"total_original","targets":[129,130],"parent":224},{"id":129,"kind":"Literal","span":"1:152-153"},{"id":130,"kind":"Ident","span":"1:133-138","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":131,"kind":"RqOperator","span":"1:202-210","alias":"total_x","targets":[133],"parent":224},{"id":133,"kind":"RqOperator","span":"1:187-199","targets":[136,137]},{"id":136,"kind":"Literal","span":"1:198-199"},{"id":137,"kind":"RqOperator","span":"1:169-184","targets":[140,141]},{"id":140,"kind":"RqOperator","span":"1:173-176"},{"id":141,"kind":"Ident","span":"1:179-184","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":142,"kind":"RqOperator","span":"1:230-246","alias":"total_floor","targets":[144],"parent":224},{"id":144,"kind":"Ident","span":"1:241-246","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":145,"kind":"RqOperator","span":"1:265-280","alias":"total_ceil","targets":[147],"parent":224},{"id":147,"kind":"Ident","span":"1:275-280","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":148,"kind":"RqOperator","span":"1:319-331","alias":"total_log10","targets":[151,152],"parent":224},{"id":151,"kind":"Literal","span":"1:330-331"},{"id":152,"kind":"RqOperator","span":"1:300-316","targets":[154]},{"id":154,"kind":"Ident","span":"1:311-316","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":155,"kind":"RqOperator","span":"1:369-381","alias":"total_log2","targets":[158,159],"parent":224},{"id":158,"kind":"Literal","span":"1:380-381"},{"id":159,"kind":"RqOperator","span":"1:350-366","targets":[161,162]},{"id":161,"kind":"Literal","span":"1:359-360"},{"id":162,"kind":"Ident","span":"1:361-366","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":163,"kind":"RqOperator","span":"1:418-430","alias":"total_sqrt","targets":[166,167],"parent":224},{"id":166,"kind":"Literal","span":"1:429-430"},{"id":167,"kind":"RqOperator","span":"1:400-415","targets":[169]},{"id":169,"kind":"Ident","span":"1:410-415","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":170,"kind":"RqOperator","span":"1:474-486","alias":"total_ln","targets":[173,174],"parent":224},{"id":173,"kind":"Literal","span":"1:485-486"},{"id":174,"kind":"RqOperator","span":"1:463-471","targets":[176]},{"id":176,"kind":"RqOperator","span":"1:447-460","targets":[178]},{"id":178,"kind":"Ident","span":"1:455-460","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":179,"kind":"RqOperator","span":"1:533-545","alias":"total_cos","targets":[182,183],"parent":224},{"id":182,"kind":"Literal","span":"1:544-545"},{"id":183,"kind":"RqOperator","span":"1:521-530","targets":[185]},{"id":185,"kind":"RqOperator","span":"1:504-518","targets":[187]},{"id":187,"kind":"Ident","span":"1:513-518","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":188,"kind":"RqOperator","span":"1:592-604","alias":"total_sin","targets":[191,192],"parent":224},{"id":191,"kind":"Literal","span":"1:603-604"},{"id":192,"kind":"RqOperator","span":"1:580-589","targets":[194]},{"id":194,"kind":"RqOperator","span":"1:563-577","targets":[196]},{"id":196,"kind":"Ident","span":"1:572-577","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":197,"kind":"RqOperator","span":"1:651-663","alias":"total_tan","targets":[200,201],"parent":224},{"id":200,"kind":"Literal","span":"1:662-663"},{"id":201,"kind":"RqOperator","span":"1:639-648","targets":[203]},{"id":203,"kind":"RqOperator","span":"1:622-636","targets":[205]},{"id":205,"kind":"Ident","span":"1:631-636","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":206,"kind":"RqOperator","span":"1:719-731","alias":"total_deg","targets":[209,210],"parent":224},{"id":209,"kind":"Literal","span":"1:730-731"},{"id":210,"kind":"RqOperator","span":"1:704-716","targets":[212]},{"id":212,"kind":"RqOperator","span":"1:689-701","targets":[214]},{"id":214,"kind":"Ident","span":"1:681-686","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":215,"kind":"RqOperator","span":"1:772-784","alias":"total_square","targets":[218,219],"parent":224},{"id":218,"kind":"Literal","span":"1:783-784"},{"id":219,"kind":"RqOperator","span":"1:760-770","targets":[222,223]},{"id":222,"kind":"Literal","span":"1:769-770"},{"id":223,"kind":"Ident","span":"1:752-757","ident":{"Ident":["this","invoices","total"]},"targets":[121]},{"id":224,"kind":"Tuple","span":"1:110-787","children":[126,131,142,145,148,155,163,170,179,188,197,206,215],"parent":225},{"id":225,"kind":"TransformCall: Select","span":"1:103-787","children":[124,224]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"invoices"}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":5}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Pipeline":{"exprs":[{"Ident":"total"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"total_original"},{"Pipeline":{"exprs":[{"Binary":{"left":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"pi"}}},"op":"Sub","right":{"Ident":"total"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}},{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"abs"}}}]},"alias":"total_x"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"floor"}}},"args":[{"Ident":"total"}]},"alias":"total_floor"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"ceil"}}},"args":[{"Ident":"total"}]},"alias":"total_ceil"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"log10"}}},"args":[{"Ident":"total"}]}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":3}}]}}]},"alias":"total_log10"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"log"}}},"args":[{"Literal":{"Integer":2}},{"Ident":"total"}]}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":3}}]}}]},"alias":"total_log2"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"sqrt"}}},"args":[{"Ident":"total"}]}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":3}}]}}]},"alias":"total_sqrt"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"ln"}}},"args":[{"Ident":"total"}]}},{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"exp"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"total_ln"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"cos"}}},"args":[{"Ident":"total"}]}},{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"acos"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"total_cos"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"sin"}}},"args":[{"Ident":"total"}]}},{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"asin"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"total_sin"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"tan"}}},"args":[{"Ident":"total"}]}},{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"atan"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"total_tan"},{"Pipeline":{"exprs":[{"Ident":"total"},{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"degrees"}}},{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"radians"}}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"total_deg"},{"Pipeline":{"exprs":[{"Ident":"total"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"pow"}}},"args":[{"Literal":{"Integer":2}}]}},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"math"},"field":{"Name":"round"}}},"args":[{"Literal":{"Integer":2}}]}}]},"alias":"total_square"}]}]}}]}}},"span":"1:82-788"}]}}
+frames:
+- - 1:96-102
+  - columns:
+    - !All
+      input_id: 121
+      except: []
+    inputs:
+    - id: 121
+      name: invoices
+      table:
+      - default_db
+      - invoices
+- - 1:103-787
+  - columns:
+    - !Single
+      name:
+      - total_original
+      target_id: 126
+      target_name: null
+    - !Single
+      name:
+      - total_x
+      target_id: 131
+      target_name: null
+    - !Single
+      name:
+      - total_floor
+      target_id: 142
+      target_name: null
+    - !Single
+      name:
+      - total_ceil
+      target_id: 145
+      target_name: null
+    - !Single
+      name:
+      - total_log10
+      target_id: 148
+      target_name: null
+    - !Single
+      name:
+      - total_log2
+      target_id: 155
+      target_name: null
+    - !Single
+      name:
+      - total_sqrt
+      target_id: 163
+      target_name: null
+    - !Single
+      name:
+      - total_ln
+      target_id: 170
+      target_name: null
+    - !Single
+      name:
+      - total_cos
+      target_id: 179
+      target_name: null
+    - !Single
+      name:
+      - total_sin
+      target_id: 188
+      target_name: null
+    - !Single
+      name:
+      - total_tan
+      target_id: 197
+      target_name: null
+    - !Single
+      name:
+      - total_deg
+      target_id: 206
+      target_name: null
+    - !Single
+      name:
+      - total_square
+      target_id: 215
+      target_name: null
+    inputs:
+    - id: 121
+      name: invoices
+      table:
+      - default_db
+      - invoices
+nodes:
+- id: 121
+  kind: Ident
+  span: 1:82-95
+  ident: !Ident
+  - default_db
+  - invoices
+  parent: 124
+- id: 124
+  kind: 'TransformCall: Take'
+  span: 1:96-102
+  children:
+  - 121
+  - 125
+  parent: 225
+- id: 125
+  kind: Literal
+  parent: 124
+- id: 126
+  kind: RqOperator
+  span: 1:141-153
+  alias: total_original
+  targets:
+  - 129
+  - 130
+  parent: 224
+- id: 129
+  kind: Literal
+  span: 1:152-153
+- id: 130
+  kind: Ident
+  span: 1:133-138
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 131
+  kind: RqOperator
+  span: 1:202-210
+  alias: total_x
+  targets:
+  - 133
+  parent: 224
+- id: 133
+  kind: RqOperator
+  span: 1:187-199
+  targets:
+  - 136
+  - 137
+- id: 136
+  kind: Literal
+  span: 1:198-199
+- id: 137
+  kind: RqOperator
+  span: 1:169-184
+  targets:
+  - 140
+  - 141
+- id: 140
+  kind: RqOperator
+  span: 1:173-176
+- id: 141
+  kind: Ident
+  span: 1:179-184
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 142
+  kind: RqOperator
+  span: 1:230-246
+  alias: total_floor
+  targets:
+  - 144
+  parent: 224
+- id: 144
+  kind: Ident
+  span: 1:241-246
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 145
+  kind: RqOperator
+  span: 1:265-280
+  alias: total_ceil
+  targets:
+  - 147
+  parent: 224
+- id: 147
+  kind: Ident
+  span: 1:275-280
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 148
+  kind: RqOperator
+  span: 1:319-331
+  alias: total_log10
+  targets:
+  - 151
+  - 152
+  parent: 224
+- id: 151
+  kind: Literal
+  span: 1:330-331
+- id: 152
+  kind: RqOperator
+  span: 1:300-316
+  targets:
+  - 154
+- id: 154
+  kind: Ident
+  span: 1:311-316
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 155
+  kind: RqOperator
+  span: 1:369-381
+  alias: total_log2
+  targets:
+  - 158
+  - 159
+  parent: 224
+- id: 158
+  kind: Literal
+  span: 1:380-381
+- id: 159
+  kind: RqOperator
+  span: 1:350-366
+  targets:
+  - 161
+  - 162
+- id: 161
+  kind: Literal
+  span: 1:359-360
+- id: 162
+  kind: Ident
+  span: 1:361-366
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 163
+  kind: RqOperator
+  span: 1:418-430
+  alias: total_sqrt
+  targets:
+  - 166
+  - 167
+  parent: 224
+- id: 166
+  kind: Literal
+  span: 1:429-430
+- id: 167
+  kind: RqOperator
+  span: 1:400-415
+  targets:
+  - 169
+- id: 169
+  kind: Ident
+  span: 1:410-415
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 170
+  kind: RqOperator
+  span: 1:474-486
+  alias: total_ln
+  targets:
+  - 173
+  - 174
+  parent: 224
+- id: 173
+  kind: Literal
+  span: 1:485-486
+- id: 174
+  kind: RqOperator
+  span: 1:463-471
+  targets:
+  - 176
+- id: 176
+  kind: RqOperator
+  span: 1:447-460
+  targets:
+  - 178
+- id: 178
+  kind: Ident
+  span: 1:455-460
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 179
+  kind: RqOperator
+  span: 1:533-545
+  alias: total_cos
+  targets:
+  - 182
+  - 183
+  parent: 224
+- id: 182
+  kind: Literal
+  span: 1:544-545
+- id: 183
+  kind: RqOperator
+  span: 1:521-530
+  targets:
+  - 185
+- id: 185
+  kind: RqOperator
+  span: 1:504-518
+  targets:
+  - 187
+- id: 187
+  kind: Ident
+  span: 1:513-518
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 188
+  kind: RqOperator
+  span: 1:592-604
+  alias: total_sin
+  targets:
+  - 191
+  - 192
+  parent: 224
+- id: 191
+  kind: Literal
+  span: 1:603-604
+- id: 192
+  kind: RqOperator
+  span: 1:580-589
+  targets:
+  - 194
+- id: 194
+  kind: RqOperator
+  span: 1:563-577
+  targets:
+  - 196
+- id: 196
+  kind: Ident
+  span: 1:572-577
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 197
+  kind: RqOperator
+  span: 1:651-663
+  alias: total_tan
+  targets:
+  - 200
+  - 201
+  parent: 224
+- id: 200
+  kind: Literal
+  span: 1:662-663
+- id: 201
+  kind: RqOperator
+  span: 1:639-648
+  targets:
+  - 203
+- id: 203
+  kind: RqOperator
+  span: 1:622-636
+  targets:
+  - 205
+- id: 205
+  kind: Ident
+  span: 1:631-636
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 206
+  kind: RqOperator
+  span: 1:719-731
+  alias: total_deg
+  targets:
+  - 209
+  - 210
+  parent: 224
+- id: 209
+  kind: Literal
+  span: 1:730-731
+- id: 210
+  kind: RqOperator
+  span: 1:704-716
+  targets:
+  - 212
+- id: 212
+  kind: RqOperator
+  span: 1:689-701
+  targets:
+  - 214
+- id: 214
+  kind: Ident
+  span: 1:681-686
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 215
+  kind: RqOperator
+  span: 1:772-784
+  alias: total_square
+  targets:
+  - 218
+  - 219
+  parent: 224
+- id: 218
+  kind: Literal
+  span: 1:783-784
+- id: 219
+  kind: RqOperator
+  span: 1:760-770
+  targets:
+  - 222
+  - 223
+- id: 222
+  kind: Literal
+  span: 1:769-770
+- id: 223
+  kind: Ident
+  span: 1:752-757
+  ident: !Ident
+  - this
+  - invoices
+  - total
+  targets:
+  - 121
+- id: 224
+  kind: Tuple
+  span: 1:110-787
+  children:
+  - 126
+  - 131
+  - 142
+  - 145
+  - 148
+  - 155
+  - 163
+  - 170
+  - 179
+  - 188
+  - 197
+  - 206
+  - 215
+  parent: 225
+- id: 225
+  kind: 'TransformCall: Select'
+  span: 1:103-787
+  children:
+  - 124
+  - 224
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: invoices
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 5
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Pipeline:
+                    exprs:
+                    - Ident: total
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                  alias: total_original
+                - Pipeline:
+                    exprs:
+                    - Binary:
+                        left:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name pi
+                        op: Sub
+                        right:
+                          Ident: total
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                    - Indirection:
+                        base:
+                          Ident: math
+                        field: !Name abs
+                  alias: total_x
+                - FuncCall:
+                    name:
+                      Indirection:
+                        base:
+                          Ident: math
+                        field: !Name floor
+                    args:
+                    - Ident: total
+                  alias: total_floor
+                - FuncCall:
+                    name:
+                      Indirection:
+                        base:
+                          Ident: math
+                        field: !Name ceil
+                    args:
+                    - Ident: total
+                  alias: total_ceil
+                - Pipeline:
+                    exprs:
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name log10
+                        args:
+                        - Ident: total
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 3
+                  alias: total_log10
+                - Pipeline:
+                    exprs:
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name log
+                        args:
+                        - Literal:
+                            Integer: 2
+                        - Ident: total
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 3
+                  alias: total_log2
+                - Pipeline:
+                    exprs:
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name sqrt
+                        args:
+                        - Ident: total
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 3
+                  alias: total_sqrt
+                - Pipeline:
+                    exprs:
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name ln
+                        args:
+                        - Ident: total
+                    - Indirection:
+                        base:
+                          Ident: math
+                        field: !Name exp
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                  alias: total_ln
+                - Pipeline:
+                    exprs:
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name cos
+                        args:
+                        - Ident: total
+                    - Indirection:
+                        base:
+                          Ident: math
+                        field: !Name acos
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                  alias: total_cos
+                - Pipeline:
+                    exprs:
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name sin
+                        args:
+                        - Ident: total
+                    - Indirection:
+                        base:
+                          Ident: math
+                        field: !Name asin
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                  alias: total_sin
+                - Pipeline:
+                    exprs:
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name tan
+                        args:
+                        - Ident: total
+                    - Indirection:
+                        base:
+                          Ident: math
+                        field: !Name atan
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                  alias: total_tan
+                - Pipeline:
+                    exprs:
+                    - Ident: total
+                    - Indirection:
+                        base:
+                          Ident: math
+                        field: !Name degrees
+                    - Indirection:
+                        base:
+                          Ident: math
+                        field: !Name radians
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                  alias: total_deg
+                - Pipeline:
+                    exprs:
+                    - Ident: total
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name pow
+                        args:
+                        - Literal:
+                            Integer: 2
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: math
+                            field: !Name round
+                        args:
+                        - Literal:
+                            Integer: 2
+                  alias: total_square
+    span: 1:82-788

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__pipelines.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__pipelines.snap
@@ -3,4 +3,308 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# sqlite:skip (Only works on Sqlite implementations which have the extension\n# installed\n# https://stackoverflow.com/questions/24037982/how-to-use-regexp-in-sqlite)\n\nfrom tracks\n\nfilter (name ~= \"Love\")\nfilter ((milliseconds / 1000 / 60) | in 3..4)\nsort track_id\ntake 1..15\nselect {name, composer}\n"
 input_file: prqlc/prqlc/tests/integration/queries/pipelines.prql
 ---
-{"frames":[["1:179-202",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}],["1:203-248",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}],["1:249-262",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}],["1:263-273",{"columns":[{"All":{"input_id":130,"except":[]}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}],["1:274-297",{"columns":[{"Single":{"name":["tracks","name"],"target_id":164,"target_name":null}},{"Single":{"name":["tracks","composer"],"target_id":165,"target_name":null}}],"inputs":[{"id":130,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":130,"kind":"Ident","span":"1:166-177","ident":{"Ident":["default_db","tracks"]},"parent":136},{"id":132,"kind":"RqOperator","span":"1:187-201","targets":[134,135],"parent":136},{"id":134,"kind":"Ident","span":"1:187-191","ident":{"Ident":["this","tracks","name"]},"targets":[130]},{"id":135,"kind":"Literal","span":"1:195-201"},{"id":136,"kind":"TransformCall: Filter","span":"1:179-202","children":[130,132],"parent":156},{"id":140,"kind":"Literal","span":"1:243-244","alias":"start"},{"id":141,"kind":"Literal","span":"1:246-247","alias":"end"},{"id":143,"kind":"RqOperator","span":"1:211-237","targets":[145,149]},{"id":145,"kind":"RqOperator","span":"1:212-231","targets":[147,148]},{"id":147,"kind":"Ident","span":"1:212-224","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[130]},{"id":148,"kind":"Literal","span":"1:227-231"},{"id":149,"kind":"Literal","span":"1:234-236"},{"id":150,"kind":"RqOperator","span":"1:240-247","targets":[152,154],"parent":156},{"id":152,"kind":"RqOperator","targets":[143,140]},{"id":154,"kind":"RqOperator","targets":[143,141]},{"id":156,"kind":"TransformCall: Filter","span":"1:203-248","children":[136,150],"parent":159},{"id":157,"kind":"Ident","span":"1:254-262","ident":{"Ident":["this","tracks","track_id"]},"targets":[130],"parent":159},{"id":159,"kind":"TransformCall: Sort","span":"1:249-262","children":[156,157],"parent":163},{"id":160,"kind":"Literal","span":"1:268-269","alias":"start","parent":163},{"id":161,"kind":"Literal","span":"1:271-273","alias":"end","parent":163},{"id":163,"kind":"TransformCall: Take","span":"1:263-273","children":[159,160,161],"parent":167},{"id":164,"kind":"Ident","span":"1:282-286","ident":{"Ident":["this","tracks","name"]},"targets":[130],"parent":166},{"id":165,"kind":"Ident","span":"1:288-296","ident":{"Ident":["this","tracks","composer"]},"targets":[130],"parent":166},{"id":166,"kind":"Tuple","span":"1:281-297","children":[164,165],"parent":167},{"id":167,"kind":"TransformCall: Select","span":"1:274-297","children":[163,166]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Binary":{"left":{"Ident":"name"},"op":"RegexSearch","right":{"Literal":{"String":"Love"}}}}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Pipeline":{"exprs":[{"Binary":{"left":{"Binary":{"left":{"Ident":"milliseconds"},"op":"DivFloat","right":{"Literal":{"Integer":1000}}}},"op":"DivFloat","right":{"Literal":{"Integer":60}}}},{"FuncCall":{"name":{"Ident":"in"},"args":[{"Range":{"start":{"Literal":{"Integer":3}},"end":{"Literal":{"Integer":4}}}}]}}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"track_id"}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Range":{"start":{"Literal":{"Integer":1}},"end":{"Literal":{"Integer":15}}}}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"name"},{"Ident":"composer"}]}]}}]}}},"span":"1:166-298"}]}}
+frames:
+- - 1:179-202
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:203-248
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:249-262
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:263-273
+  - columns:
+    - !All
+      input_id: 130
+      except: []
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:274-297
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - name
+      target_id: 164
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - composer
+      target_id: 165
+      target_name: null
+    inputs:
+    - id: 130
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 130
+  kind: Ident
+  span: 1:166-177
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 136
+- id: 132
+  kind: RqOperator
+  span: 1:187-201
+  targets:
+  - 134
+  - 135
+  parent: 136
+- id: 134
+  kind: Ident
+  span: 1:187-191
+  ident: !Ident
+  - this
+  - tracks
+  - name
+  targets:
+  - 130
+- id: 135
+  kind: Literal
+  span: 1:195-201
+- id: 136
+  kind: 'TransformCall: Filter'
+  span: 1:179-202
+  children:
+  - 130
+  - 132
+  parent: 156
+- id: 140
+  kind: Literal
+  span: 1:243-244
+  alias: start
+- id: 141
+  kind: Literal
+  span: 1:246-247
+  alias: end
+- id: 143
+  kind: RqOperator
+  span: 1:211-237
+  targets:
+  - 145
+  - 149
+- id: 145
+  kind: RqOperator
+  span: 1:212-231
+  targets:
+  - 147
+  - 148
+- id: 147
+  kind: Ident
+  span: 1:212-224
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 130
+- id: 148
+  kind: Literal
+  span: 1:227-231
+- id: 149
+  kind: Literal
+  span: 1:234-236
+- id: 150
+  kind: RqOperator
+  span: 1:240-247
+  targets:
+  - 152
+  - 154
+  parent: 156
+- id: 152
+  kind: RqOperator
+  targets:
+  - 143
+  - 140
+- id: 154
+  kind: RqOperator
+  targets:
+  - 143
+  - 141
+- id: 156
+  kind: 'TransformCall: Filter'
+  span: 1:203-248
+  children:
+  - 136
+  - 150
+  parent: 159
+- id: 157
+  kind: Ident
+  span: 1:254-262
+  ident: !Ident
+  - this
+  - tracks
+  - track_id
+  targets:
+  - 130
+  parent: 159
+- id: 159
+  kind: 'TransformCall: Sort'
+  span: 1:249-262
+  children:
+  - 156
+  - 157
+  parent: 163
+- id: 160
+  kind: Literal
+  span: 1:268-269
+  alias: start
+  parent: 163
+- id: 161
+  kind: Literal
+  span: 1:271-273
+  alias: end
+  parent: 163
+- id: 163
+  kind: 'TransformCall: Take'
+  span: 1:263-273
+  children:
+  - 159
+  - 160
+  - 161
+  parent: 167
+- id: 164
+  kind: Ident
+  span: 1:282-286
+  ident: !Ident
+  - this
+  - tracks
+  - name
+  targets:
+  - 130
+  parent: 166
+- id: 165
+  kind: Ident
+  span: 1:288-296
+  ident: !Ident
+  - this
+  - tracks
+  - composer
+  targets:
+  - 130
+  parent: 166
+- id: 166
+  kind: Tuple
+  span: 1:281-297
+  children:
+  - 164
+  - 165
+  parent: 167
+- id: 167
+  kind: 'TransformCall: Select'
+  span: 1:274-297
+  children:
+  - 163
+  - 166
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Binary:
+                  left:
+                    Ident: name
+                  op: RegexSearch
+                  right:
+                    Literal:
+                      String: Love
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Pipeline:
+                  exprs:
+                  - Binary:
+                      left:
+                        Binary:
+                          left:
+                            Ident: milliseconds
+                          op: DivFloat
+                          right:
+                            Literal:
+                              Integer: 1000
+                      op: DivFloat
+                      right:
+                        Literal:
+                          Integer: 60
+                  - FuncCall:
+                      name:
+                        Ident: in
+                      args:
+                      - Range:
+                          start:
+                            Literal:
+                              Integer: 3
+                          end:
+                            Literal:
+                              Integer: 4
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: track_id
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Range:
+                  start:
+                    Literal:
+                      Integer: 1
+                  end:
+                    Literal:
+                      Integer: 15
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: name
+                - Ident: composer
+    span: 1:166-298

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__read_csv.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__read_csv.snap
@@ -3,4 +3,66 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# sqlite:skip\n# postgres:skip\n# mysql:skip\nfrom (read_csv \"data_file_root/media_types.csv\")\nsort media_type_id\n"
 input_file: prqlc/prqlc/tests/integration/queries/read_csv.prql
 ---
-{"frames":[["1:92-110",{"columns":[{"All":{"input_id":118,"except":[]}}],"inputs":[{"id":118,"name":"_literal_118","table":["default_db","_literal_118"]}]}]],"nodes":[{"id":118,"kind":"RqOperator","span":"1:43-91","targets":[120],"parent":124},{"id":120,"kind":"Literal","span":"1:58-90"},{"id":122,"kind":"Ident","span":"1:97-110","ident":{"Ident":["this","_literal_118","media_type_id"]},"targets":[118],"parent":124},{"id":124,"kind":"TransformCall: Sort","span":"1:92-110","children":[118,122]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"FuncCall":{"name":{"Ident":"read_csv"},"args":[{"Literal":{"String":"data_file_root/media_types.csv"}}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"media_type_id"}]}}]}}},"span":"1:43-111"}]}}
+frames:
+- - 1:92-110
+  - columns:
+    - !All
+      input_id: 118
+      except: []
+    inputs:
+    - id: 118
+      name: _literal_118
+      table:
+      - default_db
+      - _literal_118
+nodes:
+- id: 118
+  kind: RqOperator
+  span: 1:43-91
+  targets:
+  - 120
+  parent: 124
+- id: 120
+  kind: Literal
+  span: 1:58-90
+- id: 122
+  kind: Ident
+  span: 1:97-110
+  ident: !Ident
+  - this
+  - _literal_118
+  - media_type_id
+  targets:
+  - 118
+  parent: 124
+- id: 124
+  kind: 'TransformCall: Sort'
+  span: 1:92-110
+  children:
+  - 118
+  - 122
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - FuncCall:
+                  name:
+                    Ident: read_csv
+                  args:
+                  - Literal:
+                      String: data_file_root/media_types.csv
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: media_type_id
+    span: 1:43-111

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
@@ -3,4 +3,311 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nlet distinct = rel -> (from t = _param.rel | group {t.*} (take 1))\n\nfrom_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2], [2], [3]] }'\ndistinct\nremove (from_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2]] }')\nsort a\n"
 input_file: prqlc/prqlc/tests/integration/queries/set_ops_remove.prql
 ---
-{"frames":[["0:3606-3683",{"columns":[{"Single":{"name":["t","a"],"target_id":136,"target_name":null}},{"Single":{"name":["b","a"],"target_id":122,"target_name":"a"}}],"inputs":[{"id":127,"name":"t","table":["default_db","_literal_127"]},{"id":122,"name":"b","table":["default_db","_literal_122"]}]}],["0:3686-3731",{"columns":[{"Single":{"name":["t","a"],"target_id":136,"target_name":null}},{"Single":{"name":["b","a"],"target_id":122,"target_name":"a"}}],"inputs":[{"id":127,"name":"t","table":["default_db","_literal_127"]},{"id":122,"name":"b","table":["default_db","_literal_122"]}]}],["1:165-238",{"columns":[{"Single":{"name":["t","a"],"target_id":207,"target_name":null}}],"inputs":[{"id":127,"name":"t","table":["default_db","_literal_127"]},{"id":122,"name":"b","table":["default_db","_literal_122"]}]}],["1:239-245",{"columns":[{"Single":{"name":["t","a"],"target_id":207,"target_name":null}}],"inputs":[{"id":127,"name":"t","table":["default_db","_literal_127"]},{"id":122,"name":"b","table":["default_db","_literal_122"]}]}]],"nodes":[{"id":122,"kind":"Array","span":"1:173-237","parent":189},{"id":127,"kind":"Array","span":"1:36-55","parent":154},{"id":136,"kind":"Ident","ident":{"Ident":["this","t","a"]},"targets":[127],"parent":138},{"id":138,"kind":"Tuple","span":"1:64-69","children":[136]},{"id":154,"kind":"TransformCall: Take","children":[127,155],"parent":189},{"id":155,"kind":"Literal","parent":154},{"id":178,"kind":"Ident","ident":{"Ident":["this","t","a"]},"targets":[136]},{"id":181,"kind":"Ident","ident":{"Ident":["that","b","a"]},"targets":[122]},{"id":187,"kind":"RqOperator","span":"0:3635-3682","targets":[178,181],"parent":189},{"id":189,"kind":"TransformCall: Join","span":"0:3606-3683","children":[154,122,187],"parent":205},{"id":197,"kind":"Ident","span":"0:6789-6791","ident":{"Ident":["this","b","a"]},"targets":[122]},{"id":201,"kind":"RqOperator","span":"0:3694-3730","targets":[197,204],"parent":205},{"id":204,"kind":"Literal","span":"0:6795-6799"},{"id":205,"kind":"TransformCall: Filter","span":"0:3686-3731","children":[189,201],"parent":209},{"id":207,"kind":"Ident","ident":{"Ident":["this","t","a"]},"targets":[136],"parent":208},{"id":208,"kind":"Tuple","span":"0:3742-3744","children":[207],"parent":209},{"id":209,"kind":"TransformCall: Select","span":"1:165-238","children":[205,208],"parent":212},{"id":210,"kind":"Ident","span":"1:244-245","ident":{"Ident":["this","t","a"]},"targets":[207],"parent":212},{"id":212,"kind":"TransformCall: Sort","span":"1:239-245","children":[209,210]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Let","name":"distinct","value":{"Func":{"return_ty":null,"body":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Indirection":{"base":{"Ident":"_param"},"field":{"Name":"rel"}},"alias":"t"}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Tuple":[{"Indirection":{"base":{"Ident":"t"},"field":"Star"}}]},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":1}}]}}]}}]}},"params":[{"name":"rel","default_value":null}],"named_params":[],"generic_type_params":[]}}},"span":"1:13-79"},{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from_text"},"args":[{"Literal":{"String":"{ \"columns\": [\"a\"], \"data\": [[1], [2], [2], [3]] }"}}],"named_args":{"format":{"Ident":"json"}}}},{"Ident":"distinct"},{"FuncCall":{"name":{"Ident":"remove"},"args":[{"FuncCall":{"name":{"Ident":"from_text"},"args":[{"Literal":{"String":"{ \"columns\": [\"a\"], \"data\": [[1], [2]] }"}}],"named_args":{"format":{"Ident":"json"}}}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"a"}]}}]}}},"span":"1:81-246"}]}}
+frames:
+- - 1:71-77
+  - columns:
+    - !Single
+      name:
+      - t
+      - a
+      target_id: 136
+      target_name: null
+    inputs:
+    - id: 127
+      name: t
+      table:
+      - default_db
+      - _literal_127
+- - 0:3606-3683
+  - columns:
+    - !Single
+      name:
+      - t
+      - a
+      target_id: 136
+      target_name: null
+    - !Single
+      name:
+      - b
+      - a
+      target_id: 122
+      target_name: a
+    inputs:
+    - id: 127
+      name: t
+      table:
+      - default_db
+      - _literal_127
+    - id: 122
+      name: b
+      table:
+      - default_db
+      - _literal_122
+- - 0:3686-3731
+  - columns:
+    - !Single
+      name:
+      - t
+      - a
+      target_id: 136
+      target_name: null
+    - !Single
+      name:
+      - b
+      - a
+      target_id: 122
+      target_name: a
+    inputs:
+    - id: 127
+      name: t
+      table:
+      - default_db
+      - _literal_127
+    - id: 122
+      name: b
+      table:
+      - default_db
+      - _literal_122
+- - 1:165-238
+  - columns:
+    - !Single
+      name:
+      - t
+      - a
+      target_id: 207
+      target_name: null
+    inputs:
+    - id: 127
+      name: t
+      table:
+      - default_db
+      - _literal_127
+    - id: 122
+      name: b
+      table:
+      - default_db
+      - _literal_122
+- - 1:239-245
+  - columns:
+    - !Single
+      name:
+      - t
+      - a
+      target_id: 207
+      target_name: null
+    inputs:
+    - id: 127
+      name: t
+      table:
+      - default_db
+      - _literal_127
+    - id: 122
+      name: b
+      table:
+      - default_db
+      - _literal_122
+nodes:
+- id: 122
+  kind: Array
+  span: 1:173-237
+  parent: 189
+- id: 127
+  kind: Array
+  span: 1:36-55
+  parent: 154
+- id: 136
+  kind: Ident
+  ident: !Ident
+  - this
+  - t
+  - a
+  targets:
+  - 127
+  parent: 138
+- id: 138
+  kind: Tuple
+  span: 1:64-69
+  children:
+  - 136
+- id: 154
+  kind: 'TransformCall: Take'
+  span: 1:71-77
+  children:
+  - 127
+  - 155
+  parent: 189
+- id: 155
+  kind: Literal
+  parent: 154
+- id: 178
+  kind: Ident
+  ident: !Ident
+  - this
+  - t
+  - a
+  targets:
+  - 136
+- id: 181
+  kind: Ident
+  ident: !Ident
+  - that
+  - b
+  - a
+  targets:
+  - 122
+- id: 187
+  kind: RqOperator
+  span: 0:3635-3682
+  targets:
+  - 178
+  - 181
+  parent: 189
+- id: 189
+  kind: 'TransformCall: Join'
+  span: 0:3606-3683
+  children:
+  - 154
+  - 122
+  - 187
+  parent: 205
+- id: 197
+  kind: Ident
+  span: 0:6789-6791
+  ident: !Ident
+  - this
+  - b
+  - a
+  targets:
+  - 122
+- id: 201
+  kind: RqOperator
+  span: 0:3694-3730
+  targets:
+  - 197
+  - 204
+  parent: 205
+- id: 204
+  kind: Literal
+  span: 0:6795-6799
+- id: 205
+  kind: 'TransformCall: Filter'
+  span: 0:3686-3731
+  children:
+  - 189
+  - 201
+  parent: 209
+- id: 207
+  kind: Ident
+  ident: !Ident
+  - this
+  - t
+  - a
+  targets:
+  - 136
+  parent: 208
+- id: 208
+  kind: Tuple
+  span: 0:3742-3744
+  children:
+  - 207
+  parent: 209
+- id: 209
+  kind: 'TransformCall: Select'
+  span: 1:165-238
+  children:
+  - 205
+  - 208
+  parent: 212
+- id: 210
+  kind: Ident
+  span: 1:244-245
+  ident: !Ident
+  - this
+  - t
+  - a
+  targets:
+  - 207
+  parent: 212
+- id: 212
+  kind: 'TransformCall: Sort'
+  span: 1:239-245
+  children:
+  - 209
+  - 210
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Let
+      name: distinct
+      value:
+        Func:
+          return_ty: null
+          body:
+            Pipeline:
+              exprs:
+              - FuncCall:
+                  name:
+                    Ident: from
+                  args:
+                  - Indirection:
+                      base:
+                        Ident: _param
+                      field: !Name rel
+                    alias: t
+              - FuncCall:
+                  name:
+                    Ident: group
+                  args:
+                  - Tuple:
+                    - Indirection:
+                        base:
+                          Ident: t
+                        field: Star
+                  - FuncCall:
+                      name:
+                        Ident: take
+                      args:
+                      - Literal:
+                          Integer: 1
+          params:
+          - name: rel
+            default_value: null
+          named_params: []
+          generic_type_params: []
+    span: 1:13-79
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from_text
+              args:
+              - Literal:
+                  String: '{ "columns": ["a"], "data": [[1], [2], [2], [3]] }'
+              named_args:
+                format:
+                  Ident: json
+          - Ident: distinct
+          - FuncCall:
+              name:
+                Ident: remove
+              args:
+              - FuncCall:
+                  name:
+                    Ident: from_text
+                  args:
+                  - Literal:
+                      String: '{ "columns": ["a"], "data": [[1], [2]] }'
+                  named_args:
+                    format:
+                      Ident: json
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: a
+    span: 1:81-246

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__sort.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__sort.snap
@@ -3,4 +3,292 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom e=employees\nfilter first_name != \"Mitchell\"\nsort {first_name, last_name}\n\n# joining may use HashMerge, which can undo ORDER BY\njoin manager=employees side:left (e.reports_to == manager.employee_id)\n\nselect {e.first_name, e.last_name, manager.first_name}\n"
 input_file: prqlc/prqlc/tests/integration/queries/sort.prql
 ---
-{"frames":[["1:30-61",{"columns":[{"All":{"input_id":128,"except":[]}}],"inputs":[{"id":128,"name":"e","table":["default_db","employees"]}]}],["1:62-90",{"columns":[{"All":{"input_id":128,"except":[]}}],"inputs":[{"id":128,"name":"e","table":["default_db","employees"]}]}],["1:145-215",{"columns":[{"All":{"input_id":128,"except":[]}},{"All":{"input_id":119,"except":[]}}],"inputs":[{"id":128,"name":"e","table":["default_db","employees"]},{"id":119,"name":"manager","table":["default_db","employees"]}]}],["1:217-271",{"columns":[{"Single":{"name":null,"target_id":144,"target_name":null}},{"Single":{"name":["e","last_name"],"target_id":145,"target_name":null}},{"Single":{"name":["manager","first_name"],"target_id":146,"target_name":null}}],"inputs":[{"id":128,"name":"e","table":["default_db","employees"]},{"id":119,"name":"manager","table":["default_db","employees"]}]}]],"nodes":[{"id":119,"kind":"Ident","span":"1:158-167","ident":{"Ident":["default_db","employees"]},"parent":143},{"id":128,"kind":"Ident","span":"1:13-29","ident":{"Ident":["default_db","employees"]},"parent":134},{"id":130,"kind":"RqOperator","span":"1:37-61","targets":[132,133],"parent":134},{"id":132,"kind":"Ident","span":"1:37-47","ident":{"Ident":["this","e","first_name"]},"targets":[128]},{"id":133,"kind":"Literal","span":"1:51-61"},{"id":134,"kind":"TransformCall: Filter","span":"1:30-61","children":[128,130],"parent":138},{"id":135,"kind":"Ident","span":"1:68-78","ident":{"Ident":["this","e","first_name"]},"targets":[128],"parent":138},{"id":136,"kind":"Ident","span":"1:80-89","ident":{"Ident":["this","e","last_name"]},"targets":[128],"parent":138},{"id":138,"kind":"TransformCall: Sort","span":"1:62-90","children":[134,135,136],"parent":143},{"id":139,"kind":"RqOperator","span":"1:179-214","targets":[141,142],"parent":143},{"id":141,"kind":"Ident","span":"1:180-191","ident":{"Ident":["this","e","reports_to"]},"targets":[128]},{"id":142,"kind":"Ident","span":"1:202-214","ident":{"Ident":["that","manager","employee_id"]},"targets":[119]},{"id":143,"kind":"TransformCall: Join","span":"1:145-215","children":[138,119,139],"parent":148},{"id":144,"kind":"Ident","span":"1:225-237","ident":{"Ident":["this","e","first_name"]},"targets":[128],"parent":147},{"id":145,"kind":"Ident","span":"1:239-250","ident":{"Ident":["this","e","last_name"]},"targets":[128],"parent":147},{"id":146,"kind":"Ident","span":"1:252-270","ident":{"Ident":["this","manager","first_name"]},"targets":[119],"parent":147},{"id":147,"kind":"Tuple","span":"1:224-271","children":[144,145,146],"parent":148},{"id":148,"kind":"TransformCall: Select","span":"1:217-271","children":[143,147]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"employees","alias":"e"}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Binary":{"left":{"Ident":"first_name"},"op":"Ne","right":{"Literal":{"String":"Mitchell"}}}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Ident":"first_name"},{"Ident":"last_name"}]}]}},{"FuncCall":{"name":{"Ident":"join"},"args":[{"Ident":"employees","alias":"manager"},{"Binary":{"left":{"Indirection":{"base":{"Ident":"e"},"field":{"Name":"reports_to"}}},"op":"Eq","right":{"Indirection":{"base":{"Ident":"manager"},"field":{"Name":"employee_id"}}}}}],"named_args":{"side":{"Ident":"left"}}}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Indirection":{"base":{"Ident":"e"},"field":{"Name":"first_name"}}},{"Indirection":{"base":{"Ident":"e"},"field":{"Name":"last_name"}}},{"Indirection":{"base":{"Ident":"manager"},"field":{"Name":"first_name"}}}]}]}}]}}},"span":"1:13-272"}]}}
+frames:
+- - 1:30-61
+  - columns:
+    - !All
+      input_id: 128
+      except: []
+    inputs:
+    - id: 128
+      name: e
+      table:
+      - default_db
+      - employees
+- - 1:62-90
+  - columns:
+    - !All
+      input_id: 128
+      except: []
+    inputs:
+    - id: 128
+      name: e
+      table:
+      - default_db
+      - employees
+- - 1:145-215
+  - columns:
+    - !All
+      input_id: 128
+      except: []
+    - !All
+      input_id: 119
+      except: []
+    inputs:
+    - id: 128
+      name: e
+      table:
+      - default_db
+      - employees
+    - id: 119
+      name: manager
+      table:
+      - default_db
+      - employees
+- - 1:217-271
+  - columns:
+    - !Single
+      name: null
+      target_id: 144
+      target_name: null
+    - !Single
+      name:
+      - e
+      - last_name
+      target_id: 145
+      target_name: null
+    - !Single
+      name:
+      - manager
+      - first_name
+      target_id: 146
+      target_name: null
+    inputs:
+    - id: 128
+      name: e
+      table:
+      - default_db
+      - employees
+    - id: 119
+      name: manager
+      table:
+      - default_db
+      - employees
+nodes:
+- id: 119
+  kind: Ident
+  span: 1:158-167
+  ident: !Ident
+  - default_db
+  - employees
+  parent: 143
+- id: 128
+  kind: Ident
+  span: 1:13-29
+  ident: !Ident
+  - default_db
+  - employees
+  parent: 134
+- id: 130
+  kind: RqOperator
+  span: 1:37-61
+  targets:
+  - 132
+  - 133
+  parent: 134
+- id: 132
+  kind: Ident
+  span: 1:37-47
+  ident: !Ident
+  - this
+  - e
+  - first_name
+  targets:
+  - 128
+- id: 133
+  kind: Literal
+  span: 1:51-61
+- id: 134
+  kind: 'TransformCall: Filter'
+  span: 1:30-61
+  children:
+  - 128
+  - 130
+  parent: 138
+- id: 135
+  kind: Ident
+  span: 1:68-78
+  ident: !Ident
+  - this
+  - e
+  - first_name
+  targets:
+  - 128
+  parent: 138
+- id: 136
+  kind: Ident
+  span: 1:80-89
+  ident: !Ident
+  - this
+  - e
+  - last_name
+  targets:
+  - 128
+  parent: 138
+- id: 138
+  kind: 'TransformCall: Sort'
+  span: 1:62-90
+  children:
+  - 134
+  - 135
+  - 136
+  parent: 143
+- id: 139
+  kind: RqOperator
+  span: 1:179-214
+  targets:
+  - 141
+  - 142
+  parent: 143
+- id: 141
+  kind: Ident
+  span: 1:180-191
+  ident: !Ident
+  - this
+  - e
+  - reports_to
+  targets:
+  - 128
+- id: 142
+  kind: Ident
+  span: 1:202-214
+  ident: !Ident
+  - that
+  - manager
+  - employee_id
+  targets:
+  - 119
+- id: 143
+  kind: 'TransformCall: Join'
+  span: 1:145-215
+  children:
+  - 138
+  - 119
+  - 139
+  parent: 148
+- id: 144
+  kind: Ident
+  span: 1:225-237
+  ident: !Ident
+  - this
+  - e
+  - first_name
+  targets:
+  - 128
+  parent: 147
+- id: 145
+  kind: Ident
+  span: 1:239-250
+  ident: !Ident
+  - this
+  - e
+  - last_name
+  targets:
+  - 128
+  parent: 147
+- id: 146
+  kind: Ident
+  span: 1:252-270
+  ident: !Ident
+  - this
+  - manager
+  - first_name
+  targets:
+  - 119
+  parent: 147
+- id: 147
+  kind: Tuple
+  span: 1:224-271
+  children:
+  - 144
+  - 145
+  - 146
+  parent: 148
+- id: 148
+  kind: 'TransformCall: Select'
+  span: 1:217-271
+  children:
+  - 143
+  - 147
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: employees
+                alias: e
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Binary:
+                  left:
+                    Ident: first_name
+                  op: Ne
+                  right:
+                    Literal:
+                      String: Mitchell
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Ident: first_name
+                - Ident: last_name
+          - FuncCall:
+              name:
+                Ident: join
+              args:
+              - Ident: employees
+                alias: manager
+              - Binary:
+                  left:
+                    Indirection:
+                      base:
+                        Ident: e
+                      field: !Name reports_to
+                  op: Eq
+                  right:
+                    Indirection:
+                      base:
+                        Ident: manager
+                      field: !Name employee_id
+              named_args:
+                side:
+                  Ident: left
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Indirection:
+                    base:
+                      Ident: e
+                    field: !Name first_name
+                - Indirection:
+                    base:
+                      Ident: e
+                    field: !Name last_name
+                - Indirection:
+                    base:
+                      Ident: manager
+                    field: !Name first_name
+    span: 1:13-272

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__switch.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__switch.snap
@@ -3,4 +3,212 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# glaredb:skip (May be a bag of String type conversion for Postgres Client)\n# mssql:test\nfrom tracks\nsort milliseconds\nselect display = case [\n    composer != null => composer,\n    genre_id < 17 => 'no composer',\n    true => f'unknown composer'\n]\ntake 10\n"
 input_file: prqlc/prqlc/tests/integration/queries/switch.prql
 ---
-{"frames":[["1:101-118",{"columns":[{"All":{"input_id":124,"except":[]}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:119-246",{"columns":[{"Single":{"name":["display"],"target_id":129,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}],["1:247-254",{"columns":[{"Single":{"name":["display"],"target_id":129,"target_name":null}}],"inputs":[{"id":124,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":124,"kind":"Ident","span":"1:89-100","ident":{"Ident":["default_db","tracks"]},"parent":128},{"id":126,"kind":"Ident","span":"1:106-118","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[124],"parent":128},{"id":128,"kind":"TransformCall: Sort","span":"1:101-118","children":[124,126],"parent":143},{"id":129,"kind":"Case","span":"1:136-246","alias":"display","targets":[130,134,135,139,140,141],"parent":142},{"id":130,"kind":"RqOperator","span":"1:147-163","targets":[132,133]},{"id":132,"kind":"Ident","span":"1:147-155","ident":{"Ident":["this","tracks","composer"]},"targets":[124]},{"id":133,"kind":"Literal","span":"1:159-163"},{"id":134,"kind":"Ident","span":"1:167-175","ident":{"Ident":["this","tracks","composer"]},"targets":[124]},{"id":135,"kind":"RqOperator","span":"1:181-194","targets":[137,138]},{"id":137,"kind":"Ident","span":"1:181-189","ident":{"Ident":["this","tracks","genre_id"]},"targets":[124]},{"id":138,"kind":"Literal","span":"1:192-194"},{"id":139,"kind":"Literal","span":"1:198-211"},{"id":140,"kind":"Literal","span":"1:217-221"},{"id":141,"kind":"FString","span":"1:225-244"},{"id":142,"kind":"Tuple","span":"1:136-246","children":[129],"parent":143},{"id":143,"kind":"TransformCall: Select","span":"1:119-246","children":[128,142],"parent":145},{"id":145,"kind":"TransformCall: Take","span":"1:247-254","children":[143,146]},{"id":146,"kind":"Literal","parent":145}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"milliseconds"}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Case":[{"condition":{"Binary":{"left":{"Ident":"composer"},"op":"Ne","right":{"Literal":"Null"}}},"value":{"Ident":"composer"}},{"condition":{"Binary":{"left":{"Ident":"genre_id"},"op":"Lt","right":{"Literal":{"Integer":17}}}},"value":{"Literal":{"String":"no composer"}}},{"condition":{"Literal":{"Boolean":true}},"value":{"FString":[{"String":"unknown composer"}]}}],"alias":"display"}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":10}}]}}]}}},"span":"1:89-255"}]}}
+frames:
+- - 1:101-118
+  - columns:
+    - !All
+      input_id: 124
+      except: []
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:119-246
+  - columns:
+    - !Single
+      name:
+      - display
+      target_id: 129
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:247-254
+  - columns:
+    - !Single
+      name:
+      - display
+      target_id: 129
+      target_name: null
+    inputs:
+    - id: 124
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 124
+  kind: Ident
+  span: 1:89-100
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 128
+- id: 126
+  kind: Ident
+  span: 1:106-118
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 124
+  parent: 128
+- id: 128
+  kind: 'TransformCall: Sort'
+  span: 1:101-118
+  children:
+  - 124
+  - 126
+  parent: 143
+- id: 129
+  kind: Case
+  span: 1:136-246
+  alias: display
+  targets:
+  - 130
+  - 134
+  - 135
+  - 139
+  - 140
+  - 141
+  parent: 142
+- id: 130
+  kind: RqOperator
+  span: 1:147-163
+  targets:
+  - 132
+  - 133
+- id: 132
+  kind: Ident
+  span: 1:147-155
+  ident: !Ident
+  - this
+  - tracks
+  - composer
+  targets:
+  - 124
+- id: 133
+  kind: Literal
+  span: 1:159-163
+- id: 134
+  kind: Ident
+  span: 1:167-175
+  ident: !Ident
+  - this
+  - tracks
+  - composer
+  targets:
+  - 124
+- id: 135
+  kind: RqOperator
+  span: 1:181-194
+  targets:
+  - 137
+  - 138
+- id: 137
+  kind: Ident
+  span: 1:181-189
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 124
+- id: 138
+  kind: Literal
+  span: 1:192-194
+- id: 139
+  kind: Literal
+  span: 1:198-211
+- id: 140
+  kind: Literal
+  span: 1:217-221
+- id: 141
+  kind: FString
+  span: 1:225-244
+- id: 142
+  kind: Tuple
+  span: 1:136-246
+  children:
+  - 129
+  parent: 143
+- id: 143
+  kind: 'TransformCall: Select'
+  span: 1:119-246
+  children:
+  - 128
+  - 142
+  parent: 145
+- id: 145
+  kind: 'TransformCall: Take'
+  span: 1:247-254
+  children:
+  - 143
+  - 146
+- id: 146
+  kind: Literal
+  parent: 145
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Ident: milliseconds
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Case:
+                - condition:
+                    Binary:
+                      left:
+                        Ident: composer
+                      op: Ne
+                      right:
+                        Literal: 'Null'
+                  value:
+                    Ident: composer
+                - condition:
+                    Binary:
+                      left:
+                        Ident: genre_id
+                      op: Lt
+                      right:
+                        Literal:
+                          Integer: 17
+                  value:
+                    Literal:
+                      String: no composer
+                - condition:
+                    Literal:
+                      Boolean: true
+                  value:
+                    FString:
+                    - !String unknown composer
+                alias: display
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Literal:
+                  Integer: 10
+    span: 1:89-255

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__take.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__take.snap
@@ -3,4 +3,103 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom tracks\nsort {+track_id}\ntake 3..5\n"
 input_file: prqlc/prqlc/tests/integration/queries/take.prql
 ---
-{"frames":[["1:25-41",{"columns":[{"All":{"input_id":121,"except":[]}}],"inputs":[{"id":121,"name":"tracks","table":["default_db","tracks"]}]}],["1:42-51",{"columns":[{"All":{"input_id":121,"except":[]}}],"inputs":[{"id":121,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":121,"kind":"Ident","span":"1:13-24","ident":{"Ident":["default_db","tracks"]},"parent":125},{"id":123,"kind":"Ident","span":"1:31-40","ident":{"Ident":["this","tracks","track_id"]},"targets":[121],"parent":125},{"id":125,"kind":"TransformCall: Sort","span":"1:25-41","children":[121,123],"parent":129},{"id":126,"kind":"Literal","span":"1:47-48","alias":"start","parent":129},{"id":127,"kind":"Literal","span":"1:50-51","alias":"end","parent":129},{"id":129,"kind":"TransformCall: Take","span":"1:42-51","children":[125,126,127]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Unary":{"op":"Add","expr":{"Ident":"track_id"}}}]}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Range":{"start":{"Literal":{"Integer":3}},"end":{"Literal":{"Integer":5}}}}]}}]}}},"span":"1:13-52"}]}}
+frames:
+- - 1:25-41
+  - columns:
+    - !All
+      input_id: 121
+      except: []
+    inputs:
+    - id: 121
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:42-51
+  - columns:
+    - !All
+      input_id: 121
+      except: []
+    inputs:
+    - id: 121
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 121
+  kind: Ident
+  span: 1:13-24
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 125
+- id: 123
+  kind: Ident
+  span: 1:31-40
+  ident: !Ident
+  - this
+  - tracks
+  - track_id
+  targets:
+  - 121
+  parent: 125
+- id: 125
+  kind: 'TransformCall: Sort'
+  span: 1:25-41
+  children:
+  - 121
+  - 123
+  parent: 129
+- id: 126
+  kind: Literal
+  span: 1:47-48
+  alias: start
+  parent: 129
+- id: 127
+  kind: Literal
+  span: 1:50-51
+  alias: end
+  parent: 129
+- id: 129
+  kind: 'TransformCall: Take'
+  span: 1:42-51
+  children:
+  - 125
+  - 126
+  - 127
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Unary:
+                    op: Add
+                    expr:
+                      Ident: track_id
+          - FuncCall:
+              name:
+                Ident: take
+              args:
+              - Range:
+                  start:
+                    Literal:
+                      Integer: 3
+                  end:
+                    Literal:
+                      Integer: 5
+    span: 1:13-52

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__text_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__text_module.snap
@@ -3,4 +3,632 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\n# glaredb:skip — TODO: started raising an error on 2024-05-20; see `window.prql`\n# for more details\nfrom albums\nselect {\n    title,\n    title_and_spaces = f\"  {title}  \",\n    low = title | text.lower,\n    up = title | text.upper,\n    ltrimmed = title | text.ltrim,\n    rtrimmed = title | text.rtrim,\n    trimmed = title | text.trim,\n    len = title | text.length,\n    subs = title | text.extract 2 5,\n    replace = title | text.replace \"al\" \"PIKA\",\n}\nsort {title}\nfilter (title | text.starts_with \"Black\") || (title | text.contains \"Sabbath\") || (title | text.ends_with \"os\")\n"
 input_file: prqlc/prqlc/tests/integration/queries/text_module.prql
 ---
-{"frames":[["1:125-463",{"columns":[{"Single":{"name":["albums","title"],"target_id":126,"target_name":null}},{"Single":{"name":["title_and_spaces"],"target_id":127,"target_name":null}},{"Single":{"name":["low"],"target_id":129,"target_name":null}},{"Single":{"name":["up"],"target_id":132,"target_name":null}},{"Single":{"name":["ltrimmed"],"target_id":135,"target_name":null}},{"Single":{"name":["rtrimmed"],"target_id":138,"target_name":null}},{"Single":{"name":["trimmed"],"target_id":141,"target_name":null}},{"Single":{"name":["len"],"target_id":144,"target_name":null}},{"Single":{"name":["subs"],"target_id":147,"target_name":null}},{"Single":{"name":["replace"],"target_id":153,"target_name":null}}],"inputs":[{"id":124,"name":"albums","table":["default_db","albums"]}]}],["1:464-476",{"columns":[{"Single":{"name":["albums","title"],"target_id":126,"target_name":null}},{"Single":{"name":["title_and_spaces"],"target_id":127,"target_name":null}},{"Single":{"name":["low"],"target_id":129,"target_name":null}},{"Single":{"name":["up"],"target_id":132,"target_name":null}},{"Single":{"name":["ltrimmed"],"target_id":135,"target_name":null}},{"Single":{"name":["rtrimmed"],"target_id":138,"target_name":null}},{"Single":{"name":["trimmed"],"target_id":141,"target_name":null}},{"Single":{"name":["len"],"target_id":144,"target_name":null}},{"Single":{"name":["subs"],"target_id":147,"target_name":null}},{"Single":{"name":["replace"],"target_id":153,"target_name":null}}],"inputs":[{"id":124,"name":"albums","table":["default_db","albums"]}]}],["1:477-588",{"columns":[{"Single":{"name":["albums","title"],"target_id":126,"target_name":null}},{"Single":{"name":["title_and_spaces"],"target_id":127,"target_name":null}},{"Single":{"name":["low"],"target_id":129,"target_name":null}},{"Single":{"name":["up"],"target_id":132,"target_name":null}},{"Single":{"name":["ltrimmed"],"target_id":135,"target_name":null}},{"Single":{"name":["rtrimmed"],"target_id":138,"target_name":null}},{"Single":{"name":["trimmed"],"target_id":141,"target_name":null}},{"Single":{"name":["len"],"target_id":144,"target_name":null}},{"Single":{"name":["subs"],"target_id":147,"target_name":null}},{"Single":{"name":["replace"],"target_id":153,"target_name":null}}],"inputs":[{"id":124,"name":"albums","table":["default_db","albums"]}]}]],"nodes":[{"id":124,"kind":"Ident","span":"1:113-124","ident":{"Ident":["default_db","albums"]},"parent":160},{"id":126,"kind":"Ident","span":"1:138-143","ident":{"Ident":["this","albums","title"]},"targets":[124],"parent":159},{"id":127,"kind":"FString","span":"1:168-182","alias":"title_and_spaces","targets":[128],"parent":159},{"id":128,"kind":"Ident","span":"1:173-178","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":129,"kind":"RqOperator","span":"1:202-212","alias":"low","targets":[131],"parent":159},{"id":131,"kind":"Ident","span":"1:194-199","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":132,"kind":"RqOperator","span":"1:231-241","alias":"up","targets":[134],"parent":159},{"id":134,"kind":"Ident","span":"1:223-228","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":135,"kind":"RqOperator","span":"1:266-276","alias":"ltrimmed","targets":[137],"parent":159},{"id":137,"kind":"Ident","span":"1:258-263","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":138,"kind":"RqOperator","span":"1:301-311","alias":"rtrimmed","targets":[140],"parent":159},{"id":140,"kind":"Ident","span":"1:293-298","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":141,"kind":"RqOperator","span":"1:335-344","alias":"trimmed","targets":[143],"parent":159},{"id":143,"kind":"Ident","span":"1:327-332","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":144,"kind":"RqOperator","span":"1:364-375","alias":"len","targets":[146],"parent":159},{"id":146,"kind":"Ident","span":"1:356-361","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":147,"kind":"RqOperator","span":"1:396-412","alias":"subs","targets":[150,151,152],"parent":159},{"id":150,"kind":"Literal","span":"1:409-410"},{"id":151,"kind":"Literal","span":"1:411-412"},{"id":152,"kind":"Ident","span":"1:388-393","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":153,"kind":"RqOperator","span":"1:436-460","alias":"replace","targets":[156,157,158],"parent":159},{"id":156,"kind":"Literal","span":"1:449-453"},{"id":157,"kind":"Literal","span":"1:454-460"},{"id":158,"kind":"Ident","span":"1:428-433","ident":{"Ident":["this","albums","title"]},"targets":[124]},{"id":159,"kind":"Tuple","span":"1:132-463","children":[126,127,129,132,135,138,141,144,147,153],"parent":160},{"id":160,"kind":"TransformCall: Select","span":"1:125-463","children":[124,159],"parent":163},{"id":161,"kind":"Ident","span":"1:470-475","ident":{"Ident":["this","albums","title"]},"targets":[126],"parent":163},{"id":163,"kind":"TransformCall: Sort","span":"1:464-476","children":[160,161],"parent":183},{"id":164,"kind":"RqOperator","span":"1:484-588","targets":[166,178],"parent":183},{"id":166,"kind":"RqOperator","span":"1:484-555","targets":[168,173]},{"id":168,"kind":"RqOperator","span":"1:493-517","targets":[171,172]},{"id":171,"kind":"Literal","span":"1:510-517"},{"id":172,"kind":"Ident","span":"1:485-490","ident":{"Ident":["this","albums","title"]},"targets":[126]},{"id":173,"kind":"RqOperator","span":"1:531-554","targets":[176,177]},{"id":176,"kind":"Literal","span":"1:545-554"},{"id":177,"kind":"Ident","span":"1:523-528","ident":{"Ident":["this","albums","title"]},"targets":[126]},{"id":178,"kind":"RqOperator","span":"1:568-587","targets":[181,182]},{"id":181,"kind":"Literal","span":"1:583-587"},{"id":182,"kind":"Ident","span":"1:560-565","ident":{"Ident":["this","albums","title"]},"targets":[126]},{"id":183,"kind":"TransformCall: Filter","span":"1:477-588","children":[163,164]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"albums"}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"title"},{"FString":[{"String":"  "},{"Expr":{"expr":{"Ident":"title"},"format":null}},{"String":"  "}],"alias":"title_and_spaces"},{"Pipeline":{"exprs":[{"Ident":"title"},{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"lower"}}}]},"alias":"low"},{"Pipeline":{"exprs":[{"Ident":"title"},{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"upper"}}}]},"alias":"up"},{"Pipeline":{"exprs":[{"Ident":"title"},{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"ltrim"}}}]},"alias":"ltrimmed"},{"Pipeline":{"exprs":[{"Ident":"title"},{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"rtrim"}}}]},"alias":"rtrimmed"},{"Pipeline":{"exprs":[{"Ident":"title"},{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"trim"}}}]},"alias":"trimmed"},{"Pipeline":{"exprs":[{"Ident":"title"},{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"length"}}}]},"alias":"len"},{"Pipeline":{"exprs":[{"Ident":"title"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"extract"}}},"args":[{"Literal":{"Integer":2}},{"Literal":{"Integer":5}}]}}]},"alias":"subs"},{"Pipeline":{"exprs":[{"Ident":"title"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"replace"}}},"args":[{"Literal":{"String":"al"}},{"Literal":{"String":"PIKA"}}]}}]},"alias":"replace"}]}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Ident":"title"}]}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Binary":{"left":{"Binary":{"left":{"Pipeline":{"exprs":[{"Ident":"title"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"starts_with"}}},"args":[{"Literal":{"String":"Black"}}]}}]}},"op":"Or","right":{"Pipeline":{"exprs":[{"Ident":"title"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"contains"}}},"args":[{"Literal":{"String":"Sabbath"}}]}}]}}}},"op":"Or","right":{"Pipeline":{"exprs":[{"Ident":"title"},{"FuncCall":{"name":{"Indirection":{"base":{"Ident":"text"},"field":{"Name":"ends_with"}}},"args":[{"Literal":{"String":"os"}}]}}]}}}}]}}]}}},"span":"1:113-589"}]}}
+frames:
+- - 1:125-463
+  - columns:
+    - !Single
+      name:
+      - albums
+      - title
+      target_id: 126
+      target_name: null
+    - !Single
+      name:
+      - title_and_spaces
+      target_id: 127
+      target_name: null
+    - !Single
+      name:
+      - low
+      target_id: 129
+      target_name: null
+    - !Single
+      name:
+      - up
+      target_id: 132
+      target_name: null
+    - !Single
+      name:
+      - ltrimmed
+      target_id: 135
+      target_name: null
+    - !Single
+      name:
+      - rtrimmed
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - trimmed
+      target_id: 141
+      target_name: null
+    - !Single
+      name:
+      - len
+      target_id: 144
+      target_name: null
+    - !Single
+      name:
+      - subs
+      target_id: 147
+      target_name: null
+    - !Single
+      name:
+      - replace
+      target_id: 153
+      target_name: null
+    inputs:
+    - id: 124
+      name: albums
+      table:
+      - default_db
+      - albums
+- - 1:464-476
+  - columns:
+    - !Single
+      name:
+      - albums
+      - title
+      target_id: 126
+      target_name: null
+    - !Single
+      name:
+      - title_and_spaces
+      target_id: 127
+      target_name: null
+    - !Single
+      name:
+      - low
+      target_id: 129
+      target_name: null
+    - !Single
+      name:
+      - up
+      target_id: 132
+      target_name: null
+    - !Single
+      name:
+      - ltrimmed
+      target_id: 135
+      target_name: null
+    - !Single
+      name:
+      - rtrimmed
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - trimmed
+      target_id: 141
+      target_name: null
+    - !Single
+      name:
+      - len
+      target_id: 144
+      target_name: null
+    - !Single
+      name:
+      - subs
+      target_id: 147
+      target_name: null
+    - !Single
+      name:
+      - replace
+      target_id: 153
+      target_name: null
+    inputs:
+    - id: 124
+      name: albums
+      table:
+      - default_db
+      - albums
+- - 1:477-588
+  - columns:
+    - !Single
+      name:
+      - albums
+      - title
+      target_id: 126
+      target_name: null
+    - !Single
+      name:
+      - title_and_spaces
+      target_id: 127
+      target_name: null
+    - !Single
+      name:
+      - low
+      target_id: 129
+      target_name: null
+    - !Single
+      name:
+      - up
+      target_id: 132
+      target_name: null
+    - !Single
+      name:
+      - ltrimmed
+      target_id: 135
+      target_name: null
+    - !Single
+      name:
+      - rtrimmed
+      target_id: 138
+      target_name: null
+    - !Single
+      name:
+      - trimmed
+      target_id: 141
+      target_name: null
+    - !Single
+      name:
+      - len
+      target_id: 144
+      target_name: null
+    - !Single
+      name:
+      - subs
+      target_id: 147
+      target_name: null
+    - !Single
+      name:
+      - replace
+      target_id: 153
+      target_name: null
+    inputs:
+    - id: 124
+      name: albums
+      table:
+      - default_db
+      - albums
+nodes:
+- id: 124
+  kind: Ident
+  span: 1:113-124
+  ident: !Ident
+  - default_db
+  - albums
+  parent: 160
+- id: 126
+  kind: Ident
+  span: 1:138-143
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+  parent: 159
+- id: 127
+  kind: FString
+  span: 1:168-182
+  alias: title_and_spaces
+  targets:
+  - 128
+  parent: 159
+- id: 128
+  kind: Ident
+  span: 1:173-178
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 129
+  kind: RqOperator
+  span: 1:202-212
+  alias: low
+  targets:
+  - 131
+  parent: 159
+- id: 131
+  kind: Ident
+  span: 1:194-199
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 132
+  kind: RqOperator
+  span: 1:231-241
+  alias: up
+  targets:
+  - 134
+  parent: 159
+- id: 134
+  kind: Ident
+  span: 1:223-228
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 135
+  kind: RqOperator
+  span: 1:266-276
+  alias: ltrimmed
+  targets:
+  - 137
+  parent: 159
+- id: 137
+  kind: Ident
+  span: 1:258-263
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 138
+  kind: RqOperator
+  span: 1:301-311
+  alias: rtrimmed
+  targets:
+  - 140
+  parent: 159
+- id: 140
+  kind: Ident
+  span: 1:293-298
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 141
+  kind: RqOperator
+  span: 1:335-344
+  alias: trimmed
+  targets:
+  - 143
+  parent: 159
+- id: 143
+  kind: Ident
+  span: 1:327-332
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 144
+  kind: RqOperator
+  span: 1:364-375
+  alias: len
+  targets:
+  - 146
+  parent: 159
+- id: 146
+  kind: Ident
+  span: 1:356-361
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 147
+  kind: RqOperator
+  span: 1:396-412
+  alias: subs
+  targets:
+  - 150
+  - 151
+  - 152
+  parent: 159
+- id: 150
+  kind: Literal
+  span: 1:409-410
+- id: 151
+  kind: Literal
+  span: 1:411-412
+- id: 152
+  kind: Ident
+  span: 1:388-393
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 153
+  kind: RqOperator
+  span: 1:436-460
+  alias: replace
+  targets:
+  - 156
+  - 157
+  - 158
+  parent: 159
+- id: 156
+  kind: Literal
+  span: 1:449-453
+- id: 157
+  kind: Literal
+  span: 1:454-460
+- id: 158
+  kind: Ident
+  span: 1:428-433
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 124
+- id: 159
+  kind: Tuple
+  span: 1:132-463
+  children:
+  - 126
+  - 127
+  - 129
+  - 132
+  - 135
+  - 138
+  - 141
+  - 144
+  - 147
+  - 153
+  parent: 160
+- id: 160
+  kind: 'TransformCall: Select'
+  span: 1:125-463
+  children:
+  - 124
+  - 159
+  parent: 163
+- id: 161
+  kind: Ident
+  span: 1:470-475
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 126
+  parent: 163
+- id: 163
+  kind: 'TransformCall: Sort'
+  span: 1:464-476
+  children:
+  - 160
+  - 161
+  parent: 183
+- id: 164
+  kind: RqOperator
+  span: 1:484-588
+  targets:
+  - 166
+  - 178
+  parent: 183
+- id: 166
+  kind: RqOperator
+  span: 1:484-555
+  targets:
+  - 168
+  - 173
+- id: 168
+  kind: RqOperator
+  span: 1:493-517
+  targets:
+  - 171
+  - 172
+- id: 171
+  kind: Literal
+  span: 1:510-517
+- id: 172
+  kind: Ident
+  span: 1:485-490
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 126
+- id: 173
+  kind: RqOperator
+  span: 1:531-554
+  targets:
+  - 176
+  - 177
+- id: 176
+  kind: Literal
+  span: 1:545-554
+- id: 177
+  kind: Ident
+  span: 1:523-528
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 126
+- id: 178
+  kind: RqOperator
+  span: 1:568-587
+  targets:
+  - 181
+  - 182
+- id: 181
+  kind: Literal
+  span: 1:583-587
+- id: 182
+  kind: Ident
+  span: 1:560-565
+  ident: !Ident
+  - this
+  - albums
+  - title
+  targets:
+  - 126
+- id: 183
+  kind: 'TransformCall: Filter'
+  span: 1:477-588
+  children:
+  - 163
+  - 164
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: albums
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: title
+                - FString:
+                  - !String '  '
+                  - !Expr
+                    expr:
+                      Ident: title
+                    format: null
+                  - !String '  '
+                  alias: title_and_spaces
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - Indirection:
+                        base:
+                          Ident: text
+                        field: !Name lower
+                  alias: low
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - Indirection:
+                        base:
+                          Ident: text
+                        field: !Name upper
+                  alias: up
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - Indirection:
+                        base:
+                          Ident: text
+                        field: !Name ltrim
+                  alias: ltrimmed
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - Indirection:
+                        base:
+                          Ident: text
+                        field: !Name rtrim
+                  alias: rtrimmed
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - Indirection:
+                        base:
+                          Ident: text
+                        field: !Name trim
+                  alias: trimmed
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - Indirection:
+                        base:
+                          Ident: text
+                        field: !Name length
+                  alias: len
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: text
+                            field: !Name extract
+                        args:
+                        - Literal:
+                            Integer: 2
+                        - Literal:
+                            Integer: 5
+                  alias: subs
+                - Pipeline:
+                    exprs:
+                    - Ident: title
+                    - FuncCall:
+                        name:
+                          Indirection:
+                            base:
+                              Ident: text
+                            field: !Name replace
+                        args:
+                        - Literal:
+                            String: al
+                        - Literal:
+                            String: PIKA
+                  alias: replace
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Ident: title
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Binary:
+                  left:
+                    Binary:
+                      left:
+                        Pipeline:
+                          exprs:
+                          - Ident: title
+                          - FuncCall:
+                              name:
+                                Indirection:
+                                  base:
+                                    Ident: text
+                                  field: !Name starts_with
+                              args:
+                              - Literal:
+                                  String: Black
+                      op: Or
+                      right:
+                        Pipeline:
+                          exprs:
+                          - Ident: title
+                          - FuncCall:
+                              name:
+                                Indirection:
+                                  base:
+                                    Ident: text
+                                  field: !Name contains
+                              args:
+                              - Literal:
+                                  String: Sabbath
+                  op: Or
+                  right:
+                    Pipeline:
+                      exprs:
+                      - Ident: title
+                      - FuncCall:
+                          name:
+                            Indirection:
+                              base:
+                                Ident: text
+                              field: !Name ends_with
+                          args:
+                          - Literal:
+                              String: os
+    span: 1:113-589

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__window.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__window.snap
@@ -3,4 +3,459 @@ source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:skip Conversion(\"cannot interpret I64(Some(1)) as an i32 value\")', connection.rs:200:34\n# duckdb:skip problems with DISTINCT ON (duckdb internal error: [with INPUT_TYPE = int; RESULT_TYPE = unsigned char]: Assertion `min_val <= input' failed.)\n# clickhouse:skip problems with DISTINCT ON\n# postgres:skip problems with DISTINCT ON\n# glaredb:skip — TODO: started raising an error on 2024-05-20, from https://github.com/PRQL/prql/actions/runs/9154902656/job/25198160283:\n    # ERROR: This feature is not implemented: Unsupported ast node in sqltorel:\n    # Substring { expr: Identifier(Ident { value: \"title\", quote_style: None }),\n    # substring_from: Some(Value(Number(\"2\", false))), substring_for:\n    # Some(Value(Number(\"5\", false))), special: true }\nfrom tracks\ngroup genre_id (\n  sort milliseconds\n  derive {\n    num = row_number this,\n    total = count this,\n    last_val = last track_id,\n  }\n  take 10\n)\nsort {genre_id, milliseconds}\nselect {track_id, genre_id, num, total, last_val}\nfilter genre_id >= 22\n"
 input_file: prqlc/prqlc/tests/integration/queries/window.prql
 ---
-{"frames":[["1:813-906",{"columns":[{"All":{"input_id":127,"except":["genre_id"]}},{"Single":{"name":["num"],"target_id":165,"target_name":null}},{"Single":{"name":["total"],"target_id":173,"target_name":null}},{"Single":{"name":["last_val"],"target_id":175,"target_name":null}}],"inputs":[{"id":127,"name":"tracks","table":["default_db","tracks"]}]}],["1:919-948",{"columns":[{"Single":{"name":["tracks","genre_id"],"target_id":129,"target_name":null}},{"All":{"input_id":127,"except":["genre_id"]}},{"Single":{"name":["num"],"target_id":165,"target_name":null}},{"Single":{"name":["total"],"target_id":173,"target_name":null}},{"Single":{"name":["last_val"],"target_id":175,"target_name":null}}],"inputs":[{"id":127,"name":"tracks","table":["default_db","tracks"]}]}],["1:949-998",{"columns":[{"Single":{"name":["tracks","track_id"],"target_id":189,"target_name":null}},{"Single":{"name":["tracks","genre_id"],"target_id":190,"target_name":null}},{"Single":{"name":["num"],"target_id":191,"target_name":null}},{"Single":{"name":["total"],"target_id":192,"target_name":null}},{"Single":{"name":["last_val"],"target_id":193,"target_name":null}}],"inputs":[{"id":127,"name":"tracks","table":["default_db","tracks"]}]}],["1:999-1020",{"columns":[{"Single":{"name":["tracks","track_id"],"target_id":189,"target_name":null}},{"Single":{"name":["tracks","genre_id"],"target_id":190,"target_name":null}},{"Single":{"name":["num"],"target_id":191,"target_name":null}},{"Single":{"name":["total"],"target_id":192,"target_name":null}},{"Single":{"name":["last_val"],"target_id":193,"target_name":null}}],"inputs":[{"id":127,"name":"tracks","table":["default_db","tracks"]}]}]],"nodes":[{"id":127,"kind":"Ident","span":"1:762-773","ident":{"Ident":["default_db","tracks"]},"parent":179},{"id":129,"kind":"Ident","span":"1:780-788","ident":{"Ident":["this","tracks","genre_id"]},"targets":[127],"parent":138},{"id":138,"kind":"Tuple","span":"1:780-788","children":[129]},{"id":157,"kind":"Ident","span":"1:798-810","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[127]},{"id":165,"kind":"RqOperator","span":"1:832-847","alias":"num","targets":[166],"parent":178},{"id":166,"kind":"Literal"},{"id":173,"kind":"RqOperator","span":"1:861-871","alias":"total","targets":[174],"parent":178},{"id":174,"kind":"Literal"},{"id":175,"kind":"RqOperator","span":"1:888-901","alias":"last_val","targets":[177],"parent":178},{"id":177,"kind":"Ident","span":"1:893-901","ident":{"Ident":["this","tracks","track_id"]},"targets":[127]},{"id":178,"kind":"Tuple","span":"1:820-906","children":[165,173,175],"parent":179},{"id":179,"kind":"TransformCall: Derive","span":"1:813-906","children":[127,178],"parent":181},{"id":181,"kind":"TransformCall: Take","children":[179,182],"parent":188},{"id":182,"kind":"Literal","parent":181},{"id":185,"kind":"Ident","span":"1:925-933","ident":{"Ident":["this","tracks","genre_id"]},"targets":[129],"parent":188},{"id":186,"kind":"Ident","span":"1:935-947","ident":{"Ident":["this","tracks","milliseconds"]},"targets":[127],"parent":188},{"id":188,"kind":"TransformCall: Sort","span":"1:919-948","children":[181,185,186],"parent":195},{"id":189,"kind":"Ident","span":"1:957-965","ident":{"Ident":["this","tracks","track_id"]},"targets":[127],"parent":194},{"id":190,"kind":"Ident","span":"1:967-975","ident":{"Ident":["this","tracks","genre_id"]},"targets":[129],"parent":194},{"id":191,"kind":"Ident","span":"1:977-980","ident":{"Ident":["this","num"]},"targets":[165],"parent":194},{"id":192,"kind":"Ident","span":"1:982-987","ident":{"Ident":["this","total"]},"targets":[173],"parent":194},{"id":193,"kind":"Ident","span":"1:989-997","ident":{"Ident":["this","last_val"]},"targets":[175],"parent":194},{"id":194,"kind":"Tuple","span":"1:956-998","children":[189,190,191,192,193],"parent":195},{"id":195,"kind":"TransformCall: Select","span":"1:949-998","children":[188,194],"parent":200},{"id":196,"kind":"RqOperator","span":"1:1006-1020","targets":[198,199],"parent":200},{"id":198,"kind":"Ident","span":"1:1006-1014","ident":{"Ident":["this","tracks","genre_id"]},"targets":[190]},{"id":199,"kind":"Literal","span":"1:1018-1020"},{"id":200,"kind":"TransformCall: Filter","span":"1:999-1020","children":[195,196]}],"ast":{"name":"Project","stmts":[{"VarDef":{"kind":"Main","name":"main","value":{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"from"},"args":[{"Ident":"tracks"}]}},{"FuncCall":{"name":{"Ident":"group"},"args":[{"Ident":"genre_id"},{"Pipeline":{"exprs":[{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Ident":"milliseconds"}]}},{"FuncCall":{"name":{"Ident":"derive"},"args":[{"Tuple":[{"FuncCall":{"name":{"Ident":"row_number"},"args":[{"Ident":"this"}]},"alias":"num"},{"FuncCall":{"name":{"Ident":"count"},"args":[{"Ident":"this"}]},"alias":"total"},{"FuncCall":{"name":{"Ident":"last"},"args":[{"Ident":"track_id"}]},"alias":"last_val"}]}]}},{"FuncCall":{"name":{"Ident":"take"},"args":[{"Literal":{"Integer":10}}]}}]}}]}},{"FuncCall":{"name":{"Ident":"sort"},"args":[{"Tuple":[{"Ident":"genre_id"},{"Ident":"milliseconds"}]}]}},{"FuncCall":{"name":{"Ident":"select"},"args":[{"Tuple":[{"Ident":"track_id"},{"Ident":"genre_id"},{"Ident":"num"},{"Ident":"total"},{"Ident":"last_val"}]}]}},{"FuncCall":{"name":{"Ident":"filter"},"args":[{"Binary":{"left":{"Ident":"genre_id"},"op":"Gte","right":{"Literal":{"Integer":22}}}}]}}]}}},"span":"1:762-1021"}]}}
+frames:
+- - 1:813-906
+  - columns:
+    - !All
+      input_id: 127
+      except:
+      - genre_id
+    - !Single
+      name:
+      - num
+      target_id: 165
+      target_name: null
+    - !Single
+      name:
+      - total
+      target_id: 173
+      target_name: null
+    - !Single
+      name:
+      - last_val
+      target_id: 175
+      target_name: null
+    inputs:
+    - id: 127
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:909-916
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 129
+      target_name: null
+    - !All
+      input_id: 127
+      except:
+      - genre_id
+    - !Single
+      name:
+      - num
+      target_id: 165
+      target_name: null
+    - !Single
+      name:
+      - total
+      target_id: 173
+      target_name: null
+    - !Single
+      name:
+      - last_val
+      target_id: 175
+      target_name: null
+    inputs:
+    - id: 127
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:919-948
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 129
+      target_name: null
+    - !All
+      input_id: 127
+      except:
+      - genre_id
+    - !Single
+      name:
+      - num
+      target_id: 165
+      target_name: null
+    - !Single
+      name:
+      - total
+      target_id: 173
+      target_name: null
+    - !Single
+      name:
+      - last_val
+      target_id: 175
+      target_name: null
+    inputs:
+    - id: 127
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:949-998
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - track_id
+      target_id: 189
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 190
+      target_name: null
+    - !Single
+      name:
+      - num
+      target_id: 191
+      target_name: null
+    - !Single
+      name:
+      - total
+      target_id: 192
+      target_name: null
+    - !Single
+      name:
+      - last_val
+      target_id: 193
+      target_name: null
+    inputs:
+    - id: 127
+      name: tracks
+      table:
+      - default_db
+      - tracks
+- - 1:999-1020
+  - columns:
+    - !Single
+      name:
+      - tracks
+      - track_id
+      target_id: 189
+      target_name: null
+    - !Single
+      name:
+      - tracks
+      - genre_id
+      target_id: 190
+      target_name: null
+    - !Single
+      name:
+      - num
+      target_id: 191
+      target_name: null
+    - !Single
+      name:
+      - total
+      target_id: 192
+      target_name: null
+    - !Single
+      name:
+      - last_val
+      target_id: 193
+      target_name: null
+    inputs:
+    - id: 127
+      name: tracks
+      table:
+      - default_db
+      - tracks
+nodes:
+- id: 127
+  kind: Ident
+  span: 1:762-773
+  ident: !Ident
+  - default_db
+  - tracks
+  parent: 179
+- id: 129
+  kind: Ident
+  span: 1:780-788
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 127
+  parent: 138
+- id: 138
+  kind: Tuple
+  span: 1:780-788
+  children:
+  - 129
+- id: 157
+  kind: Ident
+  span: 1:798-810
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 127
+- id: 165
+  kind: RqOperator
+  span: 1:832-847
+  alias: num
+  targets:
+  - 166
+  parent: 178
+- id: 166
+  kind: Literal
+- id: 173
+  kind: RqOperator
+  span: 1:861-871
+  alias: total
+  targets:
+  - 174
+  parent: 178
+- id: 174
+  kind: Literal
+- id: 175
+  kind: RqOperator
+  span: 1:888-901
+  alias: last_val
+  targets:
+  - 177
+  parent: 178
+- id: 177
+  kind: Ident
+  span: 1:893-901
+  ident: !Ident
+  - this
+  - tracks
+  - track_id
+  targets:
+  - 127
+- id: 178
+  kind: Tuple
+  span: 1:820-906
+  children:
+  - 165
+  - 173
+  - 175
+  parent: 179
+- id: 179
+  kind: 'TransformCall: Derive'
+  span: 1:813-906
+  children:
+  - 127
+  - 178
+  parent: 181
+- id: 181
+  kind: 'TransformCall: Take'
+  span: 1:909-916
+  children:
+  - 179
+  - 182
+  parent: 188
+- id: 182
+  kind: Literal
+  parent: 181
+- id: 185
+  kind: Ident
+  span: 1:925-933
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 129
+  parent: 188
+- id: 186
+  kind: Ident
+  span: 1:935-947
+  ident: !Ident
+  - this
+  - tracks
+  - milliseconds
+  targets:
+  - 127
+  parent: 188
+- id: 188
+  kind: 'TransformCall: Sort'
+  span: 1:919-948
+  children:
+  - 181
+  - 185
+  - 186
+  parent: 195
+- id: 189
+  kind: Ident
+  span: 1:957-965
+  ident: !Ident
+  - this
+  - tracks
+  - track_id
+  targets:
+  - 127
+  parent: 194
+- id: 190
+  kind: Ident
+  span: 1:967-975
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 129
+  parent: 194
+- id: 191
+  kind: Ident
+  span: 1:977-980
+  ident: !Ident
+  - this
+  - num
+  targets:
+  - 165
+  parent: 194
+- id: 192
+  kind: Ident
+  span: 1:982-987
+  ident: !Ident
+  - this
+  - total
+  targets:
+  - 173
+  parent: 194
+- id: 193
+  kind: Ident
+  span: 1:989-997
+  ident: !Ident
+  - this
+  - last_val
+  targets:
+  - 175
+  parent: 194
+- id: 194
+  kind: Tuple
+  span: 1:956-998
+  children:
+  - 189
+  - 190
+  - 191
+  - 192
+  - 193
+  parent: 195
+- id: 195
+  kind: 'TransformCall: Select'
+  span: 1:949-998
+  children:
+  - 188
+  - 194
+  parent: 200
+- id: 196
+  kind: RqOperator
+  span: 1:1006-1020
+  targets:
+  - 198
+  - 199
+  parent: 200
+- id: 198
+  kind: Ident
+  span: 1:1006-1014
+  ident: !Ident
+  - this
+  - tracks
+  - genre_id
+  targets:
+  - 190
+- id: 199
+  kind: Literal
+  span: 1:1018-1020
+- id: 200
+  kind: 'TransformCall: Filter'
+  span: 1:999-1020
+  children:
+  - 195
+  - 196
+ast:
+  name: Project
+  stmts:
+  - VarDef:
+      kind: Main
+      name: main
+      value:
+        Pipeline:
+          exprs:
+          - FuncCall:
+              name:
+                Ident: from
+              args:
+              - Ident: tracks
+          - FuncCall:
+              name:
+                Ident: group
+              args:
+              - Ident: genre_id
+              - Pipeline:
+                  exprs:
+                  - FuncCall:
+                      name:
+                        Ident: sort
+                      args:
+                      - Ident: milliseconds
+                  - FuncCall:
+                      name:
+                        Ident: derive
+                      args:
+                      - Tuple:
+                        - FuncCall:
+                            name:
+                              Ident: row_number
+                            args:
+                            - Ident: this
+                          alias: num
+                        - FuncCall:
+                            name:
+                              Ident: count
+                            args:
+                            - Ident: this
+                          alias: total
+                        - FuncCall:
+                            name:
+                              Ident: last
+                            args:
+                            - Ident: track_id
+                          alias: last_val
+                  - FuncCall:
+                      name:
+                        Ident: take
+                      args:
+                      - Literal:
+                          Integer: 10
+          - FuncCall:
+              name:
+                Ident: sort
+              args:
+              - Tuple:
+                - Ident: genre_id
+                - Ident: milliseconds
+          - FuncCall:
+              name:
+                Ident: select
+              args:
+              - Tuple:
+                - Ident: track_id
+                - Ident: genre_id
+                - Ident: num
+                - Ident: total
+                - Ident: last_val
+          - FuncCall:
+              name:
+                Ident: filter
+              args:
+              - Binary:
+                  left:
+                    Ident: genre_id
+                  op: Gte
+                  right:
+                    Literal:
+                      Integer: 22
+    span: 1:762-1021


### PR DESCRIPTION
This improves the lineage tests (makes the snapshots more legible and has more comprehensive Python binding tests).

As part of this, a small bug for span assignments was discovered and fixed regarding assigning spans for nested pipelines. 

This has the curious side effect of changing the "bad error message" for #3870 to be more specifically located to the `aggregate` portion of the failing query. I hope that this might help track down the underlying bug.