### PR TITLE
ci: Run workflows on PRs to `web`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
     # label, which we then use to trigger a `nightly` run.
     types: [opened, reopened, synchronize, labeled]
     branches:
-      - main
+      - "*"
   push:
     branches:
       - main


### PR DESCRIPTION
Workflow wasn't running on https://github.com/PRQL/prql/pull/4591

@aljazerzen I see you changed this — is using `*` OK or would you prefer we explicitly name `web`? I can also imagine someone stacking a PR on another and wanting workflows to run?