### PR TITLE
fix: generate `FALSE` instead of `expr in ()` conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Fixes**:
 
+ - using `in` with an empty array pattern (e.g. `expr | in []`) will now output a constant `false` condition instead of an `expr IN ()`, which is syntactically invalid in some SQL dialects (@Globidev, #4598)
+
 **Documentation**:
 
 **Web**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 **Fixes**:
 
- - using `in` with an empty array pattern (e.g. `expr | in []`) will now output a constant `false` condition instead of an `expr IN ()`, which is syntactically invalid in some SQL dialects (@Globidev, #4598)
+- using `in` with an empty array pattern (e.g. `expr | in []`) will now output a
+  constant `false` condition instead of an `expr IN ()`, which is syntactically
+  invalid in some SQL dialects (@Globidev, #4598)
 
 **Documentation**:
 

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -1226,6 +1226,21 @@ fn test_not_in_values() {
 }
 
 #[test]
+fn test_in_no_values() {
+    assert_snapshot!((compile(r#"
+    from employees
+    filter (title | in [])
+    "#).unwrap()), @r#"
+    SELECT
+      *
+    FROM
+      employees
+    WHERE
+      false
+    "#);
+}
+
+#[test]
 fn test_in_values_err_01() {
     assert_snapshot!((compile(r###"
     from employees


### PR DESCRIPTION
This is an attempt at fixing #4595

Disclaimer: Pretty fluent in Rust but I just discovered the codebase, so I probably missed a bunch of things. 
I guess we'll want to add tests, and I'll likely need some directions as to where exactly to put them :)
