### PR TITLE
tweak: Fix grammar in `--help`

### DIFF
--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -271,7 +271,7 @@ impl LogLevel for LoggingHelp {
 
     fn verbose_long_help() -> Option<&'static str> {
         Some(
-            r#"More v's, More vebose logging:
+            r#"More `v`s, More vebose logging:
 -v shows warnings
 -vv shows info
 -vvv shows debug

--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -40,7 +40,7 @@ fn help() {
               [possible values: auto, always, never]
 
       -v, --verbose...
-              More v's, More vebose logging:
+              More `v`s, More vebose logging:
               -v shows warnings
               -vv shows info
               -vvv shows debug
@@ -142,7 +142,7 @@ fn compile_help() {
               [possible values: auto, always, never]
 
       -v, --verbose...
-              More v's, More vebose logging:
+              More `v`s, More vebose logging:
               -v shows warnings
               -vv shows info
               -vvv shows debug


### PR DESCRIPTION
Probably the most nitty PR in PRQL history; plurals shouldn't have apostrophes...
