### PR TITLE
ci: Allow `build-web` to run outside of upstream

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -14,11 +14,6 @@ jobs:
   build-web:
     runs-on: ubuntu-latest
 
-    # Skip running workflow on forks. Checking the repository owner still allows
-    # this to be run on PRs, and then below we disable it from attempting to
-    # publish.
-    if: github.repository_owner == 'prql'
-
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4
@@ -70,8 +65,6 @@ jobs:
 
   build-codemirror-demo:
     runs-on: ubuntu-latest
-
-    if: github.repository_owner == 'prql'
 
     steps:
       - name: 📂 Checkout code

--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -24,8 +24,10 @@ jobs:
     needs: build-web
     runs-on: ubuntu-latest
 
-    # Don't attempt to publish if on a fork, including a PR.
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    # Don't attempt to publish if on a fork or on a PR running on upstream.
+    if:
+      ${{ github.repository_owner == 'prql' &&
+      !github.event.pull_request.head.repo.fork }}
 
     permissions:
       pages: write


### PR DESCRIPTION
We now have nightly passing again, and they're running fine on forks. This PR loosens a rule we likely added when build & publish were a single workflow, removing some unused conditions
