### PR TITLE
refactor: Move `into_` methods onto their originating classes

### DIFF
--- a/prqlc/prqlc-parser/src/parser/common.rs
+++ b/prqlc/prqlc-parser/src/parser/common.rs
@@ -2,7 +2,7 @@ use chumsky::prelude::*;
 
 use crate::error::parse_error::PError;
 use crate::lexer::lr::TokenKind;
-use crate::parser::pr::{Annotation, Expr, ExprKind, Stmt, StmtKind, Ty, TyKind};
+use crate::parser::pr::{Annotation, Stmt, StmtKind};
 use crate::span::Span;
 
 pub fn ident_part() -> impl Parser<TokenKind, String, Error = PError> + Clone {
@@ -36,19 +36,5 @@ pub fn into_stmt((annotations, kind): (Vec<Annotation>, StmtKind), span: Span) -
         kind,
         span: Some(span),
         annotations,
-    }
-}
-
-pub fn into_expr(kind: ExprKind, span: Span) -> Expr {
-    Expr {
-        span: Some(span),
-        ..Expr::new(kind)
-    }
-}
-
-pub fn into_ty(kind: TyKind, span: Span) -> Ty {
-    Ty {
-        span: Some(span),
-        ..Ty::new(kind)
     }
 }

--- a/prqlc/prqlc-parser/src/parser/expr.rs
+++ b/prqlc/prqlc-parser/src/parser/expr.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use super::interpolation;
 use crate::error::parse_error::PError;
 use crate::lexer::lr::{Literal, TokenKind};
-use crate::parser::common::{ctrl, ident_part, into_expr, keyword, new_line};
+use crate::parser::common::{ctrl, ident_part, keyword, new_line};
 use crate::parser::pr::Ident;
 use crate::parser::pr::*;
 use crate::parser::pr::{BinOp, UnOp};
@@ -135,7 +135,7 @@ pub fn expr() -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
             case,
             param,
         ))
-        .map_with_span(into_expr)
+        .map_with_span(ExprKind::into_expr)
         .or(pipeline)
         .boxed();
 
@@ -155,7 +155,7 @@ pub fn expr() -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
             )
             .foldl(|base, (field, span)| {
                 let base = Box::new(base);
-                into_expr(ExprKind::Indirection { base, field }, span)
+                ExprKind::Indirection { base, field }.into_expr(span)
             })
             .boxed();
 
@@ -165,7 +165,7 @@ pub fn expr() -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
             .or(operator_unary()
                 .then(term.map(Box::new))
                 .map(|(op, expr)| ExprKind::Unary(UnaryExpr { op, expr }))
-                .map_with_span(into_expr))
+                .map_with_span(ExprKind::into_expr))
             .boxed();
 
         // Ranges have five cases we need to parse:
@@ -213,7 +213,7 @@ pub fn expr() -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
                     start: start.map(Box::new),
                     end: end.map(Box::new),
                 });
-                into_expr(kind, span)
+                kind.into_expr(span)
             }
         })
         .boxed();
@@ -256,12 +256,10 @@ where
                     // in a pipeline — just return the lone expr. Otherwise,
                     // wrap them in a pipeline.
                     exprs.into_iter().exactly_one().unwrap_or_else(|exprs| {
-                        into_expr(
-                            ExprKind::Pipeline(Pipeline {
-                                exprs: exprs.collect(),
-                            }),
-                            span,
-                        )
+                        ExprKind::Pipeline(Pipeline {
+                            exprs: exprs.collect(),
+                        })
+                        .into_expr(span)
                     })
                 }),
         )
@@ -292,7 +290,7 @@ where
                 op,
                 right: Box::new(right.0),
             });
-            (into_expr(kind, span), span)
+            (ExprKind::into_expr(kind, span), span)
         })
         .map(|(e, _)| e)
         .boxed()
@@ -346,7 +344,7 @@ where
                 named_args,
             })
         })
-        .map_with_span(into_expr)
+        .map_with_span(ExprKind::into_expr)
         .labelled("function call")
 }
 
@@ -405,7 +403,7 @@ where
         })
     })
     .map(ExprKind::Func)
-    .map_with_span(into_expr)
+    .map_with_span(ExprKind::into_expr)
     .labelled("function definition")
 }
 

--- a/prqlc/prqlc-parser/src/parser/interpolation.rs
+++ b/prqlc/prqlc-parser/src/parser/interpolation.rs
@@ -1,7 +1,6 @@
 use chumsky::prelude::*;
 use itertools::Itertools;
 
-use super::common::into_expr;
 use crate::error::parse_error::{ChumError, PError};
 use crate::lexer::lr::{Literal, TokenKind};
 use crate::parser::pr::*;
@@ -37,11 +36,11 @@ fn interpolated_parser() -> impl Parser<char, Vec<InterpolateItem>, Error = Chum
             let mut parts = ident_parts.into_iter();
 
             let (first, first_span) = parts.next().unwrap();
-            let mut base = Box::new(into_expr(ExprKind::Ident(first), first_span));
+            let mut base = Box::new(ExprKind::Ident(first).into_expr(first_span));
 
             for (part, span) in parts {
                 let field = IndirectionKind::Name(part);
-                base = Box::new(into_expr(ExprKind::Indirection { base, field }, span));
+                base = Box::new(ExprKind::Indirection { base, field }.into_expr(span));
             }
             base
         })

--- a/prqlc/prqlc-parser/src/parser/pr/expr.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/expr.rs
@@ -68,6 +68,16 @@ pub enum ExprKind {
     Internal(String),
 }
 
+impl ExprKind {
+    pub fn into_expr(self, span: Span) -> Expr {
+        Expr {
+            span: Some(span),
+            kind: self,
+            alias: None,
+        }
+    }
+}
+
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Serialize, Deserialize)]
 pub enum IndirectionKind {
     Name(String),

--- a/prqlc/prqlc-parser/src/parser/pr/types.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/types.rs
@@ -50,6 +50,16 @@ pub enum TyKind {
     GenericArg((usize, String)),
 }
 
+impl TyKind {
+    pub fn into_ty(self: TyKind, span: Span) -> Ty {
+        Ty {
+            kind: self,
+            span: Some(span),
+            name: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, EnumAsInner)]
 pub enum TyTupleField {
     /// Named tuple element.

--- a/prqlc/prqlc-parser/src/parser/types.rs
+++ b/prqlc/prqlc-parser/src/parser/types.rs
@@ -126,7 +126,7 @@ pub fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> + Clone {
             .labelled("array");
 
         let term = choice((basic, ident, func, tuple, array, enum_))
-            .map_with_span(into_ty)
+            .map_with_span(TyKind::into_ty)
             .boxed();
 
         // exclude
@@ -158,7 +158,7 @@ pub fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> + Clone {
                     let mut all = Vec::with_capacity(following.len() + 1);
                     all.push((None, first));
                     all.extend(following.into_iter().map(|x| (None, x)));
-                    into_ty(TyKind::Union(all), span)
+                    TyKind::Union(all).into_ty(span)
                 }
             })
     })


### PR DESCRIPTION
As an exhaust from #4125; seems to be a small improvement in organization; but not a strong view if others disagree?
