### PR TITLE
perf: Redo benchmarks

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: clechasseur/rs-cargo@v2
         with:
           command: bench
-          args: --timings --all-targets
+          args: -p prqlc
 
   time-compilation:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   It had been deprecated for a few versions and will no longer be updated.
   (@max-sixty)
 
+- New benchmarks (@max-sixty, #4654)
+
 **New Contributors**:
 
 ## 0.12.2 — 2024-06-10
@@ -1203,8 +1205,8 @@ below in this release).
 
 **Documentation**:
 
-[This release, the changelog only contains a subset of
-documentation improvements]
+[This release, the changelog only contains a subset of documentation
+improvements]
 
 - Add docs on aliases in
   [Select](https://prql-lang.org/book/reference/stdlib/transforms/select.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1205,8 +1205,8 @@ below in this release).
 
 **Documentation**:
 
-[This release, the changelog only contains a subset of documentation
-improvements]
+[This release, the changelog only contains a subset of
+documentation improvements]
 
 - Add docs on aliases in
   [Select](https://prql-lang.org/book/reference/stdlib/transforms/select.html)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,6 @@ dependencies = [
  "anstream",
  "anyhow",
  "ariadne",
- "cfg-if",
  "chrono",
  "clap 4.4.18",
  "clap-verbosity-flag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,8 +1150,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -2878,34 +2876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "plotters"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,26 +3286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -35,8 +35,8 @@ serde_yaml = [
 ]
 # Technically tokio could be limited to external tests, but its types are in
 # signatures which would require lots of conditional compilation.
-test-dbs = ["anyhow", "duckdb", "glob", "rusqlite", "tokio"]
-test-dbs-external = ["anyhow", "duckdb", "glob", "mysql", "pg_bigdecimal", "postgres", "rusqlite", "tiberius", "tokio", "tokio-util"]
+test-dbs = ["anyhow", "duckdb", "rusqlite", "tokio"]
+test-dbs-external = ["mysql", "pg_bigdecimal", "postgres", "test-dbs", "tiberius", "tokio-util"]
 
 [dependencies]
 prqlc-parser = {path = "../prqlc-parser", version = "0.12.3"}
@@ -91,7 +91,6 @@ minijinja = {version = "2.0.2", features = ["unstable_machinery"], optional = tr
 # rather than dev-dependencies, because dev-dependencies can't be optional.
 
 duckdb = {version = "0.10.2", optional = true, features = ["bundled", "chrono"]}
-glob = {version = "0.3.1", optional = true}
 mysql = {version = "25", optional = true}
 pg_bigdecimal = {version = "0.1.0", optional = true}
 postgres = {version = "0.19.7", optional = true}
@@ -102,6 +101,7 @@ tokio-util = {version = "0.7", optional = true, features = ["compat"]}
 
 [dev-dependencies]
 cfg-if = "1.0"
+glob = {version = "0.3.1"}
 insta = {workspace = true}
 insta-cmd = {workspace = true}
 rstest = "0.21.0"
@@ -109,8 +109,17 @@ similar = {version = "2.5.0"}
 similar-asserts = "1.5.0"
 test_each_file = "0.3.2"
 
-[target.'cfg(not(target_family="wasm"))'.dev-dependencies]
-criterion = {version = "0.5.1"}
+# [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
+criterion = {version = "0.5.1", default-features = false}
+
+# We use `benches` for the benchmark harness so disable them here to simplify
+# using criterion
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+[[bin]]
+bench = false
+name = "prqlc"
 
 [[bench]]
 harness = false

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -100,7 +100,9 @@ tokio = {version = "1.37.0", optional = true, features = ["full"]}
 tokio-util = {version = "0.7", optional = true, features = ["compat"]}
 
 [dev-dependencies]
-cfg-if = "1.0"
+# default-features=false required to allow wasm compilation (which we don't use
+# for benchmarks but simplifies the code)
+criterion = {version = "0.5.1", default-features = false}
 glob = {version = "0.3.1"}
 insta = {workspace = true}
 insta-cmd = {workspace = true}
@@ -109,18 +111,14 @@ similar = {version = "2.5.0"}
 similar-asserts = "1.5.0"
 test_each_file = "0.3.2"
 
-# [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
-criterion = {version = "0.5.1", default-features = false}
-
-# We use `benches` for the benchmark harness so disable them here to simplify
-# using criterion
+# We use `benches/bench.rs` for the benchmark harness so disable searching for
+# benchmarks in bin & lib here to simplify using criterion
 # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
 bench = false
 [[bin]]
 bench = false
 name = "prqlc"
-
 [[bench]]
 harness = false
 name = "bench"


### PR DESCRIPTION
Haven't touched these in years and wanted to check that the parser changes don't have any perf impact.

Running something like `cargo bench --bench=bench -- prql_to_pl --quick` will quickly time how long it takes to parse each of our canonical queries.

One tradeoff is that _changing_ our canonical queries means that the benchmarks don't compare through time. So possibly we should have a couple we try and almost never change...
