### PR TITLE
ci: Use standard CI env vars throughout to enable caching

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -4,6 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# We need consistent env vars across all workflows for the cache to work
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR_FORCE: 1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,6 +9,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   cargo-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -16,6 +16,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   build-web:
     uses: ./.github/workflows/build-web.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   brew-dispatcher:
     name: Release on homebrew-prql
@@ -408,6 +415,4 @@ jobs:
     if: github.event_name == 'release'
     uses: ./.github/workflows/build-devcontainer.yaml
     with:
-      # TOOD: I think having this as a bool is OK, but check a recent release
-      # from 0.10.0 and confirm that it is indeed pushing the image.
       push: true

--- a/.github/workflows/test-dotnet.yaml
+++ b/.github/workflows/test-dotnet.yaml
@@ -4,6 +4,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-elixir.yaml
+++ b/.github/workflows/test-elixir.yaml
@@ -18,6 +18,11 @@ defaults:
 
 env:
   MIX_ENV: test
+  # We need consistent env vars across all workflows for the cache to work
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
   test:

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -12,6 +12,13 @@ on:
         type: string
         default: '["ubuntu-latest"]'
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -12,6 +12,7 @@ on:
         type: string
         default: '["ubuntu-latest"]'
 
+# We need consistent env vars across all workflows for the cache to work
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR_FORCE: 1

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -4,6 +4,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-prqlc-c.yaml
+++ b/.github/workflows/test-prqlc-c.yaml
@@ -4,6 +4,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   test-c:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -12,6 +12,13 @@ on:
         type: string
         default: '["ubuntu-latest"]'
 
+# We need consistent env vars across all workflows for the cache to work
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+  RUSTFLAGS: "-C debuginfo=0"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
+# We need consistent env vars across all workflows for the cache to work
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR_FORCE: 1


### PR DESCRIPTION
I realize a bunch of jobs on nightly aren't using the cache because they don't have thees set (ideally they would inherit, but seems not to be the case: https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations
