### PR TITLE
fix: Fix merge

### DIFF
--- a/prqlc/prqlc-parser/src/parser/expr.rs
+++ b/prqlc/prqlc-parser/src/parser/expr.rs
@@ -343,7 +343,7 @@ where
                 op,
                 right: Box::new(right.0),
             });
-            (into_expr(kind, span), span)
+            (kind.into_expr(span), span)
         })
         .map(|(e, _)| e)
         .boxed()


### PR DESCRIPTION
One of those extremely rare times when a merge succeeds lexically but fails semantically. We could force all branches to be up-to-date, but it's a relatively large tax
