### PR TITLE
devops: Coverage task refine

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -415,6 +415,8 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           prefix-key: ${{ env.version }}
+      # Ensure nothing remains from caching
+      - run: cargo llvm-cov clean --workspace
       - run:
           # We considered moving to using `codecov.json` with
           # `--codecov --output-path=codecov.json` since that has branch & region

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -338,9 +338,9 @@ tasks:
       Code's [Coverage
       Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters)
       extension.
-    env:
-      # Use a different target dir so we don't poison the cache
-      CARGO_TARGET_DIR: "./target-cov"
+      # We previously had a different target dir, but the default seems to use `target/llvm-cov` as its target already, so we can remove this assuming it works OK
+      # env:
+      # CARGO_TARGET_DIR: "./target-cov"
     cmds:
       - cargo llvm-cov --lcov --output-path lcov.info
         --features=default,test-dbs

--- a/lutra/Taskfile.yaml
+++ b/lutra/Taskfile.yaml
@@ -46,9 +46,6 @@ tasks:
 
   test:
     desc: The full test. Generates coverage report.
-    env:
-      # Use a different target dir so we don't poison the cache
-      CARGO_LLVM_COV_TARGET_DIR: ../target-cov
     cmds:
       - cmd: |
           cargo \

--- a/prqlc/Taskfile.yaml
+++ b/prqlc/Taskfile.yaml
@@ -51,9 +51,6 @@ tasks:
     desc: |
       A full test of prqlc (excluding --test-dbs-external).
       Generates coverage report.
-    env:
-      # Use a different target dir so we don't poison the cache
-      CARGO_LLVM_COV_TARGET_DIR: ../target-cov
     cmds:
       - cmd: |
           cargo \


### PR DESCRIPTION
- Clean before running in CI, possibly this was the cause of the issue of bad results from a couple months back
- Remove some extra env vars now that `cargo-llvm-cov` uses its own target dirs (left a note in case I was overly eager here)
