### PR TITLE
feat: improve debug log in parsing stage

### DIFF
--- a/prqlc/prqlc-parser/src/lexer/mod.rs
+++ b/prqlc/prqlc-parser/src/lexer/mod.rs
@@ -10,7 +10,7 @@ pub mod lr;
 #[cfg(test)]
 mod test;
 
-pub fn lex_string_recovery(source: &str, source_id: u16) -> (Option<Vec<Token>>, Vec<Error>) {
+pub fn lex_source_recovery(source: &str, source_id: u16) -> (Option<Vec<Token>>, Vec<Error>) {
     let (tokens, lex_errors) = ::chumsky::Parser::parse_recovery(&lexer(), source);
 
     let errors = lex_errors
@@ -18,6 +18,7 @@ pub fn lex_string_recovery(source: &str, source_id: u16) -> (Option<Vec<Token>>,
         .map(|e| convert_lexer_error(source, e, source_id))
         .collect();
 
+    log::debug!("lex errors: {:?}", errors);
     (tokens, errors)
 }
 

--- a/prqlc/prqlc-parser/src/lib.rs
+++ b/prqlc/prqlc-parser/src/lib.rs
@@ -1,7 +1,3 @@
-use crate::error::Error;
-use crate::lexer::lr::TokenKind;
-use crate::parser::pr::Stmt;
-
 pub mod error;
 pub mod generic;
 pub mod lexer;
@@ -9,37 +5,3 @@ pub mod parser;
 pub mod span;
 #[cfg(test)]
 mod test;
-
-/// Build PRQL AST from a PRQL query string.
-pub fn parse_source(source: &str, source_id: u16) -> Result<Vec<Stmt>, Vec<Error>> {
-    let (tokens, mut errors) = lexer::lex_string_recovery(source, source_id);
-    log::debug!("Lex errors: {:?}", errors);
-
-    // We don't want comments in the AST (but we do intend to use them as part of
-    // formatting)
-    let semantic_tokens: Option<_> = tokens.map(|tokens| {
-        tokens.into_iter().filter(|token| {
-            !matches!(
-                token.kind,
-                TokenKind::Comment(_) | TokenKind::LineWrap(_) | TokenKind::DocComment(_)
-            )
-        })
-    });
-
-    let ast = if let Some(semantic_tokens) = semantic_tokens {
-        let (ast, parse_errors) = parser::parse_lr_to_pr(source, source_id, semantic_tokens);
-
-        log::debug!("parse errors: {:?}", parse_errors);
-        errors.extend(parse_errors);
-
-        ast
-    } else {
-        None
-    };
-
-    if errors.is_empty() {
-        Ok(ast.unwrap_or_default())
-    } else {
-        Err(errors)
-    }
-}

--- a/prqlc/prqlc-parser/src/parser/mod.rs
+++ b/prqlc/prqlc-parser/src/parser/mod.rs
@@ -10,19 +10,28 @@ mod types;
 use chumsky::{prelude::*, Stream};
 
 use crate::error::Error;
-use crate::lexer::lr::{Token, TokenKind};
-use crate::parser::pr::Stmt;
+use crate::lexer::lr;
 use crate::span::Span;
 
 pub fn parse_lr_to_pr(
     source: &str,
     source_id: u16,
-    lr_iter: impl Iterator<Item = Token>,
-) -> (Option<Vec<Stmt>>, Vec<Error>) {
-    let stream = prepare_stream(lr_iter, source, source_id);
+    lr_iter: Vec<lr::Token>,
+) -> (Option<Vec<pr::Stmt>>, Vec<Error>) {
+    // We don't want comments in the AST (but we do intend to use them as part of
+    // formatting)
+    let semantic_tokens = lr_iter.into_iter().filter(|token| {
+        !matches!(
+            token.kind,
+            lr::TokenKind::Comment(_) | lr::TokenKind::LineWrap(_) | lr::TokenKind::DocComment(_)
+        )
+    });
+
+    let stream = prepare_stream(semantic_tokens, source, source_id);
     let (pr, parse_errors) = ::chumsky::Parser::parse_recovery(&stmt::source(), stream);
 
     let errors = parse_errors.into_iter().map(|e| e.into()).collect();
+    log::debug!("parse errors: {errors:?}");
 
     (pr, errors)
 }
@@ -30,10 +39,10 @@ pub fn parse_lr_to_pr(
 /// Convert the output of the lexer into the input of the parser. Requires
 /// supplying the original source code.
 fn prepare_stream(
-    tokens: impl Iterator<Item = Token>,
+    tokens: impl Iterator<Item = lr::Token>,
     source: &str,
     source_id: u16,
-) -> Stream<TokenKind, Span, impl Iterator<Item = (TokenKind, Span)> + Sized> {
+) -> Stream<lr::TokenKind, Span, impl Iterator<Item = (lr::TokenKind, Span)> + Sized> {
     let tokens = tokens
         .into_iter()
         .map(move |token| (token.kind, Span::new(source_id, token.span)));

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -665,7 +665,7 @@ sort full
                 signature_comment: false,
                 format: true,
                 target: "sql.any".to_string(),
-                debug_log: Some(PathBuf::from_str("./log_test.html").unwrap()),
+                debug_log: None,
             },
             &mut SourceTree::new(
                 [
@@ -693,9 +693,6 @@ sort full
         FROM
           x
         "###);
-
-        // don't check the contents, they are very prone to change
-        assert!(PathBuf::from_str("./log_test.html").unwrap().is_file());
     }
 
     #[test]

--- a/prqlc/prqlc/src/debug/log.rs
+++ b/prqlc/prqlc/src/debug/log.rs
@@ -111,7 +111,7 @@ pub struct Message {
 
 #[derive(Clone, Copy, Serialize, AsRefStr)]
 pub enum Stage {
-    Parsing(StageParsing),
+    Parsing,
     Semantic(StageSemantic),
     Sql(StageSql),
 }
@@ -119,17 +119,11 @@ pub enum Stage {
 impl Stage {
     pub(super) fn sub_stage(&self) -> Option<&'_ str> {
         match self {
-            Stage::Parsing(s) => Some(s.as_ref()),
+            Stage::Parsing => None,
             Stage::Semantic(s) => Some(s.as_ref()),
             Stage::Sql(s) => Some(s.as_ref()),
         }
     }
-}
-
-#[derive(Clone, Copy, Serialize, AsRefStr)]
-pub enum StageParsing {
-    Lexer,
-    Parser,
 }
 
 #[derive(Clone, Copy, Serialize, AsRefStr)]

--- a/prqlc/prqlc/src/parser.rs
+++ b/prqlc/prqlc/src/parser.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, path::Path};
 use itertools::Itertools;
 
 use crate::debug;
+use crate::lr;
 use crate::pr;
 use crate::{Error, Errors, Result, SourceTree, WithErrorInfo};
 
@@ -11,7 +12,7 @@ pub fn parse(file_tree: &SourceTree) -> Result<pr::ModuleDef, Errors> {
     // register a new stage of the compiler
     // (here should register lexer stage first, but that all happens in a single call to prqlc_parser)
     debug::log_entry(|| debug::DebugEntryKind::ReprPrql(file_tree.clone()));
-    debug::log_stage(debug::Stage::Parsing(debug::StageParsing::Parser));
+    debug::log_stage(debug::Stage::Parsing);
 
     let source_files = linearize_tree(file_tree)?;
 
@@ -56,6 +57,8 @@ pub(crate) fn parse_source(source: &str, source_id: u16) -> Result<Vec<pr::Stmt>
     let (tokens, mut errors) = prqlc_parser::lexer::lex_source_recovery(source, source_id);
 
     let ast = if let Some(tokens) = tokens {
+        debug::log_entry(|| debug::DebugEntryKind::ReprLr(lr::Tokens(tokens.clone())));
+
         let (ast, parse_errors) = prqlc_parser::parser::parse_lr_to_pr(source, source_id, tokens);
         errors.extend(parse_errors);
         ast

--- a/prqlc/prqlc/src/semantic/mod.rs
+++ b/prqlc/prqlc/src/semantic/mod.rs
@@ -44,10 +44,10 @@ pub fn resolve(mut module_tree: pr::ModuleDef, options: ResolverOptions) -> Resu
     load_std_lib(&mut module_tree);
 
     // expand AST into PL
+    debug::log_stage(debug::Stage::Semantic(debug::StageSemantic::AstExpand));
     let root_module_def = ast_expand::expand_module_def(module_tree)?;
     debug::log_entry(|| debug::DebugEntryKind::ReprPl(root_module_def.clone()));
 
-    debug::log_stage(debug::Stage::Semantic(debug::StageSemantic::Resolver));
     // init new root module
     let mut root_module = RootModule {
         module: Module::new_root(),
@@ -56,6 +56,7 @@ pub fn resolve(mut module_tree: pr::ModuleDef, options: ResolverOptions) -> Resu
     let mut resolver = Resolver::new(&mut root_module, options);
 
     // resolve the module def into the root module
+    debug::log_stage(debug::Stage::Semantic(debug::StageSemantic::Resolver));
     resolver.fold_statements(root_module_def.stmts)?;
     debug::log_entry(|| debug::DebugEntryKind::ReprDecl(root_module.clone()));
 
@@ -65,6 +66,7 @@ pub fn resolve(mut module_tree: pr::ModuleDef, options: ResolverOptions) -> Resu
 /// Preferred way of injecting std module.
 pub fn load_std_lib(module_tree: &mut pr::ModuleDef) {
     if !module_tree.stmts.iter().any(|s| is_mod_def_for(s, NS_STD)) {
+        log::debug!("loading std.prql");
         let _suppressed = debug::log_suppress();
 
         let std_source = include_str!("std.prql");

--- a/prqlc/prqlc/src/semantic/mod.rs
+++ b/prqlc/prqlc/src/semantic/mod.rs
@@ -12,7 +12,6 @@ pub use lowering::lower_to_ir;
 
 use self::resolver::Resolver;
 pub use self::resolver::ResolverOptions;
-use crate::debug;
 use crate::ir::constant::ConstExpr;
 use crate::ir::decl::{Module, RootModule};
 use crate::ir::pl::{self, Expr, ImportDef, ModuleDef, Stmt, StmtKind, TypeDef, VarDef};
@@ -20,6 +19,7 @@ use crate::ir::rq::RelationalQuery;
 use crate::parser::is_mod_def_for;
 use crate::pr;
 use crate::WithErrorInfo;
+use crate::{debug, parser};
 use crate::{Error, Reason, Result};
 
 /// Runs semantic analysis on the query and lowers PL to RQ.
@@ -68,7 +68,7 @@ pub fn load_std_lib(module_tree: &mut pr::ModuleDef) {
         let _suppressed = debug::log_suppress();
 
         let std_source = include_str!("std.prql");
-        match prqlc_parser::parse_source(std_source, 0) {
+        match parser::parse_source(std_source, 0) {
             Ok(stmts) => {
                 let stmt = pr::Stmt::new(pr::StmtKind::ModuleDef(pr::ModuleDef {
                     name: "std".to_string(),

--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -3,6 +3,7 @@
 use std::env::current_dir;
 use std::path::PathBuf;
 use std::process::Command;
+use std::str::FromStr;
 
 use insta_cmd::assert_cmd_snapshot;
 use insta_cmd::get_cargo_bin;
@@ -163,7 +164,7 @@ fn compile_help() {
 #[test]
 fn long_query() {
     assert_cmd_snapshot!(prqlc_command()
-        .args(["compile", "--hide-signature-comment"])
+        .args(["compile", "--hide-signature-comment", "-vvv", "--debug-log=log_test.html"])
         .pass_stdin(r#"
 let long_query = (
   from employees
@@ -254,6 +255,9 @@ from long_query
 
     ----- stderr -----
     "###);
+
+    // don't check the contents, they are very prone to change
+    assert!(PathBuf::from_str("./log_test.html").unwrap().is_file());
 }
 
 #[test]
@@ -262,6 +266,7 @@ fn compile_project() {
     cmd.args([
         "compile",
         "--hide-signature-comment",
+        "--debug-log=log_test.json",
         project_path().to_str().unwrap(),
         "-",
         "main",
@@ -310,6 +315,9 @@ fn compile_project() {
 
     ----- stderr -----
     "###);
+
+    // don't check the contents, they are very prone to change
+    assert!(PathBuf::from_str("./log_test.json").unwrap().is_file());
 
     assert_cmd_snapshot!(prqlc_command()
       .args([


### PR DESCRIPTION
Since prqlc_parser has a single top-level function `parse_source`, we were not able to emit lr tokens in the debug log, since that is prqlc only instrumentation.

So I've moved the `parse_source` function to `prqlc::parser`, and now we have this:

![image](https://github.com/PRQL/prql/assets/11072061/6d535d56-578c-46ec-abb7-baae08833470)
