### PR TITLE
build: Use `connector_arrow` re-export for arrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,6 @@ name = "lutra"
 version = "0.12.3"
 dependencies = [
  "anyhow",
- "arrow",
  "clap 4.4.18",
  "connector_arrow",
  "env_logger",

--- a/lutra/lutra/Cargo.toml
+++ b/lutra/lutra/Cargo.toml
@@ -24,7 +24,6 @@ test = false
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 anyhow = {workspace = true}
-arrow = {version = "51.0", features = ["prettyprint"], default-features = false}
 clap = {version = "4.4.18", features = ["derive"], optional = true}
 connector_arrow = {version = "0.4.2", features = ["src_sqlite"]}
 env_logger = "0.10.2"

--- a/lutra/lutra/src/cli.rs
+++ b/lutra/lutra/src/cli.rs
@@ -30,6 +30,7 @@ fn main() {
 #[cfg(not(target_family = "wasm"))]
 mod inner {
     use clap::{Parser, Subcommand};
+    use connector_arrow::arrow;
     use lutra::{CompileParams, DiscoverParams, ExecuteParams, PullSchemaParams};
 
     #[derive(Parser)]

--- a/lutra/lutra/src/execute.rs
+++ b/lutra/lutra/src/execute.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use connector_arrow::arrow;
 use prqlc::{ir::pl::Ident, Error};
 
 use super::ProjectCompiled;

--- a/lutra/lutra/src/pull_schema.rs
+++ b/lutra/lutra/src/pull_schema.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use arrow::datatypes::{DataType, SchemaRef};
 use connector_arrow::api::SchemaGet;
+use connector_arrow::arrow::datatypes::{DataType, SchemaRef};
 use itertools::Itertools;
 use prqlc::pr::{PrimitiveSet, Stmt, Ty, TyKind, TyTupleField, VarDef};
 use prqlc::{Error, WithErrorInfo};

--- a/lutra/lutra/tests/it/main.rs
+++ b/lutra/lutra/tests/it/main.rs
@@ -4,6 +4,7 @@ use std::{path::PathBuf, str::FromStr};
 
 use anyhow::Result;
 use arrow::record_batch::RecordBatch;
+use connector_arrow::arrow;
 use insta::{assert_debug_snapshot, assert_snapshot};
 use itertools::Itertools;
 use lutra::{DiscoverParams, ExecuteParams};


### PR DESCRIPTION
Re discussion at https://github.com/PRQL/prql/pull/4668 (arrow is already re-exported)
