### PR TITLE
test: Skip item size check on Linux

### DIFF
--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -492,7 +492,14 @@ fn debug() {
     ----- stderr -----
     "###);
 
-    #[cfg(not(windows))] // Windows weirdly has a different size for `SourceTree`
+    // Windows weirdly has a different size for `SourceTree`
+    #[cfg(not(windows))]
+    // This is normally fine on linux, but on one min-versions check it had
+    // different results, and didn't repro on Mac. It having different results
+    // makes it difficult to debug — try to limit to mac (where it's possible to
+    // debug) and then start ignoring the test / just check the command runs if
+    // it continues to be a problem.
+    #[cfg(not(target_os = "linux"))]
     assert_cmd_snapshot!(prqlc_command()
         .args(["debug", "ast"]), @r###"
     success: true


### PR DESCRIPTION
Notes inline (not an ideal solution, can just exclude if it fails again)
