### PR TITLE
test: Give book tests more time under nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,7 +18,8 @@ max-threads = 1
 
 [[profile.default.overrides]]
 filter = 'package(mdbook-prql)'
-slow-timeout = {period = "8s", terminate-after = 2}
+# These are testing dozens of queries, so we give them more time.
+slow-timeout = {period = "20s", terminate-after = 2}
 test-group = 'docs-mdbook'
 
 [test-groups.docs-mdbook]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,6 +17,11 @@ test-group = 'test-dbs'
 max-threads = 1
 
 [[profile.default.overrides]]
+# cli tests take a bit longer
+filter = 'test(cli)'
+slow-timeout = {period = "1s"}
+
+[[profile.default.overrides]]
 filter = 'package(mdbook-prql)'
 # These are testing dozens of queries, so we give them more time.
 slow-timeout = {period = "20s", terminate-after = 2}


### PR DESCRIPTION
One one of my older machines (which is still a 10-core M1 Max MacBook Pro...) the book tests time out under `nextest`. This gives them more time
