### PR TITLE
test: Adjust test to avoid writing to the repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,6 +2894,7 @@ dependencies = [
  "sqlparser",
  "strum 0.26.3",
  "strum_macros 0.26.4",
+ "tempfile",
  "test_each_file",
  "tiberius",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,7 +2044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -107,6 +107,7 @@ insta-cmd = {workspace = true}
 rstest = "0.21.0"
 similar = {version = "2.5.0"}
 similar-asserts = "1.5.0"
+tempfile = {version = "3.2.0"}
 test_each_file = "0.3.2"
 
 # We use `benches/bench.rs` for the benchmark harness so disable searching for

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -107,7 +107,7 @@ insta-cmd = {workspace = true}
 rstest = "0.21.0"
 similar = {version = "2.5.0"}
 similar-asserts = "1.5.0"
-tempfile = {version = "3.2.0"}
+tempfile = {version = "3.10.0"}
 test_each_file = "0.3.2"
 
 # We use `benches/bench.rs` for the benchmark harness so disable searching for

--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -356,7 +356,7 @@ fn compile_project() {
 
 #[test]
 fn format() {
-    // Test stdin formatting (unchanged)
+    // Test stdin formatting
     assert_cmd_snapshot!(prqlc_command().args(["fmt"]).pass_stdin("from tracks | take 20"), @r###"
     success: true
     exit_code: 0
@@ -366,6 +366,8 @@ fn format() {
 
     ----- stderr -----
     "###);
+
+    // Test formatting a path:
 
     // Create a temporary directory
     let temp_dir = TempDir::new().expect("Failed to create temp directory");

--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -1,12 +1,16 @@
 #![cfg(all(not(target_family = "wasm"), feature = "cli"))]
 
 use std::env::current_dir;
+use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
 
 use insta_cmd::assert_cmd_snapshot;
 use insta_cmd::get_cargo_bin;
+use tempfile::TempDir;
+use walkdir::WalkDir;
 
 #[cfg(not(windows))] // Windows has slightly different output (e.g. `prqlc.exe`), so we exclude.
 #[test]
@@ -352,7 +356,7 @@ fn compile_project() {
 
 #[test]
 fn format() {
-    // stdin
+    // Test stdin formatting (unchanged)
     assert_cmd_snapshot!(prqlc_command().args(["fmt"]).pass_stdin("from tracks | take 20"), @r###"
     success: true
     exit_code: 0
@@ -363,28 +367,51 @@ fn format() {
     ----- stderr -----
     "###);
 
-    // TODO: not good tests, since they don't actually test that the code was
-    // formatted (though we would see the files changed after running the tests
-    // if they weren't formatted). Ideally we would have a simulated
-    // environment, like a fixture.
+    // Create a temporary directory
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
 
-    // Single file
-    assert_cmd_snapshot!(prqlc_command().args(["fmt", project_path().join("artists.prql").to_str().unwrap()]), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
+    // Copy files from project_path() to temp_dir
+    copy_dir_contents(&project_path(), temp_dir.path()).expect("Failed to copy directory contents");
 
-    ----- stderr -----
-    "###);
+    // Run fmt command on the temp directory
+    let _result = prqlc_command()
+        .args(["fmt", temp_dir.path().to_str().unwrap()])
+        .status()
+        .unwrap();
 
-    // Project
-    assert_cmd_snapshot!(prqlc_command().args(["fmt", project_path().to_str().unwrap()]), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
+    // Check if files in temp_dir match the original files
+    compare_directories(&project_path(), temp_dir.path());
+}
 
-    ----- stderr -----
-    "###);
+fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {
+    for entry in WalkDir::new(src).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_file() {
+            let relative_path = path.strip_prefix(src).unwrap();
+            let dst_path = dst.join(relative_path);
+            if let Some(parent) = dst_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(path, dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn compare_directories(dir1: &Path, dir2: &Path) {
+    for entry in WalkDir::new(dir1).into_iter().filter_map(|e| e.ok()) {
+        let path1 = entry.path();
+        if path1.is_file() {
+            let relative_path = path1.strip_prefix(dir1).unwrap();
+            let path2 = dir2.join(relative_path);
+
+            assert!(path2.exists());
+            similar_asserts::assert_eq!(
+                fs::read_to_string(path1).unwrap(),
+                fs::read_to_string(path2).unwrap()
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
The existing code was inconvenient when running a program which watched files and ran tests when they changed, since it would run in an infinite loop.

This code fixes this to instead write to a temp file, at the cost of verbosity in the test
