### PR TITLE
ci: Speed up benchmarks in CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -52,7 +52,10 @@ jobs:
       - uses: clechasseur/rs-cargo@v2
         with:
           command: bench
-          args: -p prqlc
+          # GH Actions is fairly noisy, so the precise details don't matter that
+          # much. We do want to check the benchmarks run, and possibly we can
+          # use this to identify and big changes in performance.
+          args: -- --warm-up-time=0.3 --measurement-time=1
 
   time-compilation:
     runs-on: ubuntu-latest

--- a/lutra/bindings/python/Cargo.toml
+++ b/lutra/bindings/python/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 crate-type = ["cdylib"]
 doc = false
 test = false

--- a/lutra/lutra/Cargo.toml
+++ b/lutra/lutra/Cargo.toml
@@ -13,10 +13,12 @@ cli = ["clap"]
 default = ["cli"]
 
 [lib]
+bench = false
 doctest = false
 test = false
 
 [[bin]]
+bench = false
 name = "lutra"
 path = "src/cli.rs"
 required-features = ["cli"]

--- a/prqlc/bindings/elixir/native/prql/Cargo.toml
+++ b/prqlc/bindings/elixir/native/prql/Cargo.toml
@@ -11,14 +11,15 @@ rust-version.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 crate-type = ["cdylib"]
+doc = false
 doctest = false
 name = "prql"
 path = "src/lib.rs"
 test = false
-doc = false
 
 # See Readme for details on Mac
 [target.'cfg(not(any(target_family="wasm", target_os = "macos")))'.dependencies]
-prqlc = {path = "../../../../prqlc", default-features = false, version = "0.12.3" }
+prqlc = {path = "../../../../prqlc", default-features = false, version = "0.12.3"}
 rustler = "0.32.1"

--- a/prqlc/bindings/java/Cargo.toml
+++ b/prqlc/bindings/java/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 crate-type = ["cdylib"]
 doc = false
 doctest = false

--- a/prqlc/bindings/js/Cargo.toml
+++ b/prqlc/bindings/js/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 crate-type = ["cdylib", "rlib"]
 doc = false
 doctest = false

--- a/prqlc/bindings/prqlc-c/Cargo.toml
+++ b/prqlc/bindings/prqlc-c/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 # We produce both of these at the moment, but could consider refining this. ref
 # https://github.com/rust-lang/cargo/issues/8607 &
 # https://github.com/rust-lang/rust/issues/59302
+bench = false
 crate-type = ["staticlib", "cdylib"]
 doc = false
 doctest = false

--- a/prqlc/bindings/prqlc-python/Cargo.toml
+++ b/prqlc/bindings/prqlc-python/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 crate-type = ["cdylib"]
 doc = false
 doctest = false

--- a/prqlc/prqlc-macros/Cargo.toml
+++ b/prqlc/prqlc-macros/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 doctest = false
 proc-macro = true
 test = false

--- a/prqlc/prqlc-parser/Cargo.toml
+++ b/prqlc/prqlc-parser/Cargo.toml
@@ -9,15 +9,16 @@ rust-version.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 doctest = false
 
 [dependencies]
 enum-as-inner = {workspace = true}
 itertools = {workspace = true}
 log = {workspace = true}
+semver = {version = "1.0.23", features = ["serde"]}
 serde = {workspace = true}
 serde_yaml = {workspace = true, optional = true}
-semver = {version = "1.0.23", features = ["serde"]}
 strum = {version = "0.26.3", features = ["std", "derive"]}
 
 # Chumsky's default features have issues when running in wasm (though we only

--- a/prqlc/prqlc/examples/compile-files/Cargo.toml
+++ b/prqlc/prqlc/examples/compile-files/Cargo.toml
@@ -9,9 +9,11 @@ rust-version.workspace = true
 version.workspace = true
 
 [[bin]]
+bench = false
+doc = false
+doctest = false
 name = "compile-files"
 test = false
-doc = false
 
 [build-dependencies]
 prqlc = {path = '../../../prqlc', default-features = false}

--- a/web/book/Cargo.toml
+++ b/web/book/Cargo.toml
@@ -8,10 +8,12 @@ repository.workspace = true
 version.workspace = true
 
 [lib]
+bench = false
 doc = false
 doctest = false
 
 [[bin]]
+bench = false
 name = "mdbook-prql"
 test = false
 


### PR DESCRIPTION
Also make `cargo bench` output reasonable, by excluding `bench` from crates that don't have benchmarks
