### PR TITLE
internal: Try adding a label to a chumsky parser

### DIFF
--- a/prqlc/prqlc-parser/src/parser/common.rs
+++ b/prqlc/prqlc-parser/src/parser/common.rs
@@ -24,7 +24,7 @@ pub fn keyword(kw: &'static str) -> impl Parser<TokenKind, (), Error = PError> +
 }
 
 pub fn new_line() -> impl Parser<TokenKind, (), Error = PError> + Clone {
-    just(TokenKind::NewLine).ignored()
+    just(TokenKind::NewLine).ignored().labelled("new line")
 }
 
 pub fn ctrl(char: char) -> impl Parser<TokenKind, (), Error = PError> + Clone {

--- a/prqlc/prqlc-parser/src/test.rs
+++ b/prqlc/prqlc-parser/src/test.rs
@@ -76,7 +76,7 @@ fn test_error_unexpected() {
                 0:6-7,
             ),
             reason: Simple(
-                "unexpected : while parsing function call",
+                "unexpected :",
             ),
             hints: [],
             code: None,

--- a/prqlc/prqlc/tests/integration/error_messages.rs
+++ b/prqlc/prqlc/tests/integration/error_messages.rs
@@ -98,7 +98,7 @@ fn test_errors() {
        │
      1 │ Answer: T-H-A-T!
        │       ┬
-       │       ╰── unexpected : while parsing function call
+       │       ╰── unexpected :
     ───╯
     "###);
 }


### PR DESCRIPTION
Moving this from #4700. Do we know why adding a label removes the error message? Is it something to do with merging multiple labels loses the labels themselves https://github.com/PRQL/prql/blob/63571263f667964c71d11ed001f9fc04a306b83b/prqlc/prqlc-parser/src/error/parse_error.rs#L281-L292 ?

Is this the correct design? I would think we want the most specific item, not sure whether that's possible.

(Tagging @m-span as he was the most recent author of the code, but no worries if you're not sure / or if this was the result of a refactor. And having `new line` isn't important per se, I mean it as a more general question)