### PR TITLE
refactor: Move newline consumption out of pipeline

### DIFF
--- a/prqlc/prqlc-parser/src/parser/expr.rs
+++ b/prqlc/prqlc-parser/src/parser/expr.rs
@@ -123,7 +123,8 @@ fn array(
 fn pipeline_expr(
     expr: impl Parser<TokenKind, Expr, Error = PError> + Clone,
 ) -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
-    expr.delimited_by(ctrl('('), ctrl(')'))
+    expr.then_ignore(new_line().repeated())
+        .delimited_by(ctrl('('), ctrl(')'))
         .recover_with(nested_delimiters(
             TokenKind::Control('('),
             TokenKind::Control(')'),
@@ -268,7 +269,10 @@ where
     // expr has to be a param, because it can be either a normal expr() or a
     // recursive expr called from within expr(), which causes a stack overflow
 
-    let pipe = ctrl('|').or(new_line().repeated().at_least(1).ignored());
+    let pipe = choice((
+        ctrl('|').ignored(),
+        new_line().repeated().at_least(1).ignored(),
+    ));
 
     new_line()
         .repeated()
@@ -292,7 +296,6 @@ where
                     })
                 }),
         )
-        .then_ignore(new_line().repeated())
         .labelled("pipeline")
 }
 

--- a/prqlc/prqlc-parser/src/parser/stmt.rs
+++ b/prqlc/prqlc-parser/src/parser/stmt.rs
@@ -128,6 +128,7 @@ fn var_def() -> impl Parser<TokenKind, StmtKind, Error = PError> + Clone {
         .labelled("variable definition");
 
     let main_or_into = pipeline(expr_call())
+        .then_ignore(new_line().repeated())
         .map(Box::new)
         .then(keyword("into").ignore_then(ident_part()).or_not())
         .map(|(value, name)| {

--- a/prqlc/prqlc-parser/src/test.rs
+++ b/prqlc/prqlc-parser/src/test.rs
@@ -2350,6 +2350,47 @@ fn test_multiline_string() {
 }
 
 #[test]
+fn test_empty_lines() {
+    // The span of the Pipeline shouldn't include the empty lines; the VarDef
+    // should have a larger span
+    assert_yaml_snapshot!(parse_single(r#"
+from artists
+derive x = 5
+
+ 
+
+"#).unwrap(), @r###"
+    ---
+    - VarDef:
+        kind: Main
+        name: main
+        value:
+          Pipeline:
+            exprs:
+              - FuncCall:
+                  name:
+                    Ident: from
+                    span: "0:1-5"
+                  args:
+                    - Ident: artists
+                      span: "0:6-13"
+                span: "0:1-13"
+              - FuncCall:
+                  name:
+                    Ident: derive
+                    span: "0:14-20"
+                  args:
+                    - Literal:
+                        Integer: 5
+                      span: "0:25-26"
+                      alias: x
+                span: "0:14-26"
+          span: "0:1-26"
+      span: "0:1-31"
+    "### )
+}
+
+#[test]
 fn test_coalesce() {
     assert_yaml_snapshot!(parse_single(r###"
         from employees


### PR DESCRIPTION
Generally we should try and stop "eating" _following_ newlines, and instead "eat" preceeding newlines. This allows us to enforce, for example, that doc comments should follow a newline.