### PR TITLE
internal: Add a `Start` token at the beginning of LR output

### DIFF
--- a/prqlc/prqlc-parser/src/lexer/lr.rs
+++ b/prqlc/prqlc-parser/src/lexer/lr.rs
@@ -68,6 +68,10 @@ pub enum TokenKind {
     // - Change the functionality. But it's very nice to be able to comment
     //   something out and have line-wraps still work.
     LineWrap(Vec<TokenKind>),
+
+    /// A token we manually insert at the start of the input, which later stages
+    /// can treat as a newline.
+    Start,
 }
 
 #[derive(
@@ -229,6 +233,7 @@ impl std::fmt::Display for TokenKind {
                 }
                 Ok(())
             }
+            TokenKind::Start => write!(f, "start of input"),
         }
     }
 }

--- a/prqlc/prqlc-parser/src/lexer/mod.rs
+++ b/prqlc/prqlc-parser/src/lexer/mod.rs
@@ -11,7 +11,7 @@ pub mod lr;
 mod test;
 
 // TODO: we have `lex_source` and `lex_source_recovery` and don't have the same
-// structure for LR. Probably we should have a single approach to the inclusion
+// structure for PR. Probably we should have a single approach to the inclusion
 // and naming of a function which returns both the tokens & errors, and a
 // function that returns both.
 

--- a/prqlc/prqlc-parser/src/lexer/mod.rs
+++ b/prqlc/prqlc-parser/src/lexer/mod.rs
@@ -44,13 +44,13 @@ pub fn lex_source(source: &str) -> Result<lr::Tokens, Vec<Error>> {
 }
 
 /// Insert a start token so later stages can treat the start of a file like a newline
-fn insert_start(mut tokens: Vec<Token>) -> Vec<Token> {
-    let start = Token {
+fn insert_start(tokens: Vec<Token>) -> Vec<Token> {
+    std::iter::once(Token {
         kind: TokenKind::Start,
-        span: std::ops::Range { start: 0, end: 0 },
-    };
-    tokens.insert(0, start);
-    tokens
+        span: 0..0,
+    })
+    .chain(tokens)
+    .collect()
 }
 
 fn convert_lexer_error(source: &str, e: chumsky::error::Cheap<char>, source_id: u16) -> Error {

--- a/prqlc/prqlc-parser/src/lexer/test.rs
+++ b/prqlc/prqlc-parser/src/lexer/test.rs
@@ -197,6 +197,7 @@ fn test_lex_source() {
     Ok(
         Tokens(
             [
+                0..0: Start,
                 0..1: Literal(Integer(5)),
                 2..3: Control('+'),
                 4..5: Literal(Integer(3)),

--- a/prqlc/prqlc-parser/src/parser/mod.rs
+++ b/prqlc/prqlc-parser/src/parser/mod.rs
@@ -42,7 +42,10 @@ pub(crate) fn prepare_stream(
     let semantic_tokens = tokens.filter(|token| {
         !matches!(
             token.kind,
-            lr::TokenKind::Comment(_) | lr::TokenKind::LineWrap(_) | lr::TokenKind::DocComment(_)
+            lr::TokenKind::Comment(_)
+                | lr::TokenKind::LineWrap(_)
+                | lr::TokenKind::DocComment(_)
+                | lr::TokenKind::Start
         )
     });
 

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -775,6 +775,10 @@ sort full
         // TODO: terser output; maybe serialize span as `0..4`? Remove the
         // `!Ident` complication?
         assert_snapshot!(String::from_utf8(output).unwrap().trim(), @r###"
+        - kind: Start
+          span:
+            start: 0
+            end: 0
         - kind: !Ident from
           span:
             start: 0
@@ -814,6 +818,10 @@ sort full
         .unwrap();
 
         assert_snapshot!(String::from_utf8(output).unwrap().trim(), @r###"
+        - kind: Start
+          span:
+            start: 0
+            end: 0
         - kind: NewLine
           span:
             start: 0

--- a/prqlc/prqlc/tests/integration/cli.rs
+++ b/prqlc/prqlc/tests/integration/cli.rs
@@ -615,6 +615,10 @@ fn lex() {
     success: true
     exit_code: 0
     ----- stdout -----
+    - kind: Start
+      span:
+        start: 0
+        end: 0
     - kind: !Ident from
       span:
         start: 0
@@ -632,6 +636,13 @@ fn lex() {
     exit_code: 0
     ----- stdout -----
     [
+      {
+        "kind": "Start",
+        "span": {
+          "start": 0,
+          "end": 0
+        }
+      },
       {
         "kind": {
           "Ident": "from"

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__aggregation.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__aggregation.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/aggregation.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:skip"),
         12..13: NewLine,
         13..25: Comment(" mysql:skip"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__arithmetic.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__arithmetic.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/arithmetic.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__cast.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__cast.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/cast.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__constants_only.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__constants_only.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/constants_only.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..4: Ident("from"),
         5..11: Ident("genres"),
         11..12: NewLine,

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__date_to_text.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__date_to_text.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/date_to_text.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..14: Comment(" generic:skip"),
         14..15: NewLine,
         15..29: Comment(" glaredb:skip"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/distinct.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct_on.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__distinct_on.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/distinct_on.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__genre_counts.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__genre_counts.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/genre_counts.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..103: Comment(" clickhouse:skip (ClickHouse prefers aliases to column names https://github.com/PRQL/prql/issues/2827)"),
         103..104: NewLine,
         104..116: Comment(" mssql:test"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_all.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_all.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/group_all.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/group_sort.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort_limit_take.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__group_sort_limit_take.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/group_sort_limit_take.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..62: Comment(" Compute the 3 longest songs for each genre and sort by genre"),
         62..63: NewLine,
         63..75: Comment(" mssql:test"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__invoice_totals.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__invoice_totals.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/invoice_totals.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..56: Comment(" clickhouse:skip (clickhouse doesn't have lag function)"),
         56..57: NewLine,
         57..58: NewLine,

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__loop_01.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__loop_01.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/loop_01.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..47: Comment(" clickhouse:skip (DB::Exception: Syntax error)"),
         47..48: NewLine,
         48..161: Comment(" glaredb:skip (DataFusion does not support recursive CTEs https://github.com/apache/arrow-datafusion/issues/462)"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__math_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__math_module.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/math_module.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..81: Comment(" sqlite:skip (see https://github.com/rusqlite/rusqlite/issues/1211)"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__pipelines.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__pipelines.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/pipelines.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..76: Comment(" sqlite:skip (Only works on Sqlite implementations which have the extension"),
         76..77: NewLine,
         77..88: Comment(" installed"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__read_csv.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__read_csv.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/read_csv.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..13: Comment(" sqlite:skip"),
         13..14: NewLine,
         14..29: Comment(" postgres:skip"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__set_ops_remove.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/set_ops_remove.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..16: Keyword("let"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__sort.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__sort.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/sort.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__switch.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__switch.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/switch.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..75: Comment(" glaredb:skip (May be a bag of String type conversion for Postgres Client)"),
         75..76: NewLine,
         76..88: Comment(" mssql:test"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__take.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__take.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/take.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..17: Ident("from"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__text_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__text_module.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/text_module.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..12: Comment(" mssql:test"),
         12..13: NewLine,
         13..93: Comment(" glaredb:skip — TODO: started raising an error on 2024-05-20; see `window.prql`"),

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__window.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__lex__window.snap
@@ -5,6 +5,7 @@ input_file: prqlc/prqlc/tests/integration/queries/window.prql
 ---
 Tokens(
     [
+        0..0: Start,
         0..95: Comment(" mssql:skip Conversion(\"cannot interpret I64(Some(1)) as an i32 value\")', connection.rs:200:34"),
         95..96: NewLine,
         96..251: Comment(" duckdb:skip problems with DISTINCT ON (duckdb internal error: [with INPUT_TYPE = int; RESULT_TYPE = unsigned char]: Assertion `min_val <= input' failed.)"),


### PR DESCRIPTION
If we want to enforce anything starting on a new line (for example a doc comment) in the parser, then we also need to handle the start of a file — which is semantically a new line but doesn't have a literal new line token. So we add this token and then will allow it to act as a new line in the parser...