### PR TITLE
refactor: Use `sequence` in more places

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,6 +2941,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "similar",
+ "similar-asserts",
  "stacker",
  "strum 0.26.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,5 @@ semver = {version = "1.0.23", features = ["serde"]}
 serde = {version = "1.0.204", features = ["derive"]}
 serde_json = "1.0.120"
 serde_yaml = {version = "0.9.34"}
+similar = "2.5.0"
+similar-asserts = "1.5.0"

--- a/prqlc/prqlc-parser/Cargo.toml
+++ b/prqlc/prqlc-parser/Cargo.toml
@@ -35,3 +35,5 @@ chumsky = {version = "0.9.2", features = ["ahash", "std"], default-features = fa
 [dev-dependencies]
 insta = {workspace = true}
 serde_json = {workspace = true}
+similar = {workspace = true}
+similar-asserts = {workspace = true}

--- a/prqlc/prqlc-parser/src/parser/expr.rs
+++ b/prqlc/prqlc-parser/src/parser/expr.rs
@@ -122,7 +122,7 @@ fn array<'a>(
 fn pipeline_expr(
     expr: impl Parser<TokenKind, Expr, Error = PError> + Clone,
 ) -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
-    expr.then_ignore(new_line().repeated())
+    expr.padded_by(new_line().repeated())
         .delimited_by(ctrl('('), ctrl(')'))
         .recover_with(nested_delimiters(
             TokenKind::Control('('),
@@ -429,9 +429,9 @@ where
         .labelled("function call")
 }
 
-fn lambda_func<E>(expr: E) -> impl Parser<TokenKind, Expr, Error = PError> + Clone
+fn lambda_func<'a, E>(expr: E) -> impl Parser<TokenKind, Expr, Error = PError> + Clone + 'a
 where
-    E: Parser<TokenKind, Expr, Error = PError> + Clone,
+    E: Parser<TokenKind, Expr, Error = PError> + Clone + 'a,
 {
     let param = ident_part()
         .then(type_expr().delimited_by(ctrl('<'), ctrl('>')).or_not())
@@ -539,7 +539,8 @@ mod tests {
 
     use insta::assert_yaml_snapshot;
 
-    use crate::test::{parse_with_parser, trim_start};
+    use super::super::test::trim_start;
+    use crate::test::parse_with_parser;
 
     use super::*;
 

--- a/prqlc/prqlc-parser/src/parser/mod.rs
+++ b/prqlc/prqlc-parser/src/parser/mod.rs
@@ -110,7 +110,7 @@ fn doc_comment() -> impl Parser<TokenKind, String, Error = PError> + Clone {
     // can also be a file start) before the doc comment
     //
     // TODO: we currently lose any empty newlines between doc comments;
-    // eventually we want to retain them
+    // eventually we want to retain or restrict them
     (new_line().repeated().at_least(1).ignore_then(select! {
         TokenKind::DocComment(dc) => dc,
     }))
@@ -135,7 +135,8 @@ where
 /// Allows us to surround a parser by `with_doc_comment` and for a doc comment
 /// to be added to the result, as long as the result implements `SupportsDocComment`.
 ///
-/// We could manage without it tbh,
+/// (In retrospect, we could manage without it, though probably not worth the
+/// effort to remove it. We could also use it to also support Span items.)
 trait SupportsDocComment {
     fn with_doc_comment(self, doc_comment: Option<String>) -> Self;
 }

--- a/prqlc/prqlc-parser/src/parser/test.rs
+++ b/prqlc/prqlc-parser/src/parser/test.rs
@@ -1,8 +1,8 @@
 use chumsky::Parser;
 use insta::assert_yaml_snapshot;
 
-use super::prepare_stream;
 use super::{new_line, pr::Expr};
+use super::{perror::PError, prepare_stream};
 use crate::span::Span;
 use crate::test::parse_with_parser;
 use crate::{error::Error, lexer::lex_source};
@@ -13,6 +13,11 @@ fn parse_expr(source: &str) -> Result<Expr, Vec<Error>> {
         source,
         new_line().repeated().ignore_then(super::expr::expr_call()),
     )
+}
+
+/// Remove leading newlines & the start token, for tests
+pub(crate) fn trim_start() -> impl Parser<TokenKind, (), Error = PError> {
+    new_line().repeated().ignored()
 }
 
 #[test]

--- a/prqlc/prqlc-parser/src/parser/types.rs
+++ b/prqlc/prqlc-parser/src/parser/types.rs
@@ -39,7 +39,7 @@ pub(crate) fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> + Clone 
             )
             .map(TyKind::Function);
 
-        let tuple = choice((
+        let tuple = sequence(choice((
             select! { TokenKind::Range { bind_right: true, bind_left: _ } => () }
                 .ignore_then(nested_type_expr.clone())
                 .map(|ty| TyTupleField::Wildcard(Some(ty))),
@@ -48,10 +48,7 @@ pub(crate) fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> + Clone 
                 .or_not()
                 .then(nested_type_expr.clone())
                 .map(|(name, ty)| TyTupleField::Single(name, Some(ty))),
-        ))
-        .padded_by(new_line().repeated())
-        .separated_by(ctrl(','))
-        .allow_trailing()
+        )))
         .delimited_by(ctrl('{'), ctrl('}'))
         .recover_with(nested_delimiters(
             TokenKind::Control('{'),
@@ -81,29 +78,28 @@ pub(crate) fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> + Clone 
 
         let enum_ = keyword("enum")
             .ignore_then(
-                ident_part()
-                    .then(ctrl('=').ignore_then(nested_type_expr.clone()).or_not())
-                    .map(|(name, ty)| {
-                        (
-                            Some(name),
-                            ty.unwrap_or_else(|| Ty::new(TyKind::Tuple(vec![]))),
-                        )
-                    })
-                    .padded_by(new_line().repeated())
-                    .separated_by(ctrl(','))
-                    .allow_trailing()
-                    .then_ignore(new_line().repeated())
-                    .delimited_by(ctrl('{'), ctrl('}'))
-                    .recover_with(nested_delimiters(
-                        TokenKind::Control('{'),
-                        TokenKind::Control('}'),
-                        [
-                            (TokenKind::Control('{'), TokenKind::Control('}')),
-                            (TokenKind::Control('('), TokenKind::Control(')')),
-                            (TokenKind::Control('['), TokenKind::Control(']')),
-                        ],
-                        |_| vec![],
-                    )),
+                sequence(
+                    ident_part()
+                        .then(ctrl('=').ignore_then(nested_type_expr.clone()).or_not())
+                        .map(|(name, ty)| {
+                            (
+                                Some(name),
+                                ty.unwrap_or_else(|| Ty::new(TyKind::Tuple(vec![]))),
+                            )
+                        }),
+                )
+                .padded_by(new_line().repeated())
+                .delimited_by(ctrl('{'), ctrl('}'))
+                .recover_with(nested_delimiters(
+                    TokenKind::Control('{'),
+                    TokenKind::Control('}'),
+                    [
+                        (TokenKind::Control('{'), TokenKind::Control('}')),
+                        (TokenKind::Control('('), TokenKind::Control(')')),
+                        (TokenKind::Control('['), TokenKind::Control(']')),
+                    ],
+                    |_| vec![],
+                )),
             )
             .map(TyKind::Union)
             .labelled("union");

--- a/prqlc/prqlc-parser/src/test.rs
+++ b/prqlc/prqlc-parser/src/test.rs
@@ -2,7 +2,6 @@ use chumsky::Parser;
 use insta::{assert_debug_snapshot, assert_yaml_snapshot};
 use std::fmt::Debug;
 
-use crate::parser::new_line;
 use crate::parser::pr::Stmt;
 use crate::parser::prepare_stream;
 use crate::parser::stmt;
@@ -29,14 +28,7 @@ pub(crate) fn parse_with_parser<O: Debug>(
 
 /// Parse into statements
 pub(crate) fn parse_single(source: &str) -> Result<Vec<Stmt>, Vec<Error>> {
-    // parse_with_parser(source, new_line().repeated().ignore_then(stmt::source()))
     parse_with_parser(source, stmt::source())
-}
-
-// TODO: move to expr singe stmts don't need it?
-/// Remove leading newlines & the start token, for tests
-pub(crate) fn trim_start() -> impl Parser<TokenKind, (), Error = PError> {
-    new_line().repeated().ignored()
 }
 
 #[test]
@@ -1763,45 +1755,6 @@ fn test_target() {
                 span: "0:65-77"
           span: "0:45-77"
       span: "0:34-77"
-    "###);
-}
-
-#[test]
-fn test_module() {
-    assert_yaml_snapshot!(parse_single(
-            r#"
-          module hello {
-            let world = 1
-            let man = module.world
-          }
-        "#,
-        )
-        .unwrap(), @r###"
-    ---
-    - ModuleDef:
-        name: hello
-        stmts:
-          - VarDef:
-              kind: Let
-              name: world
-              value:
-                Literal:
-                  Integer: 1
-                span: "0:50-51"
-            span: "0:25-51"
-          - VarDef:
-              kind: Let
-              name: man
-              value:
-                Indirection:
-                  base:
-                    Ident: module
-                    span: "0:74-80"
-                  field:
-                    Name: world
-                span: "0:74-86"
-            span: "0:51-86"
-      span: "0:0-98"
     "###);
 }
 

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -106,8 +106,8 @@ glob = {version = "0.3.1"}
 insta = {workspace = true}
 insta-cmd = {workspace = true}
 rstest = "0.21.0"
-similar = {version = "2.5.0"}
-similar-asserts = "1.5.0"
+similar = {workspace = true}
+similar-asserts = {workspace = true}
 tempfile = {version = "3.10.0"}
 test_each_file = "0.3.3"
 

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_sort_limit_take.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__group_sort_limit_take.snap
@@ -362,7 +362,7 @@ ast:
                           Integer: 3
                         span: 1:168-169
                     span: 1:163-169
-                span: 1:137-169
+                span: 1:140-169
             span: 1:119-171
           - FuncCall:
               name:

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__invoice_totals.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__invoice_totals.snap
@@ -871,7 +871,7 @@ ast:
                           alias: total_price
                         span: 1:338-466
                     span: 1:328-466
-                span: 1:276-466
+                span: 1:281-466
             span: 1:254-468
           - FuncCall:
               name:
@@ -920,7 +920,7 @@ ast:
                             Boolean: true
                           span: 1:521-525
                     span: 1:504-592
-                span: 1:483-592
+                span: 1:488-592
             span: 1:469-594
           - FuncCall:
               name:

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__window.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__window.snap
@@ -453,7 +453,7 @@ ast:
                           Integer: 10
                         span: 1:914-916
                     span: 1:909-916
-                span: 1:790-916
+                span: 1:793-916
             span: 1:774-918
           - FuncCall:
               name:


### PR DESCRIPTION
Plus some general clearing up

Code-quality-wise `prqlc-parser` in a pretty good place now, I think...
