### PR TITLE
refactor: Fix nightly lint

### DIFF
--- a/lutra/lutra/src/compile.rs
+++ b/lutra/lutra/src/compile.rs
@@ -31,7 +31,7 @@ fn parse_and_compile(source_tree: &SourceTree) -> Result<ProjectCompiled, ErrorM
 
     // parse and resolve
     let ast_tree = prqlc::prql_to_pl_tree(source_tree)?;
-    let mut root_module = semantic::resolve(ast_tree, Default::default())?;
+    let mut root_module = semantic::resolve(ast_tree)?;
 
     // find the database module
     let database_module = find_database_module(&mut root_module)?;

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -409,7 +409,7 @@ impl Command {
                 let root_mod = prql_to_pl(&source)?;
 
                 // resolve
-                let ctx = semantic::resolve(root_mod, Default::default())?;
+                let ctx = semantic::resolve(root_mod)?;
 
                 let frames = if let Ok((main, _)) = ctx.find_main_rel(&[]) {
                     semantic::reporting::collect_frames(*main.clone().into_relation_var().unwrap())

--- a/prqlc/prqlc/src/lib.rs
+++ b/prqlc/prqlc/src/lib.rs
@@ -474,7 +474,7 @@ pub mod internal {
     ) -> Result<semantic::reporting::FrameCollector, ErrorMessages> {
         let ast = Some(pl.clone());
 
-        let root_module = semantic::resolve(pl, Default::default()).map_err(ErrorMessages::from)?;
+        let root_module = semantic::resolve(pl).map_err(ErrorMessages::from)?;
 
         let (main, _) = root_module.find_main_rel(&[]).unwrap();
         let mut fc =

--- a/prqlc/prqlc/src/semantic/mod.rs
+++ b/prqlc/prqlc/src/semantic/mod.rs
@@ -28,7 +28,7 @@ pub fn resolve_and_lower(
     main_path: &[String],
     database_module_path: Option<&[String]>,
 ) -> Result<RelationalQuery> {
-    let root_mod = resolve(file_tree, Default::default())?;
+    let root_mod = resolve(file_tree)?;
 
     debug::log_stage(debug::Stage::Semantic(debug::StageSemantic::Lowering));
     let default_db = [NS_DEFAULT_DB.to_string()];
@@ -40,7 +40,7 @@ pub fn resolve_and_lower(
 }
 
 /// Runs semantic analysis on the query.
-pub fn resolve(mut module_tree: pr::ModuleDef, options: ResolverOptions) -> Result<RootModule> {
+pub fn resolve(mut module_tree: pr::ModuleDef) -> Result<RootModule> {
     load_std_lib(&mut module_tree);
 
     // expand AST into PL
@@ -53,7 +53,7 @@ pub fn resolve(mut module_tree: pr::ModuleDef, options: ResolverOptions) -> Resu
         module: Module::new_root(),
         ..Default::default()
     };
-    let mut resolver = Resolver::new(&mut root_module, options);
+    let mut resolver = Resolver::new(&mut root_module);
 
     // resolve the module def into the root module
     debug::log_stage(debug::Stage::Semantic(debug::StageSemantic::Resolver));
@@ -86,7 +86,7 @@ pub fn load_std_lib(module_tree: &mut pr::ModuleDef) {
 }
 
 pub fn static_eval(expr: Expr, root_mod: &mut RootModule) -> Result<ConstExpr> {
-    let mut resolver = Resolver::new(root_mod, ResolverOptions::default());
+    let mut resolver = Resolver::new(root_mod);
 
     resolver.static_eval_to_constant(expr)
 }
@@ -183,7 +183,7 @@ pub mod test {
 
     pub fn parse_and_resolve(query: &str) -> Result<RootModule, Errors> {
         let source_tree = query.into();
-        Ok(resolve(parse(&source_tree)?, Default::default())?)
+        Ok(resolve(parse(&source_tree)?)?)
     }
 
     #[test]

--- a/prqlc/prqlc/src/semantic/resolver/mod.rs
+++ b/prqlc/prqlc/src/semantic/resolver/mod.rs
@@ -26,8 +26,6 @@ pub struct Resolver<'a> {
 
     pub id: IdGenerator<usize>,
 
-    pub options: ResolverOptions,
-
     pub generics: HashMap<(usize, String), Vec<crate::pr::Ty>>,
 }
 
@@ -35,10 +33,9 @@ pub struct Resolver<'a> {
 pub struct ResolverOptions {}
 
 impl Resolver<'_> {
-    pub fn new(root_mod: &mut RootModule, options: ResolverOptions) -> Resolver {
+    pub fn new(root_mod: &mut RootModule) -> Resolver {
         Resolver {
             root_mod,
-            options,
             current_module_path: Vec::new(),
             default_namespace: None,
             in_func_call_name: false,

--- a/prqlc/prqlc/src/sql/operators.rs
+++ b/prqlc/prqlc/src/sql/operators.rs
@@ -26,8 +26,7 @@ fn std() -> &'static decl::Module {
             None,
         );
         let ast = crate::parser::parse(&std_lib).unwrap();
-        let options = semantic::ResolverOptions {};
-        let context = semantic::resolve(ast, options).unwrap();
+        let context = semantic::resolve(ast).unwrap();
 
         context.module
     })

--- a/prqlc/prqlc/src/sql/pq/context.rs
+++ b/prqlc/prqlc/src/sql/pq/context.rs
@@ -64,8 +64,6 @@ pub enum RelationStatus {
 
 #[derive(Debug)]
 pub struct RelationInstance {
-    pub riid: RIId,
-
     pub table_ref: TableRef,
 
     /// When a pipeline is split, [CId]s from first pipeline are assigned a new
@@ -169,7 +167,6 @@ impl AnchorContext {
 
         let original_cids = table_ref.columns.iter().map(|(_, c)| *c).collect();
         let relation_instance = RelationInstance {
-            riid,
             table_ref,
             cid_redirects,
             original_cids,

--- a/prqlc/prqlc/tests/integration/resolving.rs
+++ b/prqlc/prqlc/tests/integration/resolving.rs
@@ -7,7 +7,7 @@ fn resolve(prql_source: &str) -> Result<String, ErrorMessages> {
     let sources = prqlc::SourceTree::single("".into(), prql_source.to_string());
     let stmts = prqlc::prql_to_pl_tree(&sources)?;
 
-    let root_module = prqlc::semantic::resolve(stmts, Default::default())
+    let root_module = prqlc::semantic::resolve(stmts)
         .map_err(|e| prqlc::ErrorMessages::from(e).composed(&sources))?;
 
     // resolved PL, restricted back into AST


### PR DESCRIPTION
Apparently `riid` isn't used, so nightly raises a compilation warning. Is it right to just remove it?
