### PR TITLE
refine: Remove lambda funcs from pipeline items

### DIFF
--- a/prqlc/prqlc-parser/src/parser/expr.rs
+++ b/prqlc/prqlc-parser/src/parser/expr.rs
@@ -30,9 +30,7 @@ pub(crate) fn expr() -> impl Parser<TokenKind, Expr, Error = PError> + Clone {
             .map(|x| x.to_string())
             .map(ExprKind::Internal);
 
-        let nested_expr = with_doc_comment(
-            pipeline(lambda_func(expr.clone()).or(func_call(expr.clone()))).boxed(),
-        );
+        let nested_expr = with_doc_comment(pipeline(func_call(expr.clone()))).boxed();
 
         let tuple = tuple(nested_expr.clone());
         let array = array(nested_expr.clone());


### PR DESCRIPTION
I don't think this is needed? Tests pass. But possibly I'm missing something...
