### PR TITLE
feat: Highlight in prqlc

### DIFF
--- a/prqlc/prqlc-macros/src/lib.rs
+++ b/prqlc/prqlc-macros/src/lib.rs
@@ -1,7 +1,7 @@
 //! Macros for PRQL compilation at build time.
 //!
 //! ```
-//! use prql_compiler_macros::prql_to_sql;
+//! use prqlc_macros::prql_to_sql;
 //!
 //! let sql: &str = prql_to_sql!("from albums | select {title, artist_id}");
 //! assert_eq!(sql, "SELECT title, artist_id FROM albums");

--- a/prqlc/prqlc-parser/src/parser/pr/stmt.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/stmt.rs
@@ -25,8 +25,6 @@ pub enum VarDefKind {
     Main,
 }
 
-// The following code is tested by the tests_misc crate to match stmt.rs in prql_compiler.
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Stmt {
     #[serde(flatten)]

--- a/prqlc/prqlc/src/cli/highlight.rs
+++ b/prqlc/prqlc/src/cli/highlight.rs
@@ -100,11 +100,31 @@ mod tests {
 
     #[test]
     fn highlight() {
-        assert_cmd_snapshot!(prqlc_command().args(["experimental", "highlight"]).pass_stdin("from tracks"), @r###"
+        // (Colors don't show because they're disabled; we could have a test
+        // that forces them to show?)
+        assert_cmd_snapshot!(prqlc_command().args(["experimental", "highlight"]).pass_stdin(r#"
+        from tracks
+        filter artist == "Bob Marley"                 # Each line transforms the previous result
+        aggregate {                                   # `aggregate` reduces each column to a value
+          plays    = sum plays,
+          longest  = max length,
+          shortest = min length,                      # Trailing commas are allowed
+        }
+
+        "#), @r###"
         success: true
         exit_code: 0
         ----- stdout -----
-        [32mfrom[39m tracks
+
+                from tracks
+                filter artist == "Bob Marley"                 # Each line transforms the previous result
+                aggregate {                                   # `aggregate` reduces each column to a value
+                  plays    = sum plays,
+                  longest  = max length,
+                  shortest = min length,                      # Trailing commas are allowed
+                }
+
+
         ----- stderr -----
         "###);
     }

--- a/prqlc/prqlc/src/cli/highlight.rs
+++ b/prqlc/prqlc/src/cli/highlight.rs
@@ -73,10 +73,12 @@ pub fn highlight(tokens: &Tokens) -> String {
 }
 
 fn is_transform(ident: &str) -> bool {
+// TODO: Could we instead source these from the standard library?
+// We could also use the semantic understanding from later compiler stages?
     match ident {
         "from" => true,
         "derive" | "select" | "filter" | "sort" | "join" | "take" | "group" | "aggregate"
-        | "window" | "lopo" => true,
+        | "window" | "loop" => true,
         _ => false,
     }
 }

--- a/prqlc/prqlc/src/cli/highlight.rs
+++ b/prqlc/prqlc/src/cli/highlight.rs
@@ -141,6 +141,7 @@ mod tests {
         "###);
     }
 
+    // TODO: import from existing location, need to adjust visibility
     fn prqlc_command() -> Command {
         let mut cmd = Command::new(get_cargo_bin("prqlc"));
         normalize_prqlc(&mut cmd);

--- a/prqlc/prqlc/src/cli/highlight.rs
+++ b/prqlc/prqlc/src/cli/highlight.rs
@@ -1,0 +1,128 @@
+use color_eyre::owo_colors::OwoColorize;
+use prqlc::{
+    lr::{TokenKind, Tokens},
+    pr::Literal,
+};
+
+/// Highlight PRQL code printed to the terminal.
+pub fn highlight(tokens: &Tokens) -> String {
+    let mut output = String::new();
+    let mut last = 0;
+
+    for token in &tokens.0 {
+        let diff = token.span.start - last;
+        last = token.span.end;
+        output.push_str(&" ".repeat(diff));
+
+        match &token.kind {
+            TokenKind::NewLine => output.push('\n'),
+            TokenKind::Ident(ident) => {
+                if is_transform(ident) {
+                    output.push_str(&ident.green().to_string())
+                } else {
+                    output.push_str(&ident.to_string())
+                }
+            }
+            TokenKind::Keyword(keyword) => output.push_str(&keyword.blue().to_string()),
+            TokenKind::Literal(literal) => output.push_str(&match literal {
+                Literal::Null => literal.green().bold().to_string(),
+                Literal::Integer(_) => literal.green().to_string(),
+                Literal::Float(_) => literal.green().to_string(),
+                Literal::Boolean(_) => literal.green().bold().to_string(),
+                Literal::String(_) => literal.yellow().to_string(),
+                _ => literal.to_string(),
+            }),
+            TokenKind::Param(param) => output.push_str(&param.purple().to_string()),
+            TokenKind::Range {
+                bind_left: _,
+                bind_right: _,
+            } => output.push_str(".."),
+            TokenKind::Interpolation(_, _) => output.push_str(&format!("{}", token.kind.yellow())),
+            TokenKind::Control(char) => output.push(*char),
+            TokenKind::ArrowThin
+            | TokenKind::ArrowFat
+            | TokenKind::Eq
+            | TokenKind::Ne
+            | TokenKind::Gte
+            | TokenKind::Lte
+            | TokenKind::RegexSearch => output.push_str(&format!("{}", token.kind)),
+            TokenKind::And | TokenKind::Or => {
+                output.push_str(&format!("{}", token.kind).purple().to_string())
+            }
+            TokenKind::Coalesce | TokenKind::DivInt | TokenKind::Pow | TokenKind::Annotate => {
+                output.push_str(&format!("{}", token.kind))
+            }
+            TokenKind::Comment(comment) => output.push_str(
+                &format!("#{comment}")
+                    .truecolor(95, 135, 135)
+                    .italic()
+                    .to_string(),
+            ),
+            TokenKind::DocComment(comment) => output.push_str(
+                &format!("#!{comment}")
+                    .truecolor(95, 135, 135)
+                    .italic()
+                    .to_string(),
+            ),
+            TokenKind::LineWrap(_) => todo!(),
+            TokenKind::Start => {}
+        }
+    }
+
+    output
+}
+
+fn is_transform(ident: &str) -> bool {
+    match ident {
+        "from" => true,
+        "derive" | "select" | "filter" | "sort" | "join" | "take" | "group" | "aggregate"
+        | "window" | "lopo" => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use insta_cmd::assert_cmd_snapshot;
+    use insta_cmd::get_cargo_bin;
+
+    #[test]
+    fn highlight() {
+        let input = r"
+foo
+
+        ";
+
+        assert_cmd_snapshot!(prqlc_command().args(["experimental", "highlight"]).pass_stdin(input), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        foo
+
+
+        ----- stderr -----
+        "###);
+    }
+
+    fn prqlc_command() -> Command {
+        let mut cmd = Command::new(get_cargo_bin("prqlc"));
+        normalize_prqlc(&mut cmd);
+        cmd
+    }
+    
+    fn normalize_prqlc(cmd: &mut Command) -> &mut Command {
+        cmd
+            // We set `CLICOLOR_FORCE` in CI to force color output, but we don't want `prqlc` to
+            // output color for our snapshot tests. And it seems to override the
+            // `--color=never` flag.
+            .env_remove("CLICOLOR_FORCE")
+            .env("NO_COLOR", "1")
+            .args(["--color=never"])
+            // We don't want the tests to be affected by the user's `RUST_BACKTRACE` setting.
+            .env_remove("RUST_BACKTRACE")
+            .env_remove("RUST_LOG")
+    }
+}

--- a/prqlc/prqlc/src/cli/highlight.rs
+++ b/prqlc/prqlc/src/cli/highlight.rs
@@ -73,8 +73,8 @@ pub fn highlight(tokens: &Tokens) -> String {
 }
 
 fn is_transform(ident: &str) -> bool {
-// TODO: Could we instead source these from the standard library?
-// We could also use the semantic understanding from later compiler stages?
+    // TODO: Could we instead source these from the standard library?
+    // We could also use the semantic understanding from later compiler stages?
     match ident {
         "from" => true,
         "derive" | "select" | "filter" | "sort" | "join" | "take" | "group" | "aggregate"
@@ -92,19 +92,11 @@ mod tests {
 
     #[test]
     fn highlight() {
-        let input = r"
-foo
-
-        ";
-
-        assert_cmd_snapshot!(prqlc_command().args(["experimental", "highlight"]).pass_stdin(input), @r###"
+        assert_cmd_snapshot!(prqlc_command().args(["experimental", "highlight"]).pass_stdin("from tracks"), @r###"
         success: true
         exit_code: 0
         ----- stdout -----
-
-        foo
-
-
+        from tracks
         ----- stderr -----
         "###);
     }
@@ -114,7 +106,7 @@ foo
         normalize_prqlc(&mut cmd);
         cmd
     }
-    
+
     fn normalize_prqlc(cmd: &mut Command) -> &mut Command {
         cmd
             // We set `CLICOLOR_FORCE` in CI to force color output, but we don't want `prqlc` to

--- a/prqlc/prqlc/src/cli/highlight.rs
+++ b/prqlc/prqlc/src/cli/highlight.rs
@@ -5,7 +5,7 @@ use prqlc::{
 };
 
 /// Highlight PRQL code printed to the terminal.
-pub fn highlight(tokens: &Tokens) -> String {
+pub(crate) fn highlight(tokens: &Tokens) -> String {
     let mut output = String::new();
     let mut last = 0;
 
@@ -75,12 +75,20 @@ pub fn highlight(tokens: &Tokens) -> String {
 fn is_transform(ident: &str) -> bool {
     // TODO: Could we instead source these from the standard library?
     // We could also use the semantic understanding from later compiler stages?
-    match ident {
-        "from" => true,
-        "derive" | "select" | "filter" | "sort" | "join" | "take" | "group" | "aggregate"
-        | "window" | "loop" => true,
-        _ => false,
-    }
+    matches!(
+        ident,
+        "from"
+            | "derive"
+            | "select"
+            | "filter"
+            | "sort"
+            | "join"
+            | "take"
+            | "group"
+            | "aggregate"
+            | "window"
+            | "loop"
+    )
 }
 
 #[cfg(test)]

--- a/prqlc/prqlc/src/cli/highlight.rs
+++ b/prqlc/prqlc/src/cli/highlight.rs
@@ -104,7 +104,7 @@ mod tests {
         success: true
         exit_code: 0
         ----- stdout -----
-        from tracks
+        [32mfrom[39m tracks
         ----- stderr -----
         "###);
     }

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
 
-mod highlight;
 mod docs_generator;
+mod highlight;
 mod jinja;
 mod watch;
 

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -1,10 +1,5 @@
 #![cfg(not(target_family = "wasm"))]
 
-mod docs_generator;
-mod highlight;
-mod jinja;
-mod watch;
-
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -36,6 +31,13 @@ use prqlc::semantic::reporting::FrameCollector;
 use prqlc::utils::maybe_strip_colors;
 use prqlc::{pl_to_prql, pl_to_rq_tree, prql_to_pl, prql_to_pl_tree, prql_to_tokens, rq_to_sql};
 use prqlc::{Options, SourceTree, Target};
+
+mod docs_generator;
+mod highlight;
+mod jinja;
+#[cfg(test)]
+mod test;
+mod watch;
 
 /// Entrypoint called by [`crate::main`]
 pub fn main() -> color_eyre::eyre::Result<()> {

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -33,6 +33,7 @@ use prqlc::ir::{pl, rq};
 use prqlc::pr;
 use prqlc::semantic;
 use prqlc::semantic::reporting::FrameCollector;
+use prqlc::utils::maybe_strip_colors;
 use prqlc::{pl_to_prql, pl_to_rq_tree, prql_to_pl, prql_to_pl_tree, prql_to_tokens, rq_to_sql};
 use prqlc::{Options, SourceTree, Target};
 
@@ -447,7 +448,7 @@ impl Command {
                 })?;
                 let tokens = prql_to_tokens(s)?;
 
-                highlight::highlight(&tokens).into_bytes()
+                maybe_strip_colors(&highlight::highlight(&tokens)).into_bytes()
             }
             Command::Compile {
                 signature_comment,

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-2.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-2.snap
@@ -1,5 +1,4 @@
 ---
-source: prqlc/prqlc/tests/integration/cli.rs
 info:
   program: prqlc
   args:
@@ -81,18 +80,24 @@ complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcomm
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from lineage; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from json-schema; and not __fish_seen_subcommand_from help" -f -a "ast" -d 'Print info about the AST data structure'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from lineage; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from json-schema; and not __fish_seen_subcommand_from help" -f -a "json-schema" -d 'Print JSON Schema'
 complete -c prqlc -n "__fish_seen_subcommand_from debug; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from lineage; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from json-schema; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -s v -l verbose -d 'Increase logging verbosity'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -s q -l quiet -d 'Silences logging output'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -f -a "doc" -d 'Generate Markdown documentation'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -s v -l verbose -d 'Increase logging verbosity'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -s q -l quiet -d 'Silences logging output'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "doc" -d 'Generate Markdown documentation'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "highlight" -d 'Syntax highlight'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -s v -l verbose -d 'Increase logging verbosity'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -s q -l quiet -d 'Silences logging output'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -f -a "doc" -d 'Generate Markdown documentation'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from highlight" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from highlight" -s v -l verbose -d 'Increase logging verbosity'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from highlight" -s q -l quiet -d 'Silences logging output'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from highlight" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "doc" -d 'Generate Markdown documentation'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "highlight" -d 'Syntax highlight'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -s t -l target -d 'Target to compile to' -r
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -l debug-log -d 'File path into which to write the debug log to' -r -F
 complete -c prqlc -n "__fish_seen_subcommand_from compile" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
@@ -130,6 +135,7 @@ complete -c prqlc -n "__fish_seen_subcommand_from help; and __fish_seen_subcomma
 complete -c prqlc -n "__fish_seen_subcommand_from help; and __fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from lineage; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from json-schema" -f -a "lineage" -d 'Output column-level lineage graph'
 complete -c prqlc -n "__fish_seen_subcommand_from help; and __fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from lineage; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from json-schema" -f -a "ast" -d 'Print info about the AST data structure'
 complete -c prqlc -n "__fish_seen_subcommand_from help; and __fish_seen_subcommand_from debug; and not __fish_seen_subcommand_from annotate; and not __fish_seen_subcommand_from lineage; and not __fish_seen_subcommand_from ast; and not __fish_seen_subcommand_from json-schema" -f -a "json-schema" -d 'Print JSON Schema'
-complete -c prqlc -n "__fish_seen_subcommand_from help; and __fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc" -f -a "doc" -d 'Generate Markdown documentation'
+complete -c prqlc -n "__fish_seen_subcommand_from help; and __fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight" -f -a "doc" -d 'Generate Markdown documentation'
+complete -c prqlc -n "__fish_seen_subcommand_from help; and __fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight" -f -a "highlight" -d 'Syntax highlight'
 
 ----- stderr -----

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-3.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-3.snap
@@ -1,5 +1,4 @@
 ---
-source: prqlc/prqlc/tests/integration/cli.rs
 info:
   program: prqlc
   args:
@@ -191,6 +190,7 @@ Register-ArgumentCompleter -Native -CommandName 'prqlc' -ScriptBlock {
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('doc', 'doc', [CompletionResultType]::ParameterValue, 'Generate Markdown documentation')
+            [CompletionResult]::new('highlight', 'highlight', [CompletionResultType]::ParameterValue, 'Syntax highlight')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
@@ -204,12 +204,26 @@ Register-ArgumentCompleter -Native -CommandName 'prqlc' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             break
         }
+        'prqlc;experimental;highlight' {
+            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Controls when to use color')
+            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Silences logging output')
+            [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Silences logging output')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            break
+        }
         'prqlc;experimental;help' {
             [CompletionResult]::new('doc', 'doc', [CompletionResultType]::ParameterValue, 'Generate Markdown documentation')
+            [CompletionResult]::new('highlight', 'highlight', [CompletionResultType]::ParameterValue, 'Syntax highlight')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
         'prqlc;experimental;help;doc' {
+            break
+        }
+        'prqlc;experimental;help;highlight' {
             break
         }
         'prqlc;experimental;help;help' {
@@ -309,9 +323,13 @@ Register-ArgumentCompleter -Native -CommandName 'prqlc' -ScriptBlock {
         }
         'prqlc;help;experimental' {
             [CompletionResult]::new('doc', 'doc', [CompletionResultType]::ParameterValue, 'Generate Markdown documentation')
+            [CompletionResult]::new('highlight', 'highlight', [CompletionResultType]::ParameterValue, 'Syntax highlight')
             break
         }
         'prqlc;help;experimental;doc' {
+            break
+        }
+        'prqlc;help;experimental;highlight' {
             break
         }
         'prqlc;help;compile' {

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-4.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-4.snap
@@ -1,5 +1,4 @@
 ---
-source: prqlc/prqlc/tests/integration/cli.rs
 info:
   program: prqlc
   args:
@@ -250,6 +249,20 @@ _arguments "${_arguments_options[@]}" \
 '::main_path -- Identifier of the main pipeline:' \
 && ret=0
 ;;
+(highlight)
+_arguments "${_arguments_options[@]}" \
+'--color=[Controls when to use color]:WHEN:(auto always never)' \
+'*-v[Increase logging verbosity]' \
+'*--verbose[Increase logging verbosity]' \
+'(-v --verbose)*-q[Silences logging output]' \
+'(-v --verbose)*--quiet[Silences logging output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'::input:_files' \
+'::output:_files' \
+'::main_path -- Identifier of the main pipeline:' \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" \
 ":: :_prqlc__experimental__help_commands" \
@@ -263,6 +276,10 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:prqlc-experimental-help-command-$line[1]:"
         case $line[1] in
             (doc)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(highlight)
 _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
@@ -410,6 +427,10 @@ _arguments "${_arguments_options[@]}" \
 _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
+(highlight)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
         esac
     ;;
 esac
@@ -550,6 +571,7 @@ _prqlc__help__experimental__doc_commands() {
 _prqlc__experimental_commands() {
     local commands; commands=(
 'doc:Generate Markdown documentation' \
+'highlight:Syntax highlight' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'prqlc experimental commands' commands "$@"
@@ -558,6 +580,7 @@ _prqlc__experimental_commands() {
 _prqlc__help__experimental_commands() {
     local commands; commands=(
 'doc:Generate Markdown documentation' \
+'highlight:Syntax highlight' \
     )
     _describe -t commands 'prqlc help experimental commands' commands "$@"
 }
@@ -591,6 +614,7 @@ _prqlc__debug__help__help_commands() {
 _prqlc__experimental__help_commands() {
     local commands; commands=(
 'doc:Generate Markdown documentation' \
+'highlight:Syntax highlight' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'prqlc experimental help commands' commands "$@"
@@ -621,6 +645,21 @@ _prqlc__help_commands() {
 _prqlc__help__help_commands() {
     local commands; commands=()
     _describe -t commands 'prqlc help help commands' commands "$@"
+}
+(( $+functions[_prqlc__experimental__help__highlight_commands] )) ||
+_prqlc__experimental__help__highlight_commands() {
+    local commands; commands=()
+    _describe -t commands 'prqlc experimental help highlight commands' commands "$@"
+}
+(( $+functions[_prqlc__experimental__highlight_commands] )) ||
+_prqlc__experimental__highlight_commands() {
+    local commands; commands=()
+    _describe -t commands 'prqlc experimental highlight commands' commands "$@"
+}
+(( $+functions[_prqlc__help__experimental__highlight_commands] )) ||
+_prqlc__help__experimental__highlight_commands() {
+    local commands; commands=()
+    _describe -t commands 'prqlc help experimental highlight commands' commands "$@"
 }
 (( $+functions[_prqlc__debug__help__json-schema_commands] )) ||
 _prqlc__debug__help__json-schema_commands() {

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion.snap
@@ -1,5 +1,4 @@
 ---
-source: prqlc/prqlc/tests/integration/cli.rs
 info:
   program: prqlc
   args:
@@ -98,11 +97,17 @@ _prqlc() {
             prqlc__experimental,help)
                 cmd="prqlc__experimental__help"
                 ;;
+            prqlc__experimental,highlight)
+                cmd="prqlc__experimental__highlight"
+                ;;
             prqlc__experimental__help,doc)
                 cmd="prqlc__experimental__help__doc"
                 ;;
             prqlc__experimental__help,help)
                 cmd="prqlc__experimental__help__help"
+                ;;
+            prqlc__experimental__help,highlight)
+                cmd="prqlc__experimental__help__highlight"
                 ;;
             prqlc__help,collect)
                 cmd="prqlc__help__collect"
@@ -151,6 +156,9 @@ _prqlc() {
                 ;;
             prqlc__help__experimental,doc)
                 cmd="prqlc__help__experimental__doc"
+                ;;
+            prqlc__help__experimental,highlight)
+                cmd="prqlc__help__experimental__highlight"
                 ;;
             *)
                 ;;
@@ -407,7 +415,7 @@ _prqlc() {
             return 0
             ;;
         prqlc__experimental)
-            opts="-v -q -h --color --verbose --quiet --help doc help"
+            opts="-v -q -h --color --verbose --quiet --help doc highlight help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -443,7 +451,7 @@ _prqlc() {
             return 0
             ;;
         prqlc__experimental__help)
-            opts="doc help"
+            opts="doc highlight help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -477,6 +485,38 @@ _prqlc() {
                 return 0
             fi
             case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        prqlc__experimental__help__highlight)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        prqlc__experimental__highlight)
+            opts="-v -q -h --color --verbose --quiet --help [INPUT] [OUTPUT] [MAIN_PATH]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --color)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -615,7 +655,7 @@ _prqlc() {
             return 0
             ;;
         prqlc__help__experimental)
-            opts="doc"
+            opts="doc highlight"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -629,6 +669,20 @@ _prqlc() {
             return 0
             ;;
         prqlc__help__experimental__doc)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        prqlc__help__experimental__highlight)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/prqlc/prqlc/src/cli/test.rs
+++ b/prqlc/prqlc/src/cli/test.rs
@@ -1,5 +1,3 @@
-#![cfg(all(not(target_family = "wasm"), feature = "cli"))]
-
 use std::env::current_dir;
 use std::fs;
 use std::path::Path;

--- a/prqlc/prqlc/src/error_message.rs
+++ b/prqlc/prqlc/src/error_message.rs
@@ -1,10 +1,9 @@
+use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Range;
 use std::path::PathBuf;
-use std::{collections::HashMap, io::stderr};
 
-use anstream::adapter::strip_str;
 use ariadne::{Cache, Config, Label, Report, ReportKind, Source};
 use serde::Serialize;
 
@@ -193,7 +192,7 @@ impl ErrorMessage {
         report.finish().write(cache, &mut out).ok()?;
         String::from_utf8(out)
             .ok()
-            .map(|x| maybe_strip_colors(x.as_str()))
+            .map(|x| crate::utils::maybe_strip_colors(x.as_str()))
     }
 
     fn compose_location(&self, source: &Source) -> Option<SourceLocation> {
@@ -205,26 +204,6 @@ impl ErrorMessage {
             start: (start.1, start.2),
             end: (end.1, end.2),
         })
-    }
-}
-
-fn should_use_color() -> bool {
-    match anstream::AutoStream::choice(&stderr()) {
-        anstream::ColorChoice::Auto => true,
-        anstream::ColorChoice::Always => true,
-        anstream::ColorChoice::AlwaysAnsi => true,
-        anstream::ColorChoice::Never => false,
-    }
-}
-
-/// Strip colors, for external libraries which don't yet strip themselves, and
-/// for insta snapshot tests. This will respond to environment variables such as
-/// `CLI_COLOR`.
-pub(crate) fn maybe_strip_colors(s: &str) -> String {
-    if !should_use_color() {
-        strip_str(s).to_string()
-    } else {
-        s.to_string()
     }
 }
 

--- a/prqlc/prqlc/src/lib.rs
+++ b/prqlc/prqlc/src/lib.rs
@@ -107,8 +107,6 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use strum::VariantNames;
 
-// pub(crate) use crate::utils;
-
 pub use error_message::{ErrorMessage, ErrorMessages, SourceLocation};
 pub use prqlc_parser::error::{Error, ErrorSource, Errors, MessageKind, Reason, WithErrorInfo};
 pub use prqlc_parser::lexer::lr;
@@ -122,8 +120,10 @@ pub mod ir;
 pub mod parser;
 pub mod semantic;
 pub mod sql;
+#[cfg(feature = "cli")]
+pub mod utils;
+#[cfg(not(feature = "cli"))]
 pub(crate) mod utils;
-// pub mod utils;
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 

--- a/prqlc/prqlc/src/lib.rs
+++ b/prqlc/prqlc/src/lib.rs
@@ -107,6 +107,8 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use strum::VariantNames;
 
+// pub(crate) use crate::utils;
+
 pub use error_message::{ErrorMessage, ErrorMessages, SourceLocation};
 pub use prqlc_parser::error::{Error, ErrorSource, Errors, MessageKind, Reason, WithErrorInfo};
 pub use prqlc_parser::lexer::lr;
@@ -120,7 +122,8 @@ pub mod ir;
 pub mod parser;
 pub mod semantic;
 pub mod sql;
-mod utils;
+pub(crate) mod utils;
+// pub mod utils;
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 

--- a/prqlc/prqlc/src/utils/mod.rs
+++ b/prqlc/prqlc/src/utils/mod.rs
@@ -1,8 +1,9 @@
 mod id_gen;
 mod toposort;
 
-use std::sync::OnceLock;
+use std::{io::stderr, sync::OnceLock};
 
+use anstream::adapter::strip_str;
 pub use id_gen::{IdGenerator, NameGenerator};
 use itertools::Itertools;
 use regex::Regex;
@@ -89,6 +90,26 @@ pub(crate) fn valid_ident() -> &'static Regex {
         // ^ ('*' | [ascii_lower '_$'] [ascii_lower ascii_digit '_$']* ) $
         Regex::new(r"^((\*)|(^[a-z_\$][a-z0-9_\$]*))$").unwrap()
     })
+}
+
+fn should_use_color() -> bool {
+    match anstream::AutoStream::choice(&stderr()) {
+        anstream::ColorChoice::Auto => true,
+        anstream::ColorChoice::Always => true,
+        anstream::ColorChoice::AlwaysAnsi => true,
+        anstream::ColorChoice::Never => false,
+    }
+}
+
+/// Strip colors, for external libraries which don't yet strip themselves, and
+/// for insta snapshot tests. This will respond to environment variables such as
+/// `CLI_COLOR`.
+pub(crate) fn maybe_strip_colors(s: &str) -> String {
+    if !should_use_color() {
+        strip_str(s).to_string()
+    } else {
+        s.to_string()
+    }
 }
 
 #[test]

--- a/prqlc/prqlc/src/utils/mod.rs
+++ b/prqlc/prqlc/src/utils/mod.rs
@@ -104,7 +104,7 @@ fn should_use_color() -> bool {
 /// Strip colors, for external libraries which don't yet strip themselves, and
 /// for insta snapshot tests. This will respond to environment variables such as
 /// `CLI_COLOR`.
-pub(crate) fn maybe_strip_colors(s: &str) -> String {
+pub fn maybe_strip_colors(s: &str) -> String {
     if !should_use_color() {
         strip_str(s).to_string()
     } else {

--- a/prqlc/prqlc/tests/integration/main.rs
+++ b/prqlc/prqlc/tests/integration/main.rs
@@ -1,5 +1,4 @@
 mod bad_error_messages;
-mod cli;
 mod dbs;
 mod error_messages;
 mod queries;


### PR DESCRIPTION
This PR adds a command called `highlight` (under `experimental`) to `prqlc` which does syntax highlighting on the terminal.

Example:

    prqlc experimental highlight example.prql

It works pretty good but single quotes becomes double quotes because that's what the lexer does.

I couldn't get the test to work because somehow it still includes the ANSI escape sequences even though the test sets the environment variable `NO_COLOR` and passes in the `--color=never` argument. It shows a diff between what is returned and what is expected that is identical.

```diff
-␛[32mfrom␛[39m foo
+␛[32mfrom␛[39m foo
```

Later maybe we can use this in `prqlc compile` too.