### PR TITLE
chore: spiffy up debug log HTML

### DIFF
--- a/prqlc/prqlc/src/debug/render_html.rs
+++ b/prqlc/prqlc/src/debug/render_html.rs
@@ -131,7 +131,10 @@ fn write_repr_prql<W: Write>(w: &mut W, source_tree: &SourceTree) -> Result {
         write_key_values(w, &[("path", &path), ("source_id", source_id)])?;
 
         let source_escaped = escape_html(source);
-        writeln!(w, r#"<code id="source-{source_id}">{source_escaped}</code>"#)?;
+        writeln!(
+            w,
+            r#"<code id="source-{source_id}">{source_escaped}</code>"#
+        )?;
         writeln!(w, "</div>")?; // source
     }
 


### PR DESCRIPTION
This changes up the HTML for the debug log so that it uses the HTML `summary` element and makes the headers bigger, slightly improves the semantics, makes sure attributes are quoted, cuts down the line length in the markup, wraps the content in the `main` element, wraps the document in the `html` element, adds two `meta` tags.