### PR TITLE
build: Release snap to stable channel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -266,7 +266,7 @@ jobs:
             ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.build.outputs.snap }}
-          release: edge
+          release: stable
 
   build-python-wheels:
     runs-on: ${{ matrix.os }}

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ source-code: https://github.com/PRQL/prql
 contact: https://twitter.com/prql_lang
 website: https://prql-lang.org/
 license: Apache-2.0
-grade: devel # must be 'stable' to release into candidate/stable channels
+grade: stable
 confinement: strict
 icon: web/website/static/img/icon.svg
 


### PR DESCRIPTION
This PR changes the way we publish the Snap package so to release it to the "stable" channel instead of the "edge" channel.

Reason is, we've had it published for several versions to the "edge" channel and it seems to work fine, so lets try to publish is to the "stable" channel.