### PR TITLE
feat(prqlc): Add HTML format to docs generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 **Features**:
 
+- Add a option to the experimental documentation generator to output the docs
+  in HTML format. The option is given using the `--format=html` option.
+  (@vanillajonathan, 4791)
+
 **Fixes**:
 
 **Documentation**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 **Features**:
 
-- Add a option to the experimental documentation generator to output the docs
-  in HTML format. The option is given using the `--format=html` option.
+- Add a option to the experimental documentation generator to output the docs in
+  HTML format. The option is given using the `--format=html` option.
   (@vanillajonathan, 4791)
 
 **Fixes**:

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -405,42 +405,30 @@ mod tests {
 
         ### fn_returns_array
 
-        #### Parameters
-
         #### Returns
         `array`
 
         ### fn_returns_bool
-
-        #### Parameters
 
         #### Returns
         `bool`
 
         ### fn_returns_float
 
-        #### Parameters
-
         #### Returns
         `float`
 
         ### fn_returns_int
-
-        #### Parameters
 
         #### Returns
         `int`
 
         ### fn_returns_null
 
-        #### Parameters
-
         #### Returns
         `null`
 
         ### fn_returns_text
-
-        #### Parameters
 
         #### Returns
         `text`

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -1,176 +1,199 @@
 use prqlc::pr::{ExprKind, Stmt, StmtKind, TyKind, VarDefKind};
 
 /// Generate HTML documentation.
-// pub fn generate_html_docs(stmts: Vec<Stmt>) -> String {
-//     let html = format!(
-//         r#"<!doctype html>
-// <html lang="en">
-//   <head>
-//     <meta charset="utf-8">
-//     <meta name="viewport" content="width=device-width, initial-scale=1">
-//     <meta name="keywords" content="prql">
-//     <meta name="generator" content="prqlc {}">
-//     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-//     <title>PRQL Docs</title>
-//   </head>
-//   <body>
-//     <header class="bg-body-tertiary">
-//       <div class="container">
-//         <h1>Documentation</h1>
-//       </div>
-//     </header>
-//     <main class="container">
-//       {{{{ content }}}}
-//     </main>
-//     <footer class="container border-top">
-//       <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> {}.</small>
-//     </footer>
-//   </body>
-// </html>
-// "#,
-//         *prqlc::COMPILER_VERSION,
-//         *prqlc::COMPILER_VERSION
-//     );
+pub fn generate_html_docs(stmts: Vec<Stmt>) -> String {
+    let html = format!(
+        r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="keywords" content="prql">
+    <meta name="generator" content="prqlc {}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <title>PRQL Docs</title>
+  </head>
+  <body>
+    <header class="bg-body-tertiary">
+      <div class="container">
+        <h1>Documentation</h1>
+      </div>
+    </header>
+    <main class="container">
+      {{{{ content }}}}
+    </main>
+    <footer class="container border-top">
+      <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> {}.</small>
+    </footer>
+  </body>
+</html>
+"#,
+        *prqlc::compiler_version(),
+        *prqlc::compiler_version()
+    );
 
-//     let mut docs = String::new();
+    let mut docs = String::new();
 
-//     docs.push_str("<h2>Functions</h2>\n");
-//     docs.push_str("<ul>\n");
-//     for stmt in stmts
-//         .clone()
-//         .into_iter()
-//         .filter(|stmt| matches!(stmt.kind, StmtKind::VarDef(_)))
-//     {
-//         let var_def = stmt.kind.as_var_def().unwrap();
-//         docs.push_str(&format!(
-//             "  <li><a href=\"#fn-{}\">{}</a></li>\n",
-//             var_def.name, var_def.name
-//         ));
-//     }
-//     docs.push_str("</ul>\n\n");
-//     if stmts
-//         .clone()
-//         .into_iter()
-//         .filter(|stmt| matches!(stmt.kind, StmtKind::VarDef(_)))
-//         .count()
-//         == 0
-//     {
-//         docs.push_str("<p>None.</p>\n\n");
-//     }
+    docs.push_str("<h2>Functions</h2>\n");
+    docs.push_str("<ul>\n");
+    for stmt in stmts
+        .clone()
+        .into_iter()
+        .filter(|stmt| matches!(stmt.kind, StmtKind::VarDef(_)))
+    {
+        let var_def = stmt.kind.as_var_def().unwrap();
+        docs.push_str(&format!(
+            "  <li><a href=\"#fn-{}\">{}</a></li>\n",
+            var_def.name, var_def.name
+        ));
+    }
+    docs.push_str("</ul>\n\n");
+    if stmts
+        .clone()
+        .into_iter()
+        .filter(|stmt| matches!(stmt.kind, StmtKind::VarDef(_)))
+        .count()
+        == 0
+    {
+        docs.push_str("<p>None.</p>\n\n");
+    }
 
-//     if stmts
-//         .clone()
-//         .into_iter()
-//         .filter(|stmt| matches!(stmt.kind, StmtKind::TypeDef(_)))
-//         .count()
-//         > 0
-//     {
-//         docs.push_str("<h2>Types</h2>\n");
-//         docs.push_str("<ul>\n");
-//         for stmt in stmts
-//             .clone()
-//             .into_iter()
-//             .filter(|stmt| matches!(stmt.kind, StmtKind::TypeDef(_)))
-//         {
-//             let type_def = stmt.kind.as_type_def().unwrap();
-//             if let Some(value) = &type_def.value {
-//                 docs.push_str(&format!(
-//                     "  <li><code>{}</code> – {:?}</li>\n",
-//                     type_def.name, value.kind
-//                 ));
-//             } else {
-//                 docs.push_str(&format!("  <li>{}</li>\n", type_def.name));
-//             }
-//         }
-//         docs.push_str("</ul>\n");
-//     }
+    if stmts
+        .clone()
+        .into_iter()
+        .filter(|stmt| matches!(stmt.kind, StmtKind::TypeDef(_)))
+        .count()
+        > 0
+    {
+        docs.push_str("<h2>Types</h2>\n");
+        docs.push_str("<ul>\n");
+        for stmt in stmts
+            .clone()
+            .into_iter()
+            .filter(|stmt| matches!(stmt.kind, StmtKind::TypeDef(_)))
+        {
+            let type_def = stmt.kind.as_type_def().unwrap();
+            if let Some(value) = &type_def.value {
+                docs.push_str(&format!(
+                    "  <li><code>{}</code> – {:?}</li>\n",
+                    type_def.name, value.kind
+                ));
+            } else {
+                docs.push_str(&format!("  <li>{}</li>\n", type_def.name));
+            }
+        }
+        docs.push_str("</ul>\n");
+    }
 
-//     if stmts
-//         .clone()
-//         .into_iter()
-//         .filter(|stmt| matches!(stmt.kind, StmtKind::ModuleDef(_)))
-//         .count()
-//         > 0
-//     {
-//         docs.push_str("<h2>Modules</h2>\n");
-//         docs.push_str("<ul>\n");
-//         for stmt in stmts
-//             .clone()
-//             .into_iter()
-//             .filter(|stmt| matches!(stmt.kind, StmtKind::ModuleDef(_)))
-//         {
-//             let module_def = stmt.kind.as_module_def().unwrap();
-//             docs.push_str(&format!("  <li>{}</li>\n", module_def.name));
-//         }
-//         docs.push_str("</ul>\n");
-//     }
+    if stmts
+        .clone()
+        .into_iter()
+        .filter(|stmt| matches!(stmt.kind, StmtKind::ModuleDef(_)))
+        .count()
+        > 0
+    {
+        docs.push_str("<h2>Modules</h2>\n");
+        docs.push_str("<ul>\n");
+        for stmt in stmts
+            .clone()
+            .into_iter()
+            .filter(|stmt| matches!(stmt.kind, StmtKind::ModuleDef(_)))
+        {
+            let module_def = stmt.kind.as_module_def().unwrap();
+            docs.push_str(&format!("  <li>{}</li>\n", module_def.name));
+        }
+        docs.push_str("</ul>\n");
+    }
 
-//     for stmt in stmts
-//         .clone()
-//         .into_iter()
-//         .filter(|stmt| matches!(stmt.kind, StmtKind::VarDef(_)))
-//     {
-//         let var_def = stmt.kind.as_var_def().unwrap();
-//         if var_def.kind != VarDefKind::Let {
-//             continue;
-//         }
+    for stmt in stmts
+        .clone()
+        .into_iter()
+        .filter(|stmt| matches!(stmt.kind, StmtKind::VarDef(_)))
+    {
+        let var_def = stmt.kind.as_var_def().unwrap();
+        if var_def.kind != VarDefKind::Let {
+            continue;
+        }
 
-//         docs.push_str("<section>\n");
-//         docs.push_str(&format!(
-//             "  <h3 id=\"fn-{}\">{}</h3>\n",
-//             var_def.name, var_def.name
-//         ));
+        docs.push_str("<section>\n");
+        docs.push_str(&format!(
+            "  <h3 id=\"fn-{}\">{}</h3>\n",
+            var_def.name, var_def.name
+        ));
 
-//         if let Some(doc_comment) = stmt.doc_comment {
-//             docs.push_str(&format!("  <p>{doc_comment}</p>\n"));
-//         }
+        docs.push_str("<div class=\"ms-3\">\n");
 
-//         if let Some(expr) = &var_def.value {
-//             match &expr.kind {
-//                 ExprKind::Func(func) => {
-//                     docs.push_str("  <h4 class=\"h6\">Parameters</h4>\n");
-//                     docs.push_str("  <ul>\n");
-//                     for param in &func.params {
-//                         docs.push_str(&format!("    <li><var>{}</var></li>\n", param.name));
-//                     }
-//                     docs.push_str("  </ul>\n");
+        if let Some(doc_comment) = stmt.doc_comment {
+            docs.push_str(&format!("  <p>{doc_comment}</p>\n"));
+        }
 
-//                     if let Some(return_ty) = &func.return_ty {
-//                         docs.push_str("  <h4 class=\"h6\">Returns</h4>\n");
-//                         match &return_ty.kind {
-//                             TyKind::Any => docs.push_str("  <p>Any</p>\n"),
-//                             TyKind::Ident(ident) => {
-//                                 docs.push_str(&format!("  <p><code>{}</code></p>\n", ident.name));
-//                             }
-//                             TyKind::Primitive(primitive) => {
-//                                 docs.push_str(&format!("  <p><code>{primitive}</code></p>\n"));
-//                             }
-//                             TyKind::Singleton(literal) => {
-//                                 docs.push_str(&format!("  <p><code>{literal}</code></p>\n"));
-//                             }
-//                             TyKind::Union(vec) => {
-//                                 docs.push_str("  <ul class=\"list-unstyled\">\n");
-//                                 for (_, ty) in vec {
-//                                     docs.push_str(&format!("    <li>{:?}</li>\n", ty.kind));
-//                                 }
-//                                 docs.push_str("  </ul>\n");
-//                             }
-//                             _ => docs.push_str("  <p class=\"text-danger\">Not implemented</p>\n"),
-//                         }
-//                     }
-//                 }
-//                 ExprKind::Pipeline(_) => {
-//                     docs.push_str("  <p>There is a pipeline.</p>\n");
-//                 }
-//                 _ => (),
-//             }
-//         }
+        if let Some(expr) = &var_def.value {
+            match &expr.kind {
+                ExprKind::Func(func) => {
+                    if func.generic_type_params.len() > 0 {
+                        docs.push_str("  <h4 class=\"h6\">Type parameters</h4>\n");
+                        docs.push_str("  <ul>\n");
+                        for param in &func.generic_type_params {
+                            docs.push_str(&format!("    <li><var>{}</var></li>\n", param.name));
+                        }
+                        docs.push_str("  </ul>\n");
+                    }
 
-//         docs.push_str("</section>\n");
-//     }
+                    if func.params.len() > 0 {
+                        docs.push_str("  <h4 class=\"h6\">Parameters</h4>\n");
+                        docs.push_str("  <ul>\n");
+                        for param in &func.params {
+                            docs.push_str(&format!("    <li><var>{}</var></li>\n", param.name));
+                        }
+                        docs.push_str("  </ul>\n");
+                    }
 
-//     html.replacen("{{ content }}", &docs, 1)
-// }
+                    if func.named_params.len() > 0 {
+                        docs.push_str("  <h4 class=\"h6\">Named parameters</h4>\n");
+                        docs.push_str("  <ul>\n");
+                        for param in &func.named_params {
+                            docs.push_str(&format!("    <li><var>{}</var></li>\n", param.name));
+                        }
+                        docs.push_str("  </ul>\n");
+                    }
+
+                    if let Some(return_ty) = &func.return_ty {
+                        docs.push_str("  <h4 class=\"h6\">Returns</h4>\n");
+                        match &return_ty.kind {
+                            TyKind::Any => docs.push_str("  <p>Any</p>\n"),
+                            TyKind::Ident(ident) => {
+                                docs.push_str(&format!("  <p><code>{}</code></p>\n", ident.name));
+                            }
+                            TyKind::Primitive(primitive) => {
+                                docs.push_str(&format!("  <p><code>{primitive}</code></p>\n"));
+                            }
+                            TyKind::Singleton(literal) => {
+                                docs.push_str(&format!("  <p><code>{literal}</code></p>\n"));
+                            }
+                            TyKind::Union(vec) => {
+                                docs.push_str("  <ul class=\"list-unstyled\">\n");
+                                for (_, ty) in vec {
+                                    docs.push_str(&format!("    <li>{:?}</li>\n", ty.kind));
+                                }
+                                docs.push_str("  </ul>\n");
+                            }
+                            _ => docs.push_str("  <p class=\"text-danger\">Not implemented</p>\n"),
+                        }
+                    }
+                }
+                ExprKind::Pipeline(_) => {
+                    docs.push_str("  <p>There is a pipeline.</p>\n");
+                }
+                _ => (),
+            }
+        }
+
+        docs.push_str("</div>\n");
+        docs.push_str("</section>\n");
+    }
+
+    html.replacen("{{ content }}", &docs, 1)
+}
 
 /// Generate Markdown documentation.
 pub fn generate_markdown_docs(stmts: Vec<Stmt>) -> String {
@@ -269,11 +292,29 @@ Generated with [prqlc](https://prql-lang.org/) {}.
         if let Some(expr) = &var_def.value {
             match &expr.kind {
                 ExprKind::Func(func) => {
-                    docs.push_str("#### Parameters\n");
-                    for param in &func.params {
-                        docs.push_str(&format!("* *{}*\n", param.name));
+                    if func.generic_type_params.len() > 0 {
+                        docs.push_str("#### Type Parameters\n");
+                        for param in &func.generic_type_params {
+                            docs.push_str(&format!("* *{}*\n", param.name));
+                        }
+                        docs.push('\n');
                     }
-                    docs.push('\n');
+
+                    if func.params.len() > 0 {
+                        docs.push_str("#### Parameters\n");
+                        for param in &func.params {
+                            docs.push_str(&format!("* *{}*\n", param.name));
+                        }
+                        docs.push('\n');
+                    }
+
+                    if func.named_params.len() > 0 {
+                        docs.push_str("#### Named parameters\n");
+                        for param in &func.named_params {
+                            docs.push_str(&format!("* *{}*\n", param.name));
+                        }
+                        docs.push('\n');
+                    }
 
                     if let Some(return_ty) = &func.return_ty {
                         docs.push_str("#### Returns\n");

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -358,6 +358,128 @@ mod tests {
     use insta_cmd::get_cargo_bin;
 
     #[test]
+    fn generate_html_docs() {
+        let input = r"
+        #! This is the x function.
+        let x = arg1 arg2 -> c
+        let fn_returns_array = -> <array> array
+        let fn_returns_bool = -> <bool> true
+        let fn_returns_float = -> <float> float
+        let fn_returns_int = -> <int> 0
+        let fn_returns_null = -> <null> null
+        let fn_returns_text = -> <text> 'text'
+
+        module foo {}
+
+        type user_id = int
+        ";
+
+        assert_cmd_snapshot!(prqlc_command().args(["experimental", "doc", "--format=html"]).pass_stdin(input), @r###"
+success: true
+exit_code: 0
+----- stdout -----
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="keywords" content="prql">
+    <meta name="generator" content="prqlc 0.13.1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <title>PRQL Docs</title>
+  </head>
+  <body>
+    <header class="bg-body-tertiary">
+      <div class="container">
+        <h1>Documentation</h1>
+      </div>
+    </header>
+    <main class="container">
+      <h2>Functions</h2>
+<ul>
+  <li><a href="#fn-x">x</a></li>
+  <li><a href="#fn-fn_returns_array">fn_returns_array</a></li>
+  <li><a href="#fn-fn_returns_bool">fn_returns_bool</a></li>
+  <li><a href="#fn-fn_returns_float">fn_returns_float</a></li>
+  <li><a href="#fn-fn_returns_int">fn_returns_int</a></li>
+  <li><a href="#fn-fn_returns_null">fn_returns_null</a></li>
+  <li><a href="#fn-fn_returns_text">fn_returns_text</a></li>
+</ul>
+
+<h2>Types</h2>
+<ul>
+  <li><code>user_id</code> – Primitive(Int)</li>
+</ul>
+<h2>Modules</h2>
+<ul>
+  <li>foo</li>
+</ul>
+<section>
+  <h3 id="fn-x">x</h3>
+<div class="ms-3">
+  <p> This is the x function.</p>
+  <h4 class="h6">Parameters</h4>
+  <ul>
+    <li><var>arg1</var></li>
+    <li><var>arg2</var></li>
+  </ul>
+</div>
+</section>
+<section>
+  <h3 id="fn-fn_returns_array">fn_returns_array</h3>
+<div class="ms-3">
+  <h4 class="h6">Returns</h4>
+  <p><code>array</code></p>
+</div>
+</section>
+<section>
+  <h3 id="fn-fn_returns_bool">fn_returns_bool</h3>
+<div class="ms-3">
+  <h4 class="h6">Returns</h4>
+  <p><code>bool</code></p>
+</div>
+</section>
+<section>
+  <h3 id="fn-fn_returns_float">fn_returns_float</h3>
+<div class="ms-3">
+  <h4 class="h6">Returns</h4>
+  <p><code>float</code></p>
+</div>
+</section>
+<section>
+  <h3 id="fn-fn_returns_int">fn_returns_int</h3>
+<div class="ms-3">
+  <h4 class="h6">Returns</h4>
+  <p><code>int</code></p>
+</div>
+</section>
+<section>
+  <h3 id="fn-fn_returns_null">fn_returns_null</h3>
+<div class="ms-3">
+  <h4 class="h6">Returns</h4>
+  <p><code>null</code></p>
+</div>
+</section>
+<section>
+  <h3 id="fn-fn_returns_text">fn_returns_text</h3>
+<div class="ms-3">
+  <h4 class="h6">Returns</h4>
+  <p><code>text</code></p>
+</div>
+</section>
+
+    </main>
+    <footer class="container border-top">
+      <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.1.</small>
+    </footer>
+  </body>
+</html>
+
+----- stderr -----
+        "###);
+    }
+
+    #[test]
     fn generate_markdown_docs() {
         let input = r"
         #! This is the x function.

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -130,7 +130,7 @@ pub fn generate_html_docs(stmts: Vec<Stmt>) -> String {
         if let Some(expr) = &var_def.value {
             match &expr.kind {
                 ExprKind::Func(func) => {
-                    if func.generic_type_params.len() > 0 {
+                    if !func.generic_type_params.is_empty() {
                         docs.push_str("  <h4 class=\"h6\">Type parameters</h4>\n");
                         docs.push_str("  <ul>\n");
                         for param in &func.generic_type_params {
@@ -139,7 +139,7 @@ pub fn generate_html_docs(stmts: Vec<Stmt>) -> String {
                         docs.push_str("  </ul>\n");
                     }
 
-                    if func.params.len() > 0 {
+                    if !func.params.is_empty() {
                         docs.push_str("  <h4 class=\"h6\">Parameters</h4>\n");
                         docs.push_str("  <ul>\n");
                         for param in &func.params {
@@ -148,7 +148,7 @@ pub fn generate_html_docs(stmts: Vec<Stmt>) -> String {
                         docs.push_str("  </ul>\n");
                     }
 
-                    if func.named_params.len() > 0 {
+                    if !func.named_params.is_empty() {
                         docs.push_str("  <h4 class=\"h6\">Named parameters</h4>\n");
                         docs.push_str("  <ul>\n");
                         for param in &func.named_params {
@@ -292,7 +292,7 @@ Generated with [prqlc](https://prql-lang.org/) {}.
         if let Some(expr) = &var_def.value {
             match &expr.kind {
                 ExprKind::Func(func) => {
-                    if func.generic_type_params.len() > 0 {
+                    if !func.generic_type_params.is_empty() {
                         docs.push_str("#### Type Parameters\n");
                         for param in &func.generic_type_params {
                             docs.push_str(&format!("* *{}*\n", param.name));
@@ -300,7 +300,7 @@ Generated with [prqlc](https://prql-lang.org/) {}.
                         docs.push('\n');
                     }
 
-                    if func.params.len() > 0 {
+                    if !func.params.is_empty() {
                         docs.push_str("#### Parameters\n");
                         for param in &func.params {
                             docs.push_str(&format!("* *{}*\n", param.name));
@@ -308,7 +308,7 @@ Generated with [prqlc](https://prql-lang.org/) {}.
                         docs.push('\n');
                     }
 
-                    if func.named_params.len() > 0 {
+                    if !func.named_params.is_empty() {
                         docs.push_str("#### Named parameters\n");
                         for param in &func.named_params {
                             docs.push_str(&format!("* *{}*\n", param.name));

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -518,7 +518,7 @@ impl Command {
                 io_args
             }
             Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => {
-                io_args.output.clone()
+                io_args
             }
             Experimental(ExperimentalCommand::Highlight(io_args)) => io_args,
             _ => unreachable!(),

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -222,10 +222,15 @@ enum DebugCommand {
 
 /// Experimental commands are prone to change
 #[derive(Subcommand, Debug, Clone)]
-pub enum ExperimentalCommand {
+enum ExperimentalCommand {
     /// Generate Markdown documentation
     #[command(name = "doc")]
-    GenerateDocs(IoArgs),
+    GenerateDocs {
+        #[command(flatten)]
+        io_args: IoArgs,
+        #[arg(value_enum, long, default_value = "markdown")]
+        format: DocsFormat,
+    },
 
     /// Syntax highlight
     #[command(name = "highlight")]
@@ -274,6 +279,12 @@ impl LogLevel for LoggingHelp {
     fn quiet_long_help() -> Option<&'static str> {
         Some("Silences logging output")
     }
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum DocsFormat {
+    Html,
+    Markdown,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -438,10 +449,13 @@ impl Command {
                     Format::Yaml => serde_yaml::to_string(&fc)?.into_bytes(),
                 }
             }
-            Command::Experimental(ExperimentalCommand::GenerateDocs(_)) => {
+            Command::Experimental(ExperimentalCommand::GenerateDocs { format, .. }) => {
                 let module_ref = prql_to_pl_tree(sources)?;
 
-                docs_generator::generate_markdown_docs(module_ref.stmts).into_bytes()
+                match format {
+                    DocsFormat::Html => docs_generator::generate_html_docs(module_ref.stmts).into_bytes(),
+                    DocsFormat::Markdown => docs_generator::generate_markdown_docs(module_ref.stmts).into_bytes()
+                }
             }
             Command::Experimental(ExperimentalCommand::Highlight(_)) => {
                 let s = sources.sources.values().exactly_one().or_else(|_| {
@@ -499,7 +513,7 @@ impl Command {
             | Debug(DebugCommand::Annotate(io_args) | DebugCommand::Lineage { io_args, .. }) => {
                 io_args
             }
-            Experimental(ExperimentalCommand::GenerateDocs(io_args)) => io_args,
+            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => io_args,
             Experimental(ExperimentalCommand::Highlight(io_args)) => io_args,
             _ => unreachable!(),
         };
@@ -535,7 +549,7 @@ impl Command {
             | Debug(DebugCommand::Annotate(io_args) | DebugCommand::Lineage { io_args, .. }) => {
                 io_args.output.clone()
             }
-            Experimental(ExperimentalCommand::GenerateDocs(io_args)) => io_args.output.clone(),
+            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => io_args.output.clone(),
             Experimental(ExperimentalCommand::Highlight(io_args)) => io_args.output.clone(),
             _ => unreachable!(),
         };

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -517,9 +517,7 @@ impl Command {
             | Debug(DebugCommand::Annotate(io_args) | DebugCommand::Lineage { io_args, .. }) => {
                 io_args
             }
-            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => {
-                io_args
-            }
+            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => io_args,
             Experimental(ExperimentalCommand::Highlight(io_args)) => io_args,
             _ => unreachable!(),
         };

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -453,8 +453,12 @@ impl Command {
                 let module_ref = prql_to_pl_tree(sources)?;
 
                 match format {
-                    DocsFormat::Html => docs_generator::generate_html_docs(module_ref.stmts).into_bytes(),
-                    DocsFormat::Markdown => docs_generator::generate_markdown_docs(module_ref.stmts).into_bytes()
+                    DocsFormat::Html => {
+                        docs_generator::generate_html_docs(module_ref.stmts).into_bytes()
+                    }
+                    DocsFormat::Markdown => {
+                        docs_generator::generate_markdown_docs(module_ref.stmts).into_bytes()
+                    }
                 }
             }
             Command::Experimental(ExperimentalCommand::Highlight(_)) => {
@@ -513,7 +517,9 @@ impl Command {
             | Debug(DebugCommand::Annotate(io_args) | DebugCommand::Lineage { io_args, .. }) => {
                 io_args
             }
-            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => io_args,
+            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => {
+                io_args.output.clone()
+            }
             Experimental(ExperimentalCommand::Highlight(io_args)) => io_args,
             _ => unreachable!(),
         };

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -555,7 +555,9 @@ impl Command {
             | Debug(DebugCommand::Annotate(io_args) | DebugCommand::Lineage { io_args, .. }) => {
                 io_args.output.clone()
             }
-            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => io_args.output.clone(),
+            Experimental(ExperimentalCommand::GenerateDocs { io_args, .. }) => {
+                io_args.output.clone()
+            }
             Experimental(ExperimentalCommand::Highlight(io_args)) => io_args.output.clone(),
             _ => unreachable!(),
         };

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-2.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-2.snap
@@ -1,4 +1,5 @@
 ---
+source: prqlc/prqlc/src/cli/test.rs
 info:
   program: prqlc
   args:
@@ -87,6 +88,7 @@ complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_s
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "doc" -d 'Generate Markdown documentation'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "highlight" -d 'Syntax highlight'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -l format -r -f -a "{html	'',markdown	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -s v -l verbose -d 'Increase logging verbosity'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -s q -l quiet -d 'Silences logging output'

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-3.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-3.snap
@@ -1,4 +1,5 @@
 ---
+source: prqlc/prqlc/src/cli/test.rs
 info:
   program: prqlc
   args:
@@ -195,6 +196,7 @@ Register-ArgumentCompleter -Native -CommandName 'prqlc' -ScriptBlock {
             break
         }
         'prqlc;experimental;doc' {
+            [CompletionResult]::new('--format', 'format', [CompletionResultType]::ParameterName, 'format')
             [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Controls when to use color')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-4.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-4.snap
@@ -1,4 +1,5 @@
 ---
+source: prqlc/prqlc/src/cli/test.rs
 info:
   program: prqlc
   args:
@@ -237,6 +238,7 @@ _arguments "${_arguments_options[@]}" \
         case $line[1] in
             (doc)
 _arguments "${_arguments_options[@]}" \
+'--format=[]:FORMAT:(html markdown)' \
 '--color=[Controls when to use color]:WHEN:(auto always never)' \
 '*-v[Increase logging verbosity]' \
 '*--verbose[Increase logging verbosity]' \

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion.snap
@@ -1,4 +1,5 @@
 ---
+source: prqlc/prqlc/src/cli/test.rs
 info:
   program: prqlc
   args:
@@ -433,12 +434,16 @@ _prqlc() {
             return 0
             ;;
         prqlc__experimental__doc)
-            opts="-v -q -h --color --verbose --quiet --help [INPUT] [OUTPUT] [MAIN_PATH]"
+            opts="-v -q -h --format --color --verbose --quiet --help [INPUT] [OUTPUT] [MAIN_PATH]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "html markdown" -- "${cur}"))
+                    return 0
+                    ;;
                 --color)
                     COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0


### PR DESCRIPTION
This PR adds a option to output the documentation generated by the experimental `prqlc` documentation generator in HTML format.

The option is given as `--format=html`.