### PR TITLE
refactor: Remove `source` arg from parser

### DIFF
--- a/prqlc/prqlc-parser/src/parser/mod.rs
+++ b/prqlc/prqlc-parser/src/parser/mod.rs
@@ -49,10 +49,9 @@ pub(crate) fn prepare_stream<'a>(
     let tokens = semantic_tokens
         .into_iter()
         .map(move |token| (token.kind, Span::new(source_id, token.span)));
-    let len = final_span;
     let eoi = Span {
-        start: len,
-        end: len + 1,
+        start: final_span,
+        end: final_span + 1,
         source_id,
     };
     Stream::from_iter(eoi, tokens)

--- a/prqlc/prqlc-parser/src/parser/mod.rs
+++ b/prqlc/prqlc-parser/src/parser/mod.rs
@@ -19,12 +19,8 @@ mod types;
 // Note that `parse_source` is in `prqlc` crate, not in `prqlc-parser` crate,
 // because it logs using the logging framework in `prqlc`.
 
-pub fn parse_lr_to_pr(
-    source: &str,
-    source_id: u16,
-    lr: Vec<lr::Token>,
-) -> (Option<Vec<pr::Stmt>>, Vec<Error>) {
-    let stream = prepare_stream(lr.into_iter(), source, source_id);
+pub fn parse_lr_to_pr(source_id: u16, lr: Vec<lr::Token>) -> (Option<Vec<pr::Stmt>>, Vec<Error>) {
+    let stream = prepare_stream(lr, source_id);
     let (pr, parse_errors) = stmt::source().parse_recovery(stream);
 
     let errors = parse_errors.into_iter().map(|e| e.into()).collect();
@@ -35,14 +31,15 @@ pub fn parse_lr_to_pr(
 
 /// Convert the output of the lexer into the input of the parser. Requires
 /// supplying the original source code.
-pub(crate) fn prepare_stream(
-    tokens: impl Iterator<Item = lr::Token>,
-    source: &str,
+pub(crate) fn prepare_stream<'a>(
+    tokens: Vec<lr::Token>,
     source_id: u16,
-) -> Stream<lr::TokenKind, Span, impl Iterator<Item = (lr::TokenKind, Span)> + Sized> {
+) -> Stream<'a, lr::TokenKind, Span, impl Iterator<Item = (lr::TokenKind, Span)> + Sized + 'a> {
+    let final_span = tokens.last().map(|t| t.span.end).unwrap_or(0);
+
     // We don't want comments in the AST (but we do intend to use them as part of
     // formatting)
-    let semantic_tokens = tokens.filter(|token| {
+    let semantic_tokens = tokens.into_iter().filter(|token| {
         !matches!(
             token.kind,
             lr::TokenKind::Comment(_) | lr::TokenKind::LineWrap(_)
@@ -52,7 +49,7 @@ pub(crate) fn prepare_stream(
     let tokens = semantic_tokens
         .into_iter()
         .map(move |token| (token.kind, Span::new(source_id, token.span)));
-    let len = source.chars().count();
+    let len = final_span;
     let eoi = Span {
         start: len,
         end: len + 1,

--- a/prqlc/prqlc-parser/src/parser/stmt.rs
+++ b/prqlc/prqlc-parser/src/parser/stmt.rs
@@ -307,7 +307,7 @@ mod tests {
             Error {
                 kind: Error,
                 span: Some(
-                    0:80-81,
+                    0:72-73,
                 ),
                 reason: Simple(
                     "unexpected end of input",

--- a/prqlc/prqlc-parser/src/parser/test.rs
+++ b/prqlc/prqlc-parser/src/parser/test.rs
@@ -27,7 +27,7 @@ fn test_prepare_stream() {
     let input = "from artists | filter name == 'John'";
     let tokens = lex_source(input).unwrap();
 
-    let mut stream = prepare_stream(tokens.0.into_iter(), input, 0);
+    let mut stream = prepare_stream(tokens.0, 0);
     assert_yaml_snapshot!(stream.fetch_tokens().collect::<Vec<(TokenKind, Span)>>(), @r###"
     ---
     - - Start

--- a/prqlc/prqlc-parser/src/test.rs
+++ b/prqlc/prqlc-parser/src/test.rs
@@ -15,7 +15,7 @@ pub(crate) fn parse_with_parser<O: Debug>(
     parser: impl Parser<TokenKind, O, Error = PError>,
 ) -> Result<O, Vec<Error>> {
     let tokens = crate::lexer::lex_source(source)?;
-    let stream = prepare_stream(tokens.0.into_iter(), source, 0);
+    let stream = prepare_stream(tokens.0, 0);
 
     // TODO: possibly should check we consume all the input? Either with an
     // end() parser or some other way (but if we add an end parser then this

--- a/prqlc/prqlc/src/parser.rs
+++ b/prqlc/prqlc/src/parser.rs
@@ -63,7 +63,7 @@ pub(crate) fn parse_source(source: &str, source_id: u16) -> Result<Vec<pr::Stmt>
     let ast = if let Some(tokens) = tokens {
         debug::log_entry(|| debug::DebugEntryKind::ReprLr(lr::Tokens(tokens.clone())));
 
-        let (ast, parse_errors) = prqlc_parser::parser::parse_lr_to_pr(source, source_id, tokens);
+        let (ast, parse_errors) = prqlc_parser::parser::parse_lr_to_pr(source_id, tokens);
         errors.extend(parse_errors);
         ast
     } else {


### PR DESCRIPTION
Unnecessary to pass `source` to parser functions; only using it to get the length, which we can get from the final span
