### PR TITLE
internal: Use span with zero len for EOI

### DIFF
--- a/prqlc/prqlc-parser/src/parser/mod.rs
+++ b/prqlc/prqlc-parser/src/parser/mod.rs
@@ -51,7 +51,7 @@ pub(crate) fn prepare_stream<'a>(
         .map(move |token| (token.kind, Span::new(source_id, token.span)));
     let eoi = Span {
         start: final_span,
-        end: final_span + 1,
+        end: final_span,
         source_id,
     };
     Stream::from_iter(eoi, tokens)

--- a/prqlc/prqlc-parser/src/parser/perror.rs
+++ b/prqlc/prqlc-parser/src/parser/perror.rs
@@ -196,15 +196,7 @@ impl<T: fmt::Display + Hash + Eq + Debug> fmt::Display for ChumError<T> {
 
 impl From<PError> for Error {
     fn from(p: PError) -> Error {
-        let mut span = p.span();
-
-        if p.found().is_none() {
-            // found end of file
-            // fix for span outside of source
-            if span.start > 0 && span.end > 0 {
-                span = span - 1;
-            }
-        }
+        let span = p.span();
 
         fn construct_parser_error(e: PError) -> Error {
             if let Some(message) = e.reason() {

--- a/prqlc/prqlc-parser/src/parser/stmt.rs
+++ b/prqlc/prqlc-parser/src/parser/stmt.rs
@@ -307,7 +307,7 @@ mod tests {
             Error {
                 kind: Error,
                 span: Some(
-                    0:72-73,
+                    0:73-73,
                 ),
                 reason: Simple(
                     "unexpected end of input",

--- a/prqlc/prqlc/tests/integration/error_messages.rs
+++ b/prqlc/prqlc/tests/integration/error_messages.rs
@@ -84,11 +84,11 @@ fn test_errors() {
        │                                    ╰── unexpected ’
     ───╯
     Error:
-       ╭─[:1:38]
+       ╭─[:1:39]
        │
      1 │ Mississippi has four S’s and four I’s.
-       │                                      ┬
-       │                                      ╰── Expected * or an identifier, but didn't find anything before the end.
+       │                                       │
+       │                                       ╰─ Expected * or an identifier, but didn't find anything before the end.
     ───╯
     "###);
 


### PR DESCRIPTION
This avoids creating a span out of bounds which then needs fixing
