### PR TITLE
refactor: Use `Option<Box<T>>`

### DIFF
--- a/prqlc/prqlc-parser/src/parser/pr/types.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/types.rs
@@ -105,7 +105,7 @@ pub enum PrimitiveSet {
 pub struct TyFunc {
     pub name_hint: Option<Ident>,
     pub params: Vec<Option<Ty>>,
-    pub return_ty: Box<Option<Ty>>,
+    pub return_ty: Option<Box<Ty>>,
 }
 
 impl Ty {

--- a/prqlc/prqlc-parser/src/parser/types.rs
+++ b/prqlc/prqlc-parser/src/parser/types.rs
@@ -29,7 +29,7 @@ pub(crate) fn type_expr() -> impl Parser<TokenKind, Ty, Error = PError> + Clone 
                     .map(Some)
                     .repeated()
                     .then_ignore(just(TokenKind::ArrowThin))
-                    .then(nested_type_expr.clone().map(Some).map(Box::new))
+                    .then(nested_type_expr.clone().map(Box::new).map(Some))
                     .map(|(params, return_ty)| TyFunc {
                         name_hint: None,
                         params,

--- a/prqlc/prqlc/src/codegen/types.rs
+++ b/prqlc/prqlc/src/codegen/types.rs
@@ -75,7 +75,7 @@ impl WriteSource for pr::TyKind {
                     r += " ";
                 }
                 r += "-> ";
-                r += &(*func.return_ty).as_ref().write(opt)?;
+                r += &func.return_ty.as_deref().write(opt)?;
                 Some(r)
             }
             Any => Some("anytype".to_string()),

--- a/prqlc/prqlc/src/ir/pl/fold.rs
+++ b/prqlc/prqlc/src/ir/pl/fold.rs
@@ -339,7 +339,7 @@ pub fn fold_type<T: ?Sized + PlFold>(fold: &mut T, ty: Ty) -> Result<Ty> {
                             .into_iter()
                             .map(|a| fold_type_opt(fold, a))
                             .try_collect()?,
-                        return_ty: Box::new(fold_type_opt(fold, *f.return_ty)?),
+                        return_ty: fold_type_opt(fold, f.return_ty.map(|x| *x))?.map(Box::new),
                         name_hint: f.name_hint,
                     })
                 })

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -547,7 +547,7 @@ impl Resolver<'_> {
             TransformKind::Window { pipeline, .. } | TransformKind::Loop(pipeline) => {
                 let pipeline = pipeline.ty.clone().unwrap();
                 let pipeline = pipeline.kind.into_function().unwrap().unwrap();
-                *pipeline.return_ty
+                pipeline.return_ty.map(|x| *x)
             }
             TransformKind::Append(bottom) => {
                 let top = transform_call.input.ty.clone().unwrap();


### PR DESCRIPTION
I was trying to understand more about `.as_deref` and used prqlc code as a learning ground. 

It seems `Option<Box<T>>` is supposed to be more idiomatic than `Box<Option<T>>`. This makes a few changes in that direction (mostly as a practical exercise for me, but hopefully a marginal improvement in our code too).

(That said, because we're mostly using moves rather than references, it only seems to have a positive impact in a couple of places, no objection if we don't merge