### PR TITLE
fix: Escape aliases when required

### DIFF
--- a/prqlc/prqlc/src/codegen/ast.rs
+++ b/prqlc/prqlc/src/codegen/ast.rs
@@ -649,7 +649,7 @@ aggregate average_country_salary = (
         assert_is_formatted(
             r#"
 from artists
-select {`customer name` = foo}"#,
+select {`customer name` = foo, x = bar.baz}"#,
         );
     }
 


### PR DESCRIPTION
Changes a function name to make it clearer too

Closes #4812