### PR TITLE
feat: Add XML documentation

### DIFF
--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -197,11 +197,10 @@ pub fn generate_html_docs(stmts: Vec<Stmt>) -> String {
 
 /// Generate XML documentation.
 pub fn generate_xml_docs(stmts: Vec<Stmt>) -> String {
-    let mut docs = format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+    let mut docs = r#"<?xml version="1.0" encoding="UTF-8"?>
 <docs>
 "#
-    );
+    .to_string();
 
     if stmts
         .clone()
@@ -334,7 +333,7 @@ pub fn generate_xml_docs(stmts: Vec<Stmt>) -> String {
                     }
 
                     if let Some(return_ty) = &func.return_ty {
-                        docs.push_str(&"      <returns");
+                        docs.push_str("      <returns");
                         match &return_ty.kind {
                             TyKind::Any => docs.push_str("/>\n"),
                             TyKind::Ident(ident) => {

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -294,6 +294,7 @@ impl LogLevel for LoggingHelp {
 enum DocsFormat {
     Html,
     Markdown,
+    Xml,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -467,6 +468,9 @@ impl Command {
                     }
                     DocsFormat::Markdown => {
                         docs_generator::generate_markdown_docs(module_ref.stmts).into_bytes()
+                    }
+                    DocsFormat::Xml => {
+                        docs_generator::generate_xml_docs(module_ref.stmts).into_bytes()
                     }
                 }
             }

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-2.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-2.snap
@@ -88,7 +88,7 @@ complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_s
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "doc" -d 'Generate Markdown documentation'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "highlight" -d 'Syntax highlight'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and not __fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from highlight; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -l format -r -f -a "{html	'',markdown	''}"
+complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -l format -r -f -a "{html	'',markdown	'',xml	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -l color -d 'Controls when to use color' -r -f -a "{auto	'',always	'',never	''}"
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -s v -l verbose -d 'Increase logging verbosity'
 complete -c prqlc -n "__fish_seen_subcommand_from experimental; and __fish_seen_subcommand_from doc" -s q -l quiet -d 'Silences logging output'

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-4.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion-4.snap
@@ -238,7 +238,7 @@ _arguments "${_arguments_options[@]}" \
         case $line[1] in
             (doc)
 _arguments "${_arguments_options[@]}" \
-'--format=[]:FORMAT:(html markdown)' \
+'--format=[]:FORMAT:(html markdown xml)' \
 '--color=[Controls when to use color]:WHEN:(auto always never)' \
 '*-v[Increase logging verbosity]' \
 '*--verbose[Increase logging verbosity]' \

--- a/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion.snap
+++ b/prqlc/prqlc/src/cli/snapshots/prqlc__cli__test__shell_completion.snap
@@ -441,7 +441,7 @@ _prqlc() {
             fi
             case "${prev}" in
                 --format)
-                    COMPREPLY=($(compgen -W "html markdown" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "html markdown xml" -- "${cur}"))
                     return 0
                     ;;
                 --color)


### PR DESCRIPTION
This PR adds a option to generate `.prql` documentation in XML format which is suitable for transformation using XSLT or querying using XPath, XQuery, XPointer, etc for integration with documentation tools, IDE or language servers or whatever.