### PR TITLE
fix: Retain raw strings through `fmt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1269,8 +1269,8 @@ below in this release).
 
 **Documentation**:
 
-[This release, the changelog only contains a subset of documentation
-improvements]
+[This release, the changelog only contains a subset of
+documentation improvements]
 
 - Add docs on aliases in
   [Select](https://prql-lang.org/book/reference/stdlib/transforms/select.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 **Fixes**:
 
+- Raw strings (`r"..."`) are retained through `prqlc fmt` (@max-sixty)
+
 **Documentation**:
 
 **Web**:
@@ -1267,8 +1269,8 @@ below in this release).
 
 **Documentation**:
 
-[This release, the changelog only contains a subset of
-documentation improvements]
+[This release, the changelog only contains a subset of documentation
+improvements]
 
 - Add docs on aliases in
   [Select](https://prql-lang.org/book/reference/stdlib/transforms/select.html)

--- a/prqlc/prqlc-parser/src/lexer/lr.rs
+++ b/prqlc/prqlc-parser/src/lexer/lr.rs
@@ -84,6 +84,7 @@ pub enum Literal {
     Float(f64),
     Boolean(bool),
     String(String),
+    RawString(String),
     Date(String),
     Time(String),
     Timestamp(String),
@@ -113,7 +114,11 @@ impl std::fmt::Display for Literal {
             Literal::Float(i) => write!(f, "{i}")?,
 
             Literal::String(s) => {
-                quote_string(s, f)?;
+                write!(f, "{}", quote_string(escape_all_except_quotes(s).as_str()))?;
+            }
+
+            Literal::RawString(s) => {
+                write!(f, "r{}", quote_string(s))?;
             }
 
             Literal::Boolean(b) => {
@@ -132,15 +137,13 @@ impl std::fmt::Display for Literal {
     }
 }
 
-fn quote_string(s: &str, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let s = escape_all_except_quotes(s);
-
+fn quote_string(s: &str) -> String {
     if !s.contains('"') {
-        return write!(f, r#""{s}""#);
+        return format!(r#""{}""#, s);
     }
 
     if !s.contains('\'') {
-        return write!(f, "'{s}'");
+        return format!("'{}'", s);
     }
 
     // when string contains both single and double quotes
@@ -149,7 +152,7 @@ fn quote_string(s: &str, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     while s.contains(&quotes) {
         quotes += "\"";
     }
-    write!(f, "{quotes}{s}{quotes}")
+    format!("{}{}{}", quotes, s, quotes)
 }
 
 fn escape_all_except_quotes(s: &str) -> String {
@@ -162,6 +165,20 @@ fn escape_all_except_quotes(s: &str) -> String {
         }
     }
     result
+}
+
+#[test]
+fn test_quote_string() {
+    use insta::assert_snapshot;
+    assert_snapshot!(("foo\nbar" ), @r###"
+    foo
+    bar
+    "###);
+    assert_snapshot!(quote_string("foo\nbar" ), @r###"
+    "foo
+    bar"
+    "###);
+    assert_snapshot!(quote_string(r#"foo\nbar"# ), @r###""foo\nbar""###);
 }
 
 // This is here because Literal::Float(f64) does not implement Hash, so we cannot simply derive it.

--- a/prqlc/prqlc-parser/src/lexer/lr.rs
+++ b/prqlc/prqlc-parser/src/lexer/lr.rs
@@ -167,20 +167,6 @@ fn escape_all_except_quotes(s: &str) -> String {
     result
 }
 
-#[test]
-fn test_quote_string() {
-    use insta::assert_snapshot;
-    assert_snapshot!(("foo\nbar" ), @r###"
-    foo
-    bar
-    "###);
-    assert_snapshot!(quote_string("foo\nbar" ), @r###"
-    "foo
-    bar"
-    "###);
-    assert_snapshot!(quote_string(r#"foo\nbar"# ), @r###""foo\nbar""###);
-}
-
 // This is here because Literal::Float(f64) does not implement Hash, so we cannot simply derive it.
 // There are reasons for that, but chumsky::Error needs Hash for the TokenKind, so it can deduplicate
 // tokens in error.

--- a/prqlc/prqlc-parser/src/lexer/mod.rs
+++ b/prqlc/prqlc-parser/src/lexer/mod.rs
@@ -284,7 +284,7 @@ fn literal() -> impl Parser<char, Literal, Error = Cheap<char>> {
 
     let raw_string = just("r")
         .ignore_then(quoted_string(false))
-        .map(Literal::String);
+        .map(Literal::RawString);
 
     let bool = (just("true").to(true))
         .or(just("false").to(false))

--- a/prqlc/prqlc-parser/src/parser/test.rs
+++ b/prqlc/prqlc-parser/src/parser/test.rs
@@ -412,7 +412,7 @@ fn test_string() {
     assert_yaml_snapshot!(parse_expr(r#"r" \nU S A ""#).unwrap(), @r###"
     ---
     Literal:
-      String: " \\nU S A "
+      RawString: " \\nU S A "
     span: "0:0-12"
     "###);
 

--- a/prqlc/prqlc-parser/src/test.rs
+++ b/prqlc/prqlc-parser/src/test.rs
@@ -1185,7 +1185,7 @@ fn test_multiline_string() {
               span: "0:9-15"
             args:
               - Literal:
-                  String: r-string test
+                  RawString: r-string test
                 span: "0:20-36"
                 alias: x
           span: "0:9-36"

--- a/prqlc/prqlc/src/codegen/mod.rs
+++ b/prqlc/prqlc/src/codegen/mod.rs
@@ -210,33 +210,47 @@ mod test {
 
     #[test]
     fn test_string_quoting() {
-        fn mk_str(s: &str) -> Expr {
+        // TODO: add some test for escapes
+        fn make_str(s: &str) -> Expr {
             Expr::new(ExprKind::Literal(Literal::String(s.to_string())))
         }
 
         assert_snapshot!(
-            write_expr(&mk_str("hello")),
+            write_expr(&make_str("hello")),
             @r###""hello""###
         );
 
         assert_snapshot!(
-            write_expr(&mk_str(r#"he's nice"#)),
+            write_expr(&make_str(r#"he's nice"#)),
             @r###""he's nice""###
         );
 
         assert_snapshot!(
-            write_expr(&mk_str(r#"he said "what up""#)),
+            write_expr(&make_str(r#"he said "what up""#)),
             @r###"'he said "what up"'"###
         );
 
         assert_snapshot!(
-            write_expr(&mk_str(r#"he said "what's up""#)),
+            write_expr(&make_str(r#"he said "what's up""#)),
             @r###"""he said "what's up""""###
         );
 
         assert_snapshot!(
-            write_expr(&mk_str(r#" single' three double""" found double"""" "#)),
+            write_expr(&make_str(r#" single' three double""" found double"""" "#)),
             @r###"""""" single' three double""" found double"""" """"""###
+        );
+    }
+
+    #[test]
+    fn test_raw_string_quoting() {
+        // TODO: add some test for escapes
+        fn make_str(s: &str) -> Expr {
+            Expr::new(ExprKind::Literal(Literal::RawString(s.to_string())))
+        }
+
+        assert_snapshot!(
+            write_expr(&make_str("hello")),
+            @r###"r"hello""###
         );
     }
 }

--- a/prqlc/prqlc/src/semantic/resolver/types.rs
+++ b/prqlc/prqlc/src/semantic/resolver/types.rs
@@ -23,6 +23,7 @@ impl Resolver<'_> {
                 Literal::Float(_) => TyKind::Primitive(PrimitiveSet::Float),
                 Literal::Boolean(_) => TyKind::Primitive(PrimitiveSet::Bool),
                 Literal::String(_) => TyKind::Primitive(PrimitiveSet::Text),
+                Literal::RawString(_) => TyKind::Primitive(PrimitiveSet::Text),
                 Literal::Date(_) => TyKind::Primitive(PrimitiveSet::Date),
                 Literal::Time(_) => TyKind::Primitive(PrimitiveSet::Time),
                 Literal::Timestamp(_) => TyKind::Primitive(PrimitiveSet::Timestamp),

--- a/prqlc/prqlc/src/sql/gen_expr.rs
+++ b/prqlc/prqlc/src/sql/gen_expr.rs
@@ -380,7 +380,9 @@ fn operator_from_name(name: &str) -> Option<BinaryOperator> {
 pub(super) fn translate_literal(l: Literal, ctx: &Context) -> Result<sql_ast::Expr> {
     Ok(match l {
         Literal::Null => sql_ast::Expr::Value(Value::Null),
-        Literal::String(s) => sql_ast::Expr::Value(Value::SingleQuotedString(s)),
+        Literal::String(s) | Literal::RawString(s) => {
+            sql_ast::Expr::Value(Value::SingleQuotedString(s))
+        }
         Literal::Boolean(b) => sql_ast::Expr::Value(Value::Boolean(b)),
         Literal::Float(f) => sql_ast::Expr::Value(Value::Number(format!("{f:?}"), false)),
         Literal::Integer(i) => sql_ast::Expr::Value(Value::Number(format!("{i}"), false)),


### PR DESCRIPTION
Part of https://github.com/PRQL/prql/issues/4838
