### PR TITLE
docs: the duckdb extension is now easy to install and use

### DIFF
--- a/web/book/src/project/integrations/duckdb.md
+++ b/web/book/src/project/integrations/duckdb.md
@@ -1,8 +1,8 @@
 # DuckDB
 
 There's a [DuckDB](https://duckdb.org/) community extension by
-**[@ywelsch](https://github.com/ywelsch)** at
-the DuckDB Community Extension Repository.
+**[@ywelsch](https://github.com/ywelsch)** at the DuckDB Community Extension
+Repository.
 
 ```sql
 INSTALL prql FROM community;
@@ -13,4 +13,6 @@ filter invoice_date >= @2009-02-01
 take 5;
 ```
 
-Check out the [extension's documentation](https://community-extensions.duckdb.org/extensions/prql.html) for more details.
+Check out the
+[extension's documentation](https://community-extensions.duckdb.org/extensions/prql.html)
+for more details.

--- a/web/book/src/project/integrations/duckdb.md
+++ b/web/book/src/project/integrations/duckdb.md
@@ -1,7 +1,16 @@
 # DuckDB
 
-There's an experimental [DuckDB](https://duckdb.org/) extension from
+There's a [DuckDB](https://duckdb.org/) community extension by
 **[@ywelsch](https://github.com/ywelsch)** at
-[ywelsch/duckdb-prql](https://github.com/ywelsch/duckdb-prql).
+the DuckDB Community Extension Repository.
 
-Check out the Readme for more details.
+```sql
+INSTALL prql FROM community;
+LOAD prql;
+-- Once the extension is loaded, you can write PRQL queries
+from (read_csv 'https://raw.githubusercontent.com/PRQL/prql/0.8.0/prql-compiler/tests/integration/data/chinook/invoices.csv')
+filter invoice_date >= @2009-02-01
+take 5;
+```
+
+Check out the [extension's documentation](https://community-extensions.duckdb.org/extensions/prql.html) for more details.


### PR DESCRIPTION
Thanks to DuckDB's amazing extension mechanism, the PRQL extension is easy to install and use now (although it is not yet available in wasm).