### PR TITLE
ci: Don't start from old caches in CI

### DIFF
--- a/.github/actions/build-prqlc-c/action.yaml
+++ b/.github/actions/build-prqlc-c/action.yaml
@@ -31,12 +31,12 @@ runs:
 
     - uses: Swatinem/rust-cache@v2
       with:
+        prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
         # Share cache with `test-rust`, except for `musl` targets.
         save-if:
           ${{ (github.ref == 'refs/heads/main') && contains(inputs.target,
           'musl') }}
         shared-key: rust-${{ inputs.target }}
-        prefix-key: ${{ env.version }}
 
     - if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/build-prqlc/action.yaml
+++ b/.github/actions/build-prqlc/action.yaml
@@ -30,12 +30,12 @@ runs:
 
     - uses: Swatinem/rust-cache@v2
       with:
+        prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
         # Share cache with `test-rust`, except for `musl` targets.
         save-if:
           ${{ (github.ref == 'refs/heads/main') && contains(inputs.target,
           'musl') }}
         shared-key: rust-${{ inputs.target }}
-        prefix-key: ${{ env.version }}
 
     - if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/time-compilation/action.yaml
+++ b/.github/actions/time-compilation/action.yaml
@@ -15,8 +15,8 @@ runs:
       id: cache
       uses: Swatinem/rust-cache@v2
       with:
+        prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: ${{ env.version }}
       # 'true' seems to require quotes (and using a bare `inputs.use_cache`
       # doesn't work); I'm really not sure why. There are some issues on the
       # interwebs around this, but I couldn't find one that explained it.

--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           shared-key: web
           save-if:
             ${{ github.ref == 'refs/heads/web' || github.ref ==

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -350,7 +350,7 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           # Share key with the `build-web` job
           shared-key: web
           save-if: false

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
           shared-key: lib
       - name: Maven test

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         id: cache
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           # `web` is the closest rust cache key. It's useful on ubuntu (last
           # checked, roughly halved the time, to 4 min), but not on other OSs
           # given we don't have those caches. We can't use a separate one given

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
           shared-key: lib
       - run: task build-php

--- a/.github/workflows/test-prqlc-c.yaml
+++ b/.github/workflows/test-prqlc-c.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
           shared-key: lib
       - name: Build

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -61,7 +61,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
         id: cache
         with:
-          prefix-key: ${{ env.version }}
+          # We add the hash of the Cargo.lock file to the key, to prevent the
+          # gradual accumulation of disk space that comes from using previous
+          # caches. The rust cache is designed to remove old packages, but isn't
+          # that successful at it, and our current cache size at ~1.3GB is about
+          # as much as GHA can handle, such that if we hold old packages, it
+          # balloons to 2GB and fails. Some discussion at:
+          # https://github.com/Swatinem/rust-cache/issues/177
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           shared-key: rust-${{ inputs.target }}
           # Don't save if empty features, because we run a test with empty
           # features on linux, and don't want to save that instead of the one

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -278,7 +278,7 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           # The mac rust cache key. It's not _that_ useful since this will build
           # much more, but it's better than nothing. This task can't have our own
           # cache, since we're out of cache space and this workflow takes 1.5GB.
@@ -393,7 +393,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ env.version }}
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           shared-key: web
           # Created by `build-web`
           save-if: false
@@ -416,8 +416,8 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          prefix-key: ${{ env.version }}
       # Ensure nothing remains from caching
       - run: cargo llvm-cov clean --workspace
       - run:
@@ -542,8 +542,8 @@ jobs:
       - name: 💰 Cache
         uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: ${{ env.version }}-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          prefix-key: ${{ env.version }}
       - name: Verify minimum rust version
         run: cargo minimal-versions test --direct
 


### PR DESCRIPTION
Notes inline. Means dependency changes will take longer to test, but also CI will be much more resilient, and not reliant on me to clear old caches
