### PR TITLE
build: Update Dockerfile from bullseye to bookworm

### DIFF
--- a/.devcontainer/base-image/Dockerfile
+++ b/.devcontainer/base-image/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
 
 # ========= Install cargo-tools for non-root user (vscode) =========
 USER vscode


### PR DESCRIPTION
This updates the Dockerfile to move on from the old Debian 11 "bullseye" to the new Debian 12 "bookwork".