### PR TITLE
docs: Update Readme & Taskfile for external dbs tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -359,7 +359,7 @@ tasks:
         --nocapture queries::results
       # We could run this ourselves, but makes iteration times much longer
       - cmd: |
-          echo "🔵 To stop containers and remove images, run 
+          echo "🔵 To stop containers and remove images, run
 
           cd prqlc/prqlc/tests/integration/dbs && docker-compose down --rmi local"
         silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -344,6 +344,16 @@ tasks:
       - cargo llvm-cov --lcov --output-path lcov.info
         --features=default,test-dbs
 
+  test-rust-external-dbs:
+    desc: Run tests which require external databases, with docker
+    cmds:
+      - cd prqlc/prqlc/tests/integration/dbs && docker-compose up -d
+      # This _only_ runs the external dbs tests, but we could make it run
+      # everything?
+      - cargo test --features=test-dbs-external --test=integration --
+        --nocapture queries::results
+      - cd prqlc/prqlc/tests/integration/dbs && docker compose down
+
   test-js:
     dir: prqlc/bindings/js
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -347,12 +347,22 @@ tasks:
   test-rust-external-dbs:
     desc: Run tests which require external databases, with docker
     cmds:
-      - cd prqlc/prqlc/tests/integration/dbs && docker-compose up -d
+      - cmd:
+          echo "🔵 Starting docker containers. In some circumstances the tests
+          will start before images are ready. After one initial failure, try
+          re-running."
+        silent: true
+      - cd prqlc/prqlc/tests/integration/dbs && docker-compose up --wait
       # This _only_ runs the external dbs tests, but we could make it run
       # everything?
       - cargo test --features=test-dbs-external --test=integration --
         --nocapture queries::results
-      - cd prqlc/prqlc/tests/integration/dbs && docker compose down
+      # We could run this ourselves, but makes iteration times much longer
+      - cmd: |
+          echo "🔵 To stop containers and remove images, run 
+
+          cd prqlc/prqlc/tests/integration/dbs && docker-compose down --rmi local"
+        silent: true
 
   test-js:
     dir: prqlc/bindings/js

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -359,9 +359,9 @@ tasks:
         --nocapture queries::results
       # We could run this ourselves, but makes iteration times much longer
       - cmd: |
-          echo "🔵 To stop containers and remove images, run
+          echo "🔵 To remove containers and remove local built images, run
 
-          cd prqlc/prqlc/tests/integration/dbs && docker-compose down --rmi local"
+          cd prqlc/prqlc/tests/integration/dbs && docker compose down --rmi local"
         silent: true
 
   test-js:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -352,7 +352,7 @@ tasks:
           will start before images are ready. After one initial failure, try
           re-running."
         silent: true
-      - cd prqlc/prqlc/tests/integration/dbs && docker-compose up --wait
+      - cd prqlc/prqlc/tests/integration/dbs && docker compose up --wait
       # This _only_ runs the external dbs tests, but we could make it run
       # everything?
       - cargo test --features=test-dbs-external --test=integration --

--- a/prqlc/prqlc/tests/integration/dbs/README.md
+++ b/prqlc/prqlc/tests/integration/dbs/README.md
@@ -35,7 +35,7 @@ manually:
    (The `--no-capture` option isn't required, but shows all the dialects tested
    per query.)
 
-3. After it's done, stop the containers and remove local images and volumes:
+3. After it's done, remove the containers:
 
    ```sh
    cd prqlc/prqlc/tests/integration/dbs && docker compose down

--- a/prqlc/prqlc/tests/integration/dbs/README.md
+++ b/prqlc/prqlc/tests/integration/dbs/README.md
@@ -19,23 +19,22 @@ ClickHouse and GlareDB are tested — we use `docker compose`:
 1. Run `docker compose up` (may take a while on the first time):
 
    ```sh
-   cd prqlc/prqlc/tests/integration
-   docker compose up
+   cd prqlc/prqlc/tests/integration/dbs && docker compose up -d
    ```
 
 2. Run the tests:
 
    ```sh
-   cargo test --features=test-dbs-external --no-capture
+   cargo test --features=test-dbs-external -- --nocapture
    ```
 
-   The `--no-capture` option isn't required, but shows all the dialects tested
-   per query.
+   (The `--no-capture` option isn't required, but shows all the dialects tested
+   per query.)
 
 3. After it's done, stop the containers and remove local images and volumes:
 
    ```sh
-   docker compose down -v --rmi local
+   cd prqlc/prqlc/tests/integration/dbs && docker compose down
    ```
 
 Note: on an M1, if the MSSQL docker container doesn't run, refer to

--- a/prqlc/prqlc/tests/integration/dbs/README.md
+++ b/prqlc/prqlc/tests/integration/dbs/README.md
@@ -14,7 +14,11 @@ cargo test --features=test-dbs
 ## External DBs
 
 To run tests against external databases — currently Postgres, MySQL, SQL Server,
-ClickHouse and GlareDB are tested — we use `docker compose`:
+ClickHouse and GlareDB are tested using `docker compose` to create the
+databases.
+
+The steps are all covered by `task test-rust-external-dbs`; to run them
+manually:
 
 1. Run `docker compose up` (may take a while on the first time):
 


### PR DESCRIPTION
I don't think the instructions were quite correct. Reinforces that having tests > scripts > docs...
