### PR TITLE
ci: Temporarily disable taskfile test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -270,8 +270,8 @@ jobs:
       # don't want to have to run it on, for example, every dependency change.
       #
       # Disabling due to https://github.com/PRQL/prql/pull/4876
-      false && (needs.rules.outputs.taskfile == 'true' ||
-      needs.rules.outputs.nightly-upstream == 'true')
+      "'false' && needs.rules.outputs.taskfile == 'true' ||
+      needs.rules.outputs.nightly-upstream == 'true'"
     runs-on: macos-14
     steps:
       - name: 📂 Checkout code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -270,8 +270,8 @@ jobs:
       # don't want to have to run it on, for example, every dependency change.
       #
       # Disabling due to https://github.com/PRQL/prql/pull/4876
-      false && needs.rules.outputs.taskfile == 'true' ||
-      needs.rules.outputs.nightly-upstream == 'true'
+      false && (needs.rules.outputs.taskfile == 'true' ||
+      needs.rules.outputs.nightly-upstream == 'true')
     runs-on: macos-14
     steps:
       - name: 📂 Checkout code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -270,8 +270,8 @@ jobs:
       # don't want to have to run it on, for example, every dependency change.
       #
       # Disabling due to https://github.com/PRQL/prql/pull/4876
-      "'false' && needs.rules.outputs.taskfile == 'true' ||
-      needs.rules.outputs.nightly-upstream == 'true'"
+      (1 == 0) && needs.rules.outputs.taskfile == 'true' ||
+      needs.rules.outputs.nightly-upstream == 'true'
     runs-on: macos-14
     steps:
       - name: 📂 Checkout code


### PR DESCRIPTION
Seems that `||` binds closer than `&&` in GHA? Or there's another mistake; we'll see. Closes #4886
