### PR TITLE
ci: Try disabling taskfile test again

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -270,8 +270,9 @@ jobs:
       # don't want to have to run it on, for example, every dependency change.
       #
       # Disabling due to https://github.com/PRQL/prql/pull/4876
-      (1 == 0) && needs.rules.outputs.taskfile == 'true' ||
-      needs.rules.outputs.nightly-upstream == 'true'
+      false
+      # needs.rules.outputs.taskfile == 'true' ||
+      # needs.rules.outputs.nightly-upstream == 'true'
     runs-on: macos-14
     steps:
       - name: 📂 Checkout code


### PR DESCRIPTION
Really not sure why the previous attempt didn't work; am I missing something very obvious?
