### PR TITLE
fix(web): correct likely logic error in example

### DIFF
--- a/web/website/data/examples/expressions.yaml
+++ b/web/website/data/examples/expressions.yaml
@@ -2,7 +2,7 @@ label: Expressions
 prql: |
   from track_plays
   derive {
-    finished = started + unfinished,
+    finished = started - unfinished,
     fin_share = finished / started,        # Use previous definitions
     fin_ratio = fin_share / (1-fin_share), # BTW, hanging commas are optional!
   }
@@ -10,9 +10,9 @@ prql: |
 sql: |
   SELECT
     *,
-    started + unfinished AS finished,
-    (started + unfinished) / started AS fin_share,
-    (started + unfinished) / started / (1 - (started + unfinished) / started)
+    started - unfinished AS finished,
+    (started - unfinished) / started AS fin_share,
+    (started - unfinished) / started / (1 - (started - unfinished) / started)
      AS fin_ratio
   FROM
     track_plays


### PR DESCRIPTION
It's more intuitive to calculate finished as all that are started minus the unfinished ones. There's no clear right or wrong here as this is just example code but it doesn't harm to make it non-surprising.

The invariant is likely: `started = finished + unfinished `