### PR TITLE
fix(prqlc-python): fix the `display` option works

### DIFF
--- a/prqlc/bindings/prqlc-python/src/lib.rs
+++ b/prqlc/bindings/prqlc-python/src/lib.rs
@@ -12,12 +12,8 @@ pub fn compile(prql_query: &str, options: Option<CompileOptions>) -> PyResult<St
         ));
     };
 
-    Ok(prql_query)
-        .and_then(prqlc_lib::prql_to_pl)
-        .and_then(prqlc_lib::pl_to_rq)
-        .and_then(|rq| prqlc_lib::rq_to_sql(rq, &options.unwrap_or_default()))
-        .map_err(|e| e.composed(&prql_query.into()))
-        .map_err(|e| (PyErr::new::<exceptions::PyValueError, _>(e.to_string())))
+    prqlc_lib::compile(prql_query, &options.unwrap_or_default())
+        .map_err(|err| (PyErr::new::<exceptions::PyValueError, _>(err.to_string())))
 }
 
 #[pyfunction]


### PR DESCRIPTION
A follow up for #4333
So far the display option has not worked.

```python
import prqlc
options1 = prqlc.CompileOptions(
    format=True, signature_comment=True, target="sql.postgres", display='plain'
)
options2 = prqlc.CompileOptions(
    format=True, signature_comment=True, target="sql.postgres", display='ansi_color'
)
prqlc.compile("from a | select")
prqlc.compile("from a | select", options=options1)
prqlc.compile("from a | select", options=options2)
```

![image](https://github.com/user-attachments/assets/9741e405-397e-4384-b61b-855600c3ef00)

By the way I do not know the best way to test this option.
IIUC asntream automatically detects the state of the output and decides whether to include the ansi code or not, so if we take a snapshot in the interactive development environment, the ansi code is included but on CI the ansi code is removed, so the snapshot test fails.

My understanding is that this behavior of the display option is not very ideal, and ideally the ansi code should always be included when `'ansi_color'` is specified.