### PR TITLE
ci: pin to ubuntu-22.04 for now

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 3600
     steps:
       - name: 📂 Checkout code

--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 📂 Checkout code
@@ -65,7 +65,7 @@ jobs:
           path: web/website/public/
 
   build-codemirror-demo:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 📂 Checkout code

--- a/.github/workflows/lint-megalinter.yaml
+++ b/.github/workflows/lint-megalinter.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   megalinter:
     name: MegaLinter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Give the default GITHUB_TOKEN write permission to commit and push, comment
     # issues & post new PR; remove the ones you do not need

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   cargo-audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # We can't read PRQL repo security events on forks, which causes this to
     # incorrectly fail (
     # https://github.com/PRQL/prql/actions/runs/5718693342/job/15495030808?pr=3195#step:3:28
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   cargo-bench:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: clechasseur/rs-cargo@v2
@@ -56,7 +56,7 @@ jobs:
           args: -- --warm-up-time=0.3 --measurement-time=1
 
   time-compilation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         use_cache: [true, false]
@@ -74,7 +74,7 @@ jobs:
       RUSTDOCFLAGS: "-Dwarnings"
 
   check-unused-dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
 
   # test-docker:
   #   # We only test the build in `test-all`; this also runs tests.
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   steps:
   #     - name: 📂 Checkout code
   #       uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
 
   code-ql:
     # Currently almost the default code-ql config
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -29,7 +29,7 @@ jobs:
 
   deploy-web:
     needs: build-web
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Don't attempt to publish if on a fork or on a PR running on upstream.
     if:

--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   main:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
@@ -47,7 +47,7 @@ jobs:
   backport:
     # Backport to `web` branch on `pr-backport-web`
     name: Backport to `web` branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Confirm that it's merged and has a label to ensure nothing is backported without oversight
     if: |
       github.event.pull_request.merged
@@ -69,7 +69,7 @@ jobs:
           title_template: "chore: Backport #<%= number%> to `web`"
 
   automerge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,9 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
           - os: macos-14
             target: aarch64-apple-darwin
@@ -93,9 +93,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
           - os: macos-14
             target: aarch64-apple-darwin
@@ -273,7 +273,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         package:
           - prqlc-python
           - lutra-python
@@ -287,16 +287,16 @@ jobs:
             package: lutra-python
             target: universal2-apple-darwin
           # Also produce more targets for ubuntu:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             package: prqlc-python
             target: aarch64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             package: prqlc-python
             target: source
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             package: lutra-python
             target: aarch64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             package: lutra-python
             target: source
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   brew-dispatcher:
     name: Release on homebrew-prql
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'release'
     steps:
       - uses: actions/github-script@v7
@@ -119,7 +119,7 @@ jobs:
           files: ${{ steps.build-artifact.outputs.artifact-name }}
 
   publish-winget:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-prqlc
     if: github.event_name == 'release'
     steps:
@@ -133,7 +133,7 @@ jobs:
           fork-user: prql-bot
 
   build-deb-package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -188,7 +188,7 @@ jobs:
           files: prqlc_*.deb
 
   build-rpm-package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +248,7 @@ jobs:
           files: prqlc-*.rpm
 
   build-and-publish-snap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'release' }}
     steps:
       - name: 📂 Checkout code
@@ -309,7 +309,7 @@ jobs:
           profile: release
 
   publish-python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-python-wheels]
     if: github.event_name == 'release'
     strategy:
@@ -332,7 +332,7 @@ jobs:
           args: --skip-existing *
 
   publish-js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4
@@ -368,7 +368,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-to-cargo:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4
@@ -386,7 +386,7 @@ jobs:
 
   # Requires another pass: https://github.com/PRQL/prql/issues/850
   # publish-prql-java:
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   steps:
   #     - name: Checkout code
   #       uses: actions/checkout@v4
@@ -404,7 +404,7 @@ jobs:
   #         directory: prql-java/java/
 
   push-web-branch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'release'
     steps:
       - name: 📂 Checkout code

--- a/.github/workflows/test-dotnet.yaml
+++ b/.github/workflows/test-dotnet.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-elixir.yaml
+++ b/.github/workflows/test-elixir.yaml
@@ -5,12 +5,12 @@ on:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
   workflow_dispatch:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
 
 defaults:
   run:

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -5,12 +5,12 @@ on:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
   workflow_dispatch:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
 
 # We need consistent env vars across all workflows for the cache to work
 env:

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -5,12 +5,12 @@ on:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
   workflow_dispatch:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
 
 # We need consistent env vars across all workflows for the cache to work
 env:

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-prqlc-c.yaml
+++ b/.github/workflows/test-prqlc-c.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test-c:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -5,12 +5,12 @@ on:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
   workflow_dispatch:
     inputs:
       oss:
         type: string
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
 
 # We need consistent env vars across all workflows for the cache to work
 env:
@@ -31,7 +31,7 @@ jobs:
       - name: Build wheel
         uses: ./.github/actions/build-python
         with:
-          target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64' || '' }}
+          target: ${{ matrix.os == 'ubuntu-22.04' && 'x86_64' || '' }}
           package: prqlc-python
           profile: dev
       - uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
   # the changes in PR, others also define a set of other criteria, such as
   # whether a label has been added, or we're on `main` branch.
   rules:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: read
     outputs:
@@ -354,7 +354,7 @@ jobs:
     # Another option is https://github.com/lycheeverse/lychee, but it was
     # weirdly difficult to exclude a directory, and I managed to get
     # rate-limited by GH because of it scanning node_modules.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4
@@ -380,7 +380,7 @@ jobs:
       needs.rules.outputs.book == 'true' || needs.rules.outputs.nightly ==
       'true'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 📂 Checkout code
@@ -407,7 +407,7 @@ jobs:
         run: hyperlink web/book/book/
 
   measure-code-cov:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: rules
     steps:
       - name: 📂 Checkout code
@@ -473,7 +473,7 @@ jobs:
   test-grammars:
     # Currently tests lezer grammars. We could split that out into a separate
     # job if we want when we add more.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: rules
     if:
       needs.rules.outputs.grammars == 'true' || needs.rules.outputs.main ==
@@ -510,7 +510,7 @@ jobs:
       push: ${{ needs.rules.outputs.devcontainer-push == 'true' }}
 
   test-msrv:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: rules
     if: needs.rules.outputs.nightly == 'true'
     steps:
@@ -528,7 +528,7 @@ jobs:
         run: cargo msrv verify
 
   test-deps-min-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: rules
     if: needs.rules.outputs.nightly == 'true'
     steps:
@@ -576,7 +576,7 @@ jobs:
       - test-rust
       - test-rust-main
       - test-taskfile
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         # https://github.com/re-actors/alls-green/issues/23
@@ -698,7 +698,7 @@ jobs:
       RUSTDOCFLAGS: "-Dwarnings"
 
   create-issue-on-nightly-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - check-ok-to-merge
       - rules
@@ -723,7 +723,7 @@ jobs:
           search_existing: open
 
   update-rust-toolchain:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: rules
     if: ${{ needs.rules.outputs.nightly-upstream == 'true' }}
     # Note that this doesn't change the minimum supported version, only the

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -180,17 +180,17 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             features: default,test-dbs-external
           # Only run wasm on ubuntu, given it's the same rust target. (There is
           # a possibility of having a failure on just one platform, but it's
           # quite unlikely. If we do observe this, we can add those tests them
           # to nightly.
           - target: wasm32-unknown-unknown
-            os: ubuntu-latest
+            os: ubuntu-22.04
             features: default
     with:
-      os: ubuntu-latest
+      os: ubuntu-22.04
       target: ${{ matrix.target }}
       features: ${{ matrix.features }}
       nightly: ${{ needs.rules.outputs.nightly == 'true' }}
@@ -209,8 +209,8 @@ jobs:
       # 20 workflow limit.
       oss:
         ${{ (needs.rules.outputs.python == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-latest", "macos-14", "windows-latest"]' ||
-        '["ubuntu-latest"]' }}
+        == 'true') && '["ubuntu-22.04", "macos-14", "windows-latest"]' ||
+        '["ubuntu-22.04"]' }}
 
   test-js:
     needs: rules
@@ -220,8 +220,8 @@ jobs:
       # Only run on ubuntu unless there's a lang-specific change or we're running nightly.
       oss:
         ${{ (needs.rules.outputs.js == 'true' || needs.rules.outputs.nightly ==
-        'true') && '["ubuntu-latest", "macos-14", "windows-latest"]' ||
-        '["ubuntu-latest"]' }}
+        'true') && '["ubuntu-22.04", "macos-14", "windows-latest"]' ||
+        '["ubuntu-22.04"]' }}
 
   test-dotnet:
     needs: rules
@@ -242,7 +242,7 @@ jobs:
       # Currently we never run windows
       oss:
         ${{ (needs.rules.outputs.java == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-latest", "macos-14"]' || '["ubuntu-latest"]' }}
+        == 'true') && '["ubuntu-22.04", "macos-14"]' || '["ubuntu-22.04"]' }}
 
   test-elixir:
     needs: rules
@@ -253,8 +253,8 @@ jobs:
       # Currently we never run Mac, see prql-elixir docs for details
       oss:
         ${{ (needs.rules.outputs.elixir == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-latest", "windows-latest"]' ||
-        '["ubuntu-latest"]' }}
+        == 'true') && '["ubuntu-22.04", "windows-latest"]' ||
+        '["ubuntu-22.04"]' }}
 
   test-prqlc-c:
     needs: rules
@@ -316,13 +316,13 @@ jobs:
             target: x86_64-pc-windows-msvc
             # We'd like to reenable integration tests on Windows, ref https://github.com/wangfenjin/duckdb-rs/issues/179.
             features: default
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             # One test with no features
             features: ""
 
           # TODO: potentially enable these
-          # - os: ubuntu-latest
+          # - os: ubuntu-22.04
           #   target: aarch64-unknown-linux-musl
 
     uses: ./.github/workflows/test-rust.yaml
@@ -634,14 +634,14 @@ jobs:
       matrix:
         include:
           # Match the features with the available caches from tests
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             features: default
           # TODO: Until we have tests for these, we don't have a cache for them.
           # If we can add tests, then re-enable them. They run on `release.yaml`
           # regardless.
           #
-          # - os: ubuntu-latest
+          # - os: ubuntu-22.04
           #   target: aarch64-unknown-linux-musl
           - os: macos-14
             target: aarch64-apple-darwin
@@ -673,7 +673,7 @@ jobs:
       matrix:
         include:
           # Match the features with the available caches from tests
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             features: default
           - os: macos-14

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -253,8 +253,8 @@ jobs:
       # Currently we never run Mac, see prql-elixir docs for details
       oss:
         ${{ (needs.rules.outputs.elixir == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-22.04", "windows-latest"]' ||
-        '["ubuntu-22.04"]' }}
+        == 'true') && '["ubuntu-22.04", "windows-latest"]' || '["ubuntu-22.04"]'
+        }}
 
   test-prqlc-c:
     needs: rules

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -519,6 +519,9 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-msrv
+          # TODO: remove this version pinning
+          # The latest 0.16 supports workspace inheritance, so the check will fail
+          version: "0.15"
         # Note this currently uses a manually maintained key in
         # `prqlc/prqlc/Cargo.toml`, because of
         # https://github.com/foresterre/cargo-msrv/issues/590


### PR DESCRIPTION
See https://github.com/PRQL/prql/pull/4941#issuecomment-2402040831

So far, CI in this repository does not seem to support Ubuntu 24.04.