### PR TITLE
docs: Change "qStudio" to "QStudio" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We're also spending time thinking about:
 - Making it really easy to start using PRQL. We're doing that by building
   integrations with tools that folks already use; for example a VS Code
   extension, Jupyter integration, and the recent
-  [qStudio](https://www.timestored.com/qstudio/prql-ide) integration. If there
+  [QStudio](https://www.timestored.com/qstudio/prql-ide) integration. If there
   are tools you're familiar with that you think would be open to integrating
   with PRQL, please let us know in an issue.
 - Whether all our initial decisions were correct — for example

--- a/web/book/src/SUMMARY.md
+++ b/web/book/src/SUMMARY.md
@@ -107,7 +107,7 @@ General information about the project, tooling and development.
   - [ClickHouse](./project/integrations/clickhouse.md)
   - [Jupyter](./project/integrations/jupyter.md)
   - [DuckDB](./project/integrations/duckdb.md)
-  - [qStudio](./project/integrations/qstudio.md)
+  - [QStudio](./project/integrations/qstudio.md)
   - [Prefect](./project/integrations/prefect.md)
   - [VS Code](./project/integrations/vscode.md)
   - [PostgreSQL](./project/integrations/postgresql.md)

--- a/web/book/src/project/integrations/README.md
+++ b/web/book/src/project/integrations/README.md
@@ -6,7 +6,7 @@ PRQL is building integrations with lots of external tools, including:
 - [ClickHouse](./clickhouse.md)
 - [Jupyter](./jupyter.md)
 - [DuckDB](./duckdb.md)
-- [qStudio](./qstudio.md)
+- [QStudio](./qstudio.md)
 - [Prefect](./prefect.md)
 - [VS Code](./vscode.md)
 - [PostgreSQL](./postgresql.md)

--- a/web/book/src/project/integrations/qstudio.md
+++ b/web/book/src/project/integrations/qstudio.md
@@ -1,17 +1,20 @@
-# qStudio IDE
+# QStudio IDE
 
-[qStudio](https://www.timestored.com/qstudio/prql-ide) is a SQL GUI that lets
-you browse tables, run SQL scripts, and chart and export the results. qStudio
+[QStudio](https://www.timestored.com/qstudio/prql-ide) is a SQL GUI that lets
+you browse tables, run SQL scripts, and chart and export the results. QStudio
 runs on Windows, macOS and Linux, and works with every popular database
 including mysql, postgresql, mssql, kdb....
 
 ```admonish note
-qStudio relies on the PRQL compiler. You must ensure that `prqlc` is in your path. See the [installation instructions](https://prql-lang.org/book/project/integrations/prqlc-cli.html#installation) for `prqlc` in the PRQL reference guide for details.
+QStudio relies on the PRQL compiler. You must ensure that `prqlc` is in your path. See the [installation instructions](https://prql-lang.org/book/project/integrations/prqlc-cli.html#installation) for `prqlc` in the PRQL reference guide for details.
 ```
 
-qStudio calls `prqlc` (the PRQL compiler) to generate SQL code from PRQL queries
+QStudio calls `prqlc` (the PRQL compiler) to generate SQL code from PRQL queries
 (.prql files) then runs the SQL against the selected database to display the
 results. For more details, check out:
 
-- [qStudio site](https://www.timestored.com/qstudio/prql-ide)
-- [qStudio-PRQL Quick Start](https://github.com/richb-hanover/qStudio-PRQL_Quick_Start)
+- [QStudio site](https://www.timestored.com/qstudio/prql-ide)
+- [QStudio-PRQL Quick Start](https://github.com/richb-hanover/qStudio-PRQL_Quick_Start)
+- There is a
+  [double-clickable macOS app](https://randomneuronsfiring.com/wp-content/uploads/QStudio.zip)
+  that bundles QStudio and the `prqlc` compiler.

--- a/web/website/config.yml
+++ b/web/website/config.yml
@@ -71,6 +71,6 @@ params:
     - static/img/favicon-32x32.png
   title: PRQL
 
-  license: "© 2022-2023, PRQL Developers. Apache 2.0 Licensed"
+  license: "© 2022-2024, PRQL Developers. Apache 2.0 Licensed"
 
 googleAnalytics: G-LQJDD599T4

--- a/web/website/content/_index.md
+++ b/web/website/content/_index.md
@@ -186,11 +186,11 @@ integrations_section:
       link: https://github.com/ywelsch/duckdb-prql
       text: A DuckDB extension to execute PRQL
 
-    - label: "qStudio"
+    - label: "QStudio"
       link: https://www.timestored.com/qstudio/prql-ide
       text:
-        "qStudio is a SQL GUI that lets you browse tables, run SQL scripts, and
-        chart and export the results. qStudio runs on Windows, macOS and Linux,
+        "QStudio is a SQL GUI that lets you browse tables, run SQL scripts, and
+        chart and export the results. QStudio runs on Windows, macOS and Linux,
         and works with every popular database including mysql, postgresql,
         mssql, kdb..."
 


### PR DESCRIPTION
QStudio has re-branded the name of their SQL IDE. This updates the PRQL site to math

Also mention the pre-built macOS application that bundles QStudio and `prqlc`; 

Also update website copyright to 2022-2024