### PR TITLE
refactor: remove generics

### DIFF
--- a/prqlc/prqlc-parser/src/parser/pr/expr.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/expr.rs
@@ -145,9 +145,6 @@ pub struct Func {
 
     /// Named function parameters.
     pub named_params: Vec<FuncParam>,
-
-    /// Generic type arguments within this function.
-    pub generic_type_params: Vec<GenericTypeParam>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]

--- a/prqlc/prqlc-parser/src/parser/pr/types.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/types.rs
@@ -39,9 +39,6 @@ pub enum TyKind {
 
     /// Type that is the largest subtype of `base` while not a subtype of `exclude`.
     Difference { base: Box<Ty>, exclude: Box<Ty> },
-
-    /// A generic argument. Contains id of the function call node and generic type param name.
-    GenericArg((usize, String)),
 }
 
 impl TyKind {

--- a/prqlc/prqlc-parser/src/parser/pr/types.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/types.rs
@@ -36,9 +36,6 @@ pub enum TyKind {
 
     /// Type of functions with defined params and return types.
     Function(Option<TyFunc>),
-
-    /// Type that is the largest subtype of `base` while not a subtype of `exclude`.
-    Difference { base: Box<Ty>, exclude: Box<Ty> },
 }
 
 impl TyKind {

--- a/prqlc/prqlc-parser/src/parser/stmt.rs
+++ b/prqlc/prqlc-parser/src/parser/stmt.rs
@@ -551,7 +551,6 @@ mod tests {
                       name: ~
                     default_value: ~
                 named_params: []
-                generic_type_params: []
               span: "0:21-57"
           span: "0:0-57"
         "#);
@@ -584,7 +583,6 @@ mod tests {
                             name: ~
                           default_value: ~
                       named_params: []
-                      generic_type_params: []
                     span: "0:41-77"
                 span: "0:20-77"
               - VarDef:
@@ -606,7 +604,6 @@ mod tests {
                             name: ~
                           default_value: ~
                       named_params: []
-                      generic_type_params: []
                     span: "0:98-133"
                 span: "0:77-133"
           span: "0:0-139"

--- a/prqlc/prqlc-parser/src/test.rs
+++ b/prqlc/prqlc-parser/src/test.rs
@@ -388,7 +388,6 @@ fn test_function() {
               - name: x
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:15-26"
       span: "0:0-26"
     "#);
@@ -407,7 +406,6 @@ fn test_function() {
               - name: x
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:15-22"
       span: "0:0-22"
     "#);
@@ -434,7 +432,6 @@ fn test_function() {
               - name: x
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:15-28"
       span: "0:0-28"
     "#);
@@ -461,7 +458,6 @@ fn test_function() {
               - name: x
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:15-26"
       span: "0:0-26"
     "#);
@@ -510,7 +506,6 @@ fn test_function() {
               - name: x
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:10-51"
       span: "0:0-51"
     "#);
@@ -530,7 +525,6 @@ fn test_function() {
               - name: return_constant
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:0-27"
       span: "0:0-27"
     "#);
@@ -557,7 +551,6 @@ fn test_function() {
               - name: X
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:12-28"
       span: "0:0-28"
     "#);
@@ -620,7 +613,6 @@ fn test_function() {
               - name: x
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:27-147"
       span: "0:0-147"
     "#);
@@ -650,7 +642,6 @@ fn test_function() {
                 default_value:
                   Ident: a
                   span: "0:15-16"
-            generic_type_params: []
           span: "0:10-27"
       span: "0:0-27"
     "#);
@@ -842,7 +833,6 @@ fn test_inline_pipeline() {
               - name: x
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:13-37"
       span: "0:0-37"
     "#);
@@ -1599,7 +1589,6 @@ fn test_annotation() {
               - name: b
                 default_value: ~
             named_params: []
-            generic_type_params: []
           span: "0:49-61"
       span: "0:0-61"
       annotations:

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -130,15 +130,6 @@ pub fn generate_html_docs(stmts: Vec<Stmt>) -> String {
         if let Some(expr) = &var_def.value {
             match &expr.kind {
                 ExprKind::Func(func) => {
-                    if !func.generic_type_params.is_empty() {
-                        docs.push_str("  <h4 class=\"h6\">Type parameters</h4>\n");
-                        docs.push_str("  <ul>\n");
-                        for param in &func.generic_type_params {
-                            docs.push_str(&format!("    <li><var>{}</var></li>\n", param.name));
-                        }
-                        docs.push_str("  </ul>\n");
-                    }
-
                     if !func.params.is_empty() {
                         docs.push_str("  <h4 class=\"h6\">Parameters</h4>\n");
                         docs.push_str("  <ul>\n");
@@ -284,14 +275,6 @@ Generated with [prqlc](https://prql-lang.org/) {}.
         if let Some(expr) = &var_def.value {
             match &expr.kind {
                 ExprKind::Func(func) => {
-                    if !func.generic_type_params.is_empty() {
-                        docs.push_str("#### Type Parameters\n");
-                        for param in &func.generic_type_params {
-                            docs.push_str(&format!("* *{}*\n", param.name));
-                        }
-                        docs.push('\n');
-                    }
-
                     if !func.params.is_empty() {
                         docs.push_str("#### Parameters\n");
                         for param in &func.params {

--- a/prqlc/prqlc/src/codegen/ast.rs
+++ b/prqlc/prqlc/src/codegen/ast.rs
@@ -195,22 +195,6 @@ impl WriteSource for pr::ExprKind {
             }
             Func(c) => {
                 let mut r = "func ".to_string();
-                if !c.generic_type_params.is_empty() {
-                    r += opt.consume("<")?;
-                    for generic_param in &c.generic_type_params {
-                        r += opt.consume(&write_ident_part(&generic_param.name))?;
-                        r += opt.consume(": ")?;
-                        r += &opt.consume(
-                            SeparatedExprs {
-                                exprs: &generic_param.domain,
-                                inline: " | ",
-                                line_end: "|",
-                            }
-                            .write(opt.clone())?,
-                        )?;
-                    }
-                    r += opt.consume("> ")?;
-                }
 
                 for param in &c.params {
                     r += opt.consume(&write_ident_part(&param.name))?;

--- a/prqlc/prqlc/src/codegen/types.rs
+++ b/prqlc/prqlc/src/codegen/types.rs
@@ -64,7 +64,6 @@ impl WriteSource for pr::TyKind {
                 let exclude = exclude.write(opt.clone())?;
                 Some(format!("{base} - {exclude}"))
             }
-            GenericArg(_) => Some("?".to_string()),
         }
     }
 }

--- a/prqlc/prqlc/src/codegen/types.rs
+++ b/prqlc/prqlc/src/codegen/types.rs
@@ -59,11 +59,6 @@ impl WriteSource for pr::TyKind {
                 r += &func.return_ty.as_deref().write(opt)?;
                 Some(r)
             }
-            Difference { base, exclude } => {
-                let base = base.write(opt.clone())?;
-                let exclude = exclude.write(opt.clone())?;
-                Some(format!("{base} - {exclude}"))
-            }
         }
     }
 }

--- a/prqlc/prqlc/src/ir/pl/expr.rs
+++ b/prqlc/prqlc/src/ir/pl/expr.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Lineage, TransformCall};
 use crate::codegen::write_ty;
-use crate::pr::{GenericTypeParam, Ident, Literal, Span, Ty};
+use crate::pr::{Ident, Literal, Span, Ty};
 
 /// Expr is anything that has a value and thus a type.
 /// Most of these can contain other [Expr] themselves; literals should be [ExprKind::Literal].
@@ -111,9 +111,6 @@ pub struct Func {
 
     /// Named function parameters.
     pub named_params: Vec<FuncParam>,
-
-    /// Generic type arguments within this function.
-    pub generic_type_params: Vec<GenericTypeParam>,
 
     /// Arguments that have already been provided.
     pub args: Vec<Expr>,

--- a/prqlc/prqlc/src/ir/pl/fold.rs
+++ b/prqlc/prqlc/src/ir/pl/fold.rs
@@ -351,10 +351,7 @@ pub fn fold_type<T: ?Sized + PlFold>(fold: &mut T, ty: Ty) -> Result<Ty> {
                 base: Box::new(fold.fold_type(*base)?),
                 exclude: Box::new(fold.fold_type(*exclude)?),
             },
-            TyKind::Ident(_)
-            | TyKind::Primitive(_)
-            | TyKind::Singleton(_)
-            | TyKind::GenericArg(_) => ty.kind,
+            TyKind::Ident(_) | TyKind::Primitive(_) | TyKind::Singleton(_) => ty.kind,
         },
         span: ty.span,
         name: ty.name,

--- a/prqlc/prqlc/src/ir/pl/fold.rs
+++ b/prqlc/prqlc/src/ir/pl/fold.rs
@@ -347,10 +347,6 @@ pub fn fold_type<T: ?Sized + PlFold>(fold: &mut T, ty: Ty) -> Result<Ty> {
                 })
                 .transpose()?,
             ),
-            TyKind::Difference { base, exclude } => TyKind::Difference {
-                base: Box::new(fold.fold_type(*base)?),
-                exclude: Box::new(fold.fold_type(*exclude)?),
-            },
             TyKind::Ident(_) | TyKind::Primitive(_) | TyKind::Singleton(_) => ty.kind,
         },
         span: ty.span,

--- a/prqlc/prqlc/src/semantic/ast_expand.rs
+++ b/prqlc/prqlc/src/semantic/ast_expand.rs
@@ -67,7 +67,6 @@ pub fn expand_expr(expr: pr::Expr) -> Result<pl::Expr> {
                 name_hint: None,
                 args: Vec::new(),
                 env: HashMap::new(),
-                generic_type_params: v.generic_type_params,
             }
             .into(),
         ),
@@ -347,7 +346,6 @@ fn restrict_expr_kind(value: pl::ExprKind) -> pr::ExprKind {
                     body: restrict_expr_box(v.body),
                     params: restrict_func_params(v.params),
                     named_params: restrict_func_params(v.named_params),
-                    generic_type_params: v.generic_type_params,
                 }
                 .into(),
             );

--- a/prqlc/prqlc/src/semantic/eval.rs
+++ b/prqlc/prqlc/src/semantic/eval.rs
@@ -426,7 +426,6 @@ fn new_func(name: &str, params: &[&str]) -> Expr {
         named_params: Default::default(),
         args: Default::default(),
         env: Default::default(),
-        generic_type_params: Default::default(),
     }));
     Expr {
         alias: Some(name.to_string()),

--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -173,7 +173,7 @@ impl pl::PlFold for Resolver<'_> {
 
                 // fold function
                 let func = self.apply_args_to_closure(func, args, named_args)?;
-                self.fold_function(func,  *span)?
+                self.fold_function(func, *span)?
             }
 
             pl::ExprKind::Func(closure) => self.fold_function(closure, *span)?,

--- a/prqlc/prqlc/src/semantic/resolver/expr.rs
+++ b/prqlc/prqlc/src/semantic/resolver/expr.rs
@@ -108,7 +108,7 @@ impl pl::PlFold for Resolver<'_> {
 
                     DeclKind::Expr(expr) => match &expr.kind {
                         pl::ExprKind::Func(closure) => {
-                            let closure = self.fold_function_types(closure.clone(), id)?;
+                            let closure = self.fold_function_types(closure.clone())?;
 
                             let expr = pl::Expr::new(pl::ExprKind::Func(closure));
 
@@ -173,10 +173,10 @@ impl pl::PlFold for Resolver<'_> {
 
                 // fold function
                 let func = self.apply_args_to_closure(func, args, named_args)?;
-                self.fold_function(func, id, *span)?
+                self.fold_function(func,  *span)?
             }
 
-            pl::ExprKind::Func(closure) => self.fold_function(closure, id, *span)?,
+            pl::ExprKind::Func(closure) => self.fold_function(closure, *span)?,
 
             pl::ExprKind::Tuple(exprs) => {
                 let exprs = self.fold_exprs(exprs)?;

--- a/prqlc/prqlc/src/semantic/resolver/functions.rs
+++ b/prqlc/prqlc/src/semantic/resolver/functions.rs
@@ -13,11 +13,7 @@ use crate::Result;
 use crate::{Error, Span, WithErrorInfo};
 
 impl Resolver<'_> {
-    pub fn fold_function(
-        &mut self,
-        closure: Box<Func>,
-        span: Option<Span>,
-    ) -> Result<Expr> {
+    pub fn fold_function(&mut self, closure: Box<Func>, span: Option<Span>) -> Result<Expr> {
         let closure = self.fold_function_types(closure)?;
 
         log::debug!(

--- a/prqlc/prqlc/src/semantic/resolver/mod.rs
+++ b/prqlc/prqlc/src/semantic/resolver/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::ir::decl::RootModule;
 use crate::utils::IdGenerator;
 
@@ -25,8 +23,6 @@ pub struct Resolver<'a> {
     in_func_call_name: bool,
 
     pub id: IdGenerator<usize>,
-
-    pub generics: HashMap<(usize, String), Vec<crate::pr::Ty>>,
 }
 
 #[derive(Default, Clone)]
@@ -40,7 +36,6 @@ impl Resolver<'_> {
             default_namespace: None,
             in_func_call_name: false,
             id: IdGenerator::new(),
-            generics: Default::default(),
         }
     }
 }

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -646,7 +646,6 @@ impl Resolver<'_> {
             named_params: vec![],
 
             env: Default::default(),
-            generic_type_params: Default::default(),
         });
         Ok(*expr_of_func(func, span))
     }

--- a/prqlc/prqlc/src/semantic/resolver/types.rs
+++ b/prqlc/prqlc/src/semantic/resolver/types.rs
@@ -1,9 +1,7 @@
-use itertools::Itertools;
-
 use super::Resolver;
 use crate::codegen::{write_ty, write_ty_kind};
 use crate::ir::pl::*;
-use crate::pr::{PrimitiveSet, Ty, TyFunc, TyKind, TyTupleField};
+use crate::pr::{PrimitiveSet, Ty, TyKind, TyTupleField};
 use crate::Result;
 use crate::{Error, Reason, WithErrorInfo};
 
@@ -167,87 +165,7 @@ impl Resolver<'_> {
             return Ok(());
         }
 
-        // if type is a generic, infer the constraint
-        if let TyKind::GenericArg(generic_id) = &expected.kind {
-            let domain = std::mem::take(self.generics.get_mut(generic_id).unwrap());
-
-            let (new_domain, _rejected): (Vec<_>, _) = domain
-                .into_iter()
-                .partition(|possible_type| is_super_type_of(possible_type, found));
-
-            if new_domain.is_empty() {
-                return Err(Error::new_simple(
-                    "this argument does not match any of the generic types",
-                ));
-            }
-
-            // infer the new constraint
-            *self.generics.get_mut(generic_id).unwrap() = new_domain;
-            return Ok(());
-        }
-
         Err(compose_type_error(found, expected, who))
-    }
-
-    pub fn resolve_generic_args(&mut self, mut ty: Ty) -> Result<Ty, Error> {
-        ty.kind = match ty.kind {
-            // the meaningful part
-            TyKind::GenericArg(id) => {
-                let domain = self.generics.remove(&id).unwrap();
-
-                if domain.len() > 1 {
-                    return Err(Error::new_simple(
-                        "cannot determine the type of generic arg",
-                    ));
-                }
-                // there will always be at least one, since we will never restrict to an empty domain
-                return Ok(domain.into_iter().next().unwrap());
-            }
-
-            // recurse into container types
-            // this could probably be implemented with folding, but I don't want another full fold impl
-            TyKind::Tuple(fields) => TyKind::Tuple(
-                fields
-                    .into_iter()
-                    .map(|field| -> Result<_, Error> {
-                        Ok(match field {
-                            TyTupleField::Single(name, ty) => {
-                                TyTupleField::Single(name, self.resolve_generic_args_opt(ty)?)
-                            }
-                            TyTupleField::Wildcard(ty) => {
-                                TyTupleField::Wildcard(self.resolve_generic_args_opt(ty)?)
-                            }
-                        })
-                    })
-                    .try_collect()?,
-            ),
-            TyKind::Array(ty) => {
-                TyKind::Array(Some(Box::new(self.resolve_generic_args(*ty.unwrap())?)))
-            }
-            TyKind::Function(func) => TyKind::Function(
-                func.map(|f| -> Result<_, Error> {
-                    Ok(TyFunc {
-                        params: f
-                            .params
-                            .into_iter()
-                            .map(|a| self.resolve_generic_args_opt(a))
-                            .try_collect()?,
-                        return_ty: self
-                            .resolve_generic_args_opt(f.return_ty.map(|x| *x))?
-                            .map(Box::new),
-                        name_hint: f.name_hint,
-                    })
-                })
-                .transpose()?,
-            ),
-
-            _ => ty.kind,
-        };
-        Ok(ty)
-    }
-
-    pub fn resolve_generic_args_opt(&mut self, ty: Option<Ty>) -> Result<Option<Ty>, Error> {
-        ty.map(|x| self.resolve_generic_args(x)).transpose()
     }
 }
 

--- a/prqlc/prqlc/src/semantic/resolver/types.rs
+++ b/prqlc/prqlc/src/semantic/resolver/types.rs
@@ -73,13 +73,6 @@ impl Resolver<'_> {
                 TyKind::Array(items_ty)
             }
 
-            ExprKind::All { within, except } => {
-                let base = Box::new(Resolver::infer_type(within)?.unwrap());
-                let exclude = Box::new(Resolver::infer_type(except)?.unwrap());
-
-                TyKind::Difference { base, exclude }
-            }
-
             _ => return Ok(None),
         };
         Ok(Some(Ty {
@@ -390,18 +383,6 @@ fn maybe_type_intersection(a: Option<Ty>, b: Option<Ty>) -> Option<Ty> {
 
 pub fn type_intersection(a: Ty, b: Ty) -> Ty {
     match (a.kind, b.kind) {
-        // difference
-        (TyKind::Difference { base, exclude }, b_kind) => {
-            let b = Ty { kind: b_kind, ..b };
-            let base = Box::new(type_intersection(*base, b));
-            Ty::new(TyKind::Difference { base, exclude })
-        }
-        (a_kind, TyKind::Difference { base, exclude }) => {
-            let a = Ty { kind: a_kind, ..a };
-            let base = Box::new(type_intersection(a, *base));
-            Ty::new(TyKind::Difference { base, exclude })
-        }
-
         (a_kind, b_kind) if a_kind == b_kind => Ty { kind: a_kind, ..a },
 
         // tuple

--- a/prqlc/prqlc/tests/integration/resolving.rs
+++ b/prqlc/prqlc/tests/integration/resolving.rs
@@ -56,24 +56,3 @@ fn resolve_types_05() {
     )
     .unwrap(), @"type A = null");
 }
-
-#[test]
-fn resolve_generics_01() {
-    assert_snapshot!(resolve(
-        r#"
-    let add_one = func <A: int | float> a <A> -> <A> a + 1
-        
-    let my_int = add_one 1
-    let my_float = add_one 1.0
-    "#,
-    )
-    .unwrap(), @r"
-    let add_one = func <A: int | float> a <A> -> <A> (
-      std.add a 1
-    )
-
-    let my_float <float> = `(std.add ...)`
-
-    let my_int <int> = `(std.add ...)`
-    ");
-}

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
@@ -287,7 +287,6 @@ ast:
           - name: rel
             default_value: null
           named_params: []
-          generic_type_params: []
         span: 1:28-79
     span: 1:0-79
   - VarDef:


### PR DESCRIPTION
- **remove generics**
- **remove difference type**

Edit: rationale

Generics and difference types were meant to replace lineage, which is used to know which columns are in-scope at each location in the query.

It turns out that this would be very hard to accomplish due all rules around name resolving that PRQL has. So a few months ago, I abandoned that effort in favor of sticking with current name resolution implementation, based on lineage.

This PR is now cleaning out code that has been unused (except in a few "resolving" tests).