### PR TITLE
feat: Add syntax highlighting for KSyntaxHighlighting

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -8,6 +8,8 @@ extend-exclude = [
 ]
 
 [default.extend-words]
+# <itemDatas> in grammars/KSyntaxHighlighting/prql.xml
+datas = "datas"
 # Java test framework
 testng = "testng"
 # Readme highlighting the first characters of these words

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 **Integrations**:
 
+- Add syntax highlight file for KSyntaxHighlighting. (@vanillajonathan, #5177)
+
 **Internal changes**:
 
 **New Contributors**:

--- a/grammars/KSyntaxHighlighting/README.md
+++ b/grammars/KSyntaxHighlighting/README.md
@@ -1,0 +1,22 @@
+# Syntax highlighting for KSyntaxHighlighting
+
+This is a syntax highlighting file the
+[KSyntaxHighlighting](https://invent.kde.org/frameworks/syntax-highlighting) component used by
+text editors and integrated development environments such as
+[Kate](https://kate-editor.org/),
+[KWrite](https://apps.kde.org/kwrite/) and
+[KDevelop](https://kdevelop.org/).
+
+## Installation
+
+To install for the current user, copy the `prql.xml` file to:
+
+| System               | Path                                                                                 |
+|----------------------|--------------------------------------------------------------------------------------|
+| For local user       | `$HOME/.local/share/org.kde.syntax-highlighting/syntax/`                             |
+| For Flatpak packages | `$HOME/.var/app/PACKAGE_NAME/data/org.kde.syntax-highlighting/syntax/`               |
+| For Snap packages    | `$HOME/snap/PACKAGE_NAME/current/.local/share/org.kde.syntax-highlighting/syntax/`   |
+| On Windows           | `%USERPROFILE%\AppData\Local\org.kde.syntax-highlighting\syntax\`                    |
+| On macOS             | `$HOME/Library/Application Support/org.kde.syntax-highlighting/syntax/`              |
+
+For Flatpak and Snap the PACKAGE_NAME is something like `org.kde.kate`, `org.kde.kwrite` or `org.kde.kdevelop`.

--- a/grammars/KSyntaxHighlighting/README.md
+++ b/grammars/KSyntaxHighlighting/README.md
@@ -1,22 +1,22 @@
 # Syntax highlighting for KSyntaxHighlighting
 
 This is a syntax highlighting file the
-[KSyntaxHighlighting](https://invent.kde.org/frameworks/syntax-highlighting) component used by
-text editors and integrated development environments such as
-[Kate](https://kate-editor.org/),
-[KWrite](https://apps.kde.org/kwrite/) and
+[KSyntaxHighlighting](https://invent.kde.org/frameworks/syntax-highlighting)
+component used by text editors and integrated development environments such as
+[Kate](https://kate-editor.org/), [KWrite](https://apps.kde.org/kwrite/) and
 [KDevelop](https://kdevelop.org/).
 
 ## Installation
 
 To install for the current user, copy the `prql.xml` file to:
 
-| System               | Path                                                                                 |
-|----------------------|--------------------------------------------------------------------------------------|
-| For local user       | `$HOME/.local/share/org.kde.syntax-highlighting/syntax/`                             |
-| For Flatpak packages | `$HOME/.var/app/PACKAGE_NAME/data/org.kde.syntax-highlighting/syntax/`               |
-| For Snap packages    | `$HOME/snap/PACKAGE_NAME/current/.local/share/org.kde.syntax-highlighting/syntax/`   |
-| On Windows           | `%USERPROFILE%\AppData\Local\org.kde.syntax-highlighting\syntax\`                    |
-| On macOS             | `$HOME/Library/Application Support/org.kde.syntax-highlighting/syntax/`              |
+| System               | Path                                                                               |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| For local user       | `$HOME/.local/share/org.kde.syntax-highlighting/syntax/`                           |
+| For Flatpak packages | `$HOME/.var/app/PACKAGE_NAME/data/org.kde.syntax-highlighting/syntax/`             |
+| For Snap packages    | `$HOME/snap/PACKAGE_NAME/current/.local/share/org.kde.syntax-highlighting/syntax/` |
+| On Windows           | `%USERPROFILE%\AppData\Local\org.kde.syntax-highlighting\syntax\`                  |
+| On macOS             | `$HOME/Library/Application Support/org.kde.syntax-highlighting/syntax/`            |
 
-For Flatpak and Snap the PACKAGE_NAME is something like `org.kde.kate`, `org.kde.kwrite` or `org.kde.kdevelop`.
+For Flatpak and Snap the PACKAGE_NAME is something like `org.kde.kate`,
+`org.kde.kwrite` or `org.kde.kdevelop`.

--- a/grammars/KSyntaxHighlighting/prql.xml
+++ b/grammars/KSyntaxHighlighting/prql.xml
@@ -373,7 +373,7 @@
       </context>
     </contexts>
 
-    <itemDatas>
+    <itemData>
       <itemData name="Normal Text"      defStyleNum="dsNormal"   spellChecking="false" />
 
       <itemData name="Keyword"          defStyleNum="dsKeyword"  spellChecking="false" />
@@ -398,7 +398,7 @@
       <itemData name="String Substitution" defStyleNum="dsSpecialChar" spellChecking="false"/>
       <itemData name="Annotation" defStyleNum="dsAttribute" spellChecking="false"/>
       <itemData name="Error" defStyleNum="dsError"/>
-    </itemDatas>
+    </itemData>
   </highlighting>
 
   <general>

--- a/grammars/KSyntaxHighlighting/prql.xml
+++ b/grammars/KSyntaxHighlighting/prql.xml
@@ -373,7 +373,7 @@
       </context>
     </contexts>
 
-    <itemData>
+    <itemDatas>
       <itemData name="Normal Text"      defStyleNum="dsNormal"   spellChecking="false" />
 
       <itemData name="Keyword"          defStyleNum="dsKeyword"  spellChecking="false" />
@@ -398,7 +398,7 @@
       <itemData name="String Substitution" defStyleNum="dsSpecialChar" spellChecking="false"/>
       <itemData name="Annotation" defStyleNum="dsAttribute" spellChecking="false"/>
       <itemData name="Error" defStyleNum="dsError"/>
-    </itemData>
+    </itemDatas>
   </highlighting>
 
   <general>

--- a/grammars/KSyntaxHighlighting/prql.xml
+++ b/grammars/KSyntaxHighlighting/prql.xml
@@ -1,0 +1,413 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language
+[
+  <!ENTITY digitPart "[0-9](?:_?[0-9])*">
+  <!ENTITY beforeDigit "(?&lt;![\.\w[:^ascii:]])">
+  <!ENTITY beforePointFloat "(?&lt;![\w[:^ascii:]])">
+
+  <!ENTITY escapedHex "\\x[0-9A-Fa-f]{2}">
+  <!ENTITY escapedHexUni "&escapedHex;|\\u\{[0-9A-Fa-f]{1,6}\}">
+]
+>
+<!-- PRQL https://prql-lang.org/ -->
+<language name="PRQL" version="0" kateversion="5.0" section="Database" extensions="*.prql" author="vanillajonathan" license="MIT">
+  <highlighting>
+    <list name="imports">
+      <item>module</item>
+    </list>
+
+    <list name="builtinfuncs">
+      <item>aggregate</item>
+      <item>derive</item>
+      <item>filter</item>
+      <item>from</item>
+      <item>group</item>
+      <item>join</item>
+      <item>select</item>
+      <item>sort</item>
+      <item>take</item>
+      <item>window</item>
+    </list>
+
+    <list name="specialvars">
+      <item>null</item>
+      <item>this</item>
+      <item>that</item>
+      <item>true</item>
+      <item>false</item>
+    </list>
+
+    <list name="declarations">
+      <item>type</item>
+      <item>alias</item>
+    </list>
+
+    <list name="types">
+      <item>bool</item>
+      <item>float</item>
+      <item>int</item>
+      <item>int8</item>
+      <item>int16</item>
+      <item>int32</item>
+      <item>int64</item>
+      <item>int128</item>
+      <item>text</item>
+      <item>date</item>
+      <item>time</item>
+      <item>timestamp</item>
+    </list>
+
+    <list name="letExpressions">
+      <item>let</item>
+      <item>in</item>
+    </list>
+
+    <!-- Built-in modules -->
+    <list name="modules_builtin">
+      <item>date</item>
+      <item>math</item>
+      <item>text</item>
+      <item>prql</item>
+    </list>
+
+    <!-- Methods of the date module -->
+    <list name="date_functions">
+      <item>to_text</item>
+    </list>
+
+    <!-- Methods of the math module -->
+    <list name="math_functions">
+      <item>abs</item>
+      <item>acos</item>
+      <item>asin</item>
+      <item>atan</item>
+      <item>ceil</item>
+      <item>cos</item>
+      <item>degrees</item>
+      <item>exp</item>
+      <item>floor</item>
+      <item>ln</item>
+      <item>log</item>
+      <item>log10</item>
+      <item>pi</item>
+      <item>pow</item>
+      <item>radians</item>
+      <item>round</item>
+      <item>sin</item>
+      <item>sqrt</item>
+      <item>tan</item>
+    </list>
+
+    <!-- Methods of the text module -->
+    <list name="text_functions">
+      <item>lower</item>
+      <item>upper</item>
+      <item>ltrim</item>
+      <item>rtrim</item>
+      <item>trim</item>
+      <item>length</item>
+      <item>extract</item>
+      <item>replace</item>
+      <item>starts_with</item>
+      <item>contains</item>
+      <item>ends_with</item>
+    </list>
+
+    <list name="durations">
+      <item>microseconds</item>
+      <item>milliseconds</item>
+      <item>seconds</item>
+      <item>minutes</item>
+      <item>hours</item>
+      <item>days</item>
+      <item>weeks</item>
+      <item>months</item>
+      <item>years</item>
+    </list>
+
+    <contexts>
+      <context name="Normal" attribute="Normal Text" lineEndContext="#stay">
+        <DetectChar attribute="Comment" char="#" context="Hash comment"/>
+
+        <keyword attribute="Data Type" context="#stay" String="types" />
+        <keyword attribute="Special Variable" String="specialvars" context="#stay"/>
+        <keyword attribute="Builtin Function" String="builtinfuncs" context="#stay"/>
+        <keyword attribute="Keyword"          context="#stay" String="declarations" />
+        <keyword attribute="Keyword"          context="#stay" String="letExpressions" />
+        <keyword attribute="Keyword"          context="#stay" String="imports" />
+
+        <IncludeRules context="Number" />
+        <IncludeRules context="StringVariants" />
+
+        <RegExpr attribute="Annotation" String="@\{.*\}" firstNonSpace="true"/>
+        <RegExpr attribute="Operator"         context="#stay" String="-&gt;|::|\/\/|\.\.|&amp;&amp;|\|\||\+\+|\|&gt;|&lt;\||&gt;&gt;|&lt;&lt;|==|\/=|&lt;=|&gt;=|[+-\/*%=&gt;&lt;^\|!@#$&amp;~?]" />
+
+        <Int        attribute="Decimal" context="#stay" />
+        <RegExpr    attribute="Hex"     context="#stay" String="0x[\da-f]+" insensitive="true" />
+        <RegExpr    attribute="Float"   context="#stay" String="\d+\.\d+(e[+-]?\d+)?" insensitive="true" />
+      </context>
+
+      <!-- math module -->
+      <context name="FindMemberModuleMath" attribute="Normal Text" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!NoRegExp">
+        <DetectSpaces />
+        <DetectChar context="#pop!MemberModuleMath" attribute="Symbol" char="." />
+      </context>
+      <context name="MemberModuleMath" attribute="Normal Text" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+        <keyword context="#pop!NoRegExp" attribute="Module Function (Built-in)" String="math_functions" />
+        <IncludeRules context="DefaultMemberObject" />
+      </context>
+
+      <context name="Number" attribute="Normal Text" lineEndContext="#pop">
+        <!-- fast path -->
+        <RegExpr String="&beforeDigit;[0-9]|&beforePointFloat;\.[0-9]" context="AssumeNumber" lookAhead="1"/>
+      </context>
+      <context name="AssumeNumber" attribute="Normal Text" lineEndContext="#pop">
+        <!-- Hexadecimal: 0xA1, Binary: 0b01, Octal: 0o71 -->
+        <RegExpr attribute="Hex" String="0x(?:_?[0-9a-fA-F])+" context="CheckSuffixError"/>
+        <RegExpr attribute="Binary" String="0b(?:_?[01])+" context="CheckSuffixError"/>
+        <RegExpr attribute="Octal" String="0o(?:_?[0-7])+" context="CheckSuffixError"/>
+        <!-- Float: 1.1 ; 1. ; .1 ; 1e3 ; 1.1e3 ; 1.e3 ; .1e3 -->
+        <RegExpr attribute="Float" String="(?:&digitPart;(?:\.(?:&digitPart;)?)?|\.&digitPart;)[eE][\+\-]?&digitPart;|&digitPart;\.(?:&digitPart;)?|\.&digitPart;" context="CheckSuffixError"/>
+        <!-- Decimal: 123 ; 000 -->
+        <!-- l and L are python2 suffixes -->
+        <RegExpr attribute="Int" String="(?:[1-9](?:_?[0-9])*|0(?:_?0)*)" context="CheckSuffixError"/>
+      </context>
+
+      <context name="CheckSuffixError" attribute="Normal Text" lineEndContext="#pop#pop" fallthrough="1" fallthroughContext="#pop#pop">
+        <RegExpr attribute="Error" String="\w+" context="#pop#pop"/>
+      </context>
+
+      <context name="StringVariants" attribute="Normal Text" lineEndContext="#stay">
+        <!-- fast path -->
+        <RegExpr String="(?:f|r|s)?['&quot;]" insensitive="true" context="AssumeStringVariants" lookAhead="1"/>
+      </context>
+
+      <context name="AssumeStringVariants" attribute="Normal Text" lineEndContext="#stay">
+        <StringDetect attribute="String" String="'''"                context="#pop!Triple A-string" beginRegion="Triple A-region"/>
+        <StringDetect attribute="String" String="&quot;&quot;&quot;" context="#pop!Triple Q-string" beginRegion="Triple Q-region"/>
+        <StringDetect attribute="String" String="'"                  context="#pop!Single A-string"/>
+        <StringDetect attribute="String" String="&quot;"             context="#pop!Single Q-string"/>
+
+        <StringDetect attribute="F-String" String="f'''"                insensitive="true" context="#pop!Triple A-F-String" beginRegion="Triple A-region"/>
+        <StringDetect attribute="F-String" String="f&quot;&quot;&quot;" insensitive="true" context="#pop!Triple Q-F-String" beginRegion="Triple Q-region"/>
+        <StringDetect attribute="F-String" String="f'"                  insensitive="true" context="#pop!Single A-F-String"/>
+        <StringDetect attribute="F-String" String="f&quot;"             insensitive="true" context="#pop!Single Q-F-String"/>
+
+        <StringDetect attribute="R-String" String="r'''"                insensitive="true" context="#pop!Triple A-R-String" beginRegion="Triple A-region"/>
+        <StringDetect attribute="R-String" String="r&quot;&quot;&quot;" insensitive="true" context="#pop!Triple Q-R-String" beginRegion="Triple Q-region"/>
+        <StringDetect attribute="R-String" String="r'"                  insensitive="true" context="#pop!Single A-R-String"/>
+        <StringDetect attribute="R-String" String="r&quot;"             insensitive="true" context="#pop!Single Q-R-String"/>
+
+        <StringDetect attribute="S-String" String="s'''"                insensitive="true" context="#pop!Triple A-S-String" beginRegion="Triple A-region"/>
+        <StringDetect attribute="S-String" String="s&quot;&quot;&quot;" insensitive="true" context="#pop!Triple Q-S-String" beginRegion="Triple Q-region"/>
+        <StringDetect attribute="S-String" String="s'"                  insensitive="true" context="#pop!Single A-S-String"/>
+        <StringDetect attribute="S-String" String="s&quot;"             insensitive="true" context="#pop!Single Q-S-String"/>
+      </context>
+
+      <!-- Comments -->
+
+      <context name="Hash comment" attribute="Comment" lineEndContext="#pop">
+        <DetectSpaces />
+        <IncludeRules context="##Comments" />
+        <DetectIdentifier/>
+      </context>
+
+      <!-- escape characters -->
+      <context name="stringescape" attribute="String Char" lineEndContext="#stay">
+        <DetectChar char="\" lookAhead="1" context="stringescape2"/>
+      </context>
+      <context name="stringescape2" attribute="String Char" lineEndContext="#pop">
+        <RegExpr attribute="String Char" String="\\[\\'&quot;bfnrt]|\\[0-7]{1,3}|&escapedHexUni;" context="#pop"/>
+        <LineContinue attribute="Operator" context="#pop"/>
+        <RegExpr attribute="Error" String="." context="#pop"/>
+      </context>
+
+      <!-- f-literals -->
+      <context name="stringinterpolation" attribute="F-String" lineEndContext="#stay">
+        <Detect2Chars attribute="String Char" char="{" char1="{" context="#stay"/>
+        <DetectChar attribute="String Substitution" char="{" context="String Interpolation"/>
+        <Detect2Chars attribute="String Char" char="}" char1="}" context="#stay"/>
+        <DetectChar attribute="Error" char="}" context="#stay"/>
+      </context>
+      <context name="String Interpolation" attribute="String Substitution" lineEndContext="#stay">
+        <RegExpr attribute="String Substitution" String=".*\}" context="#pop"/>
+        <IncludeRules context="Normal"/>
+      </context>
+
+      <!-- Triple-quoted A-strings -->
+      <context name="Triple A-string" attribute="String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="String"/>
+        <DetectIdentifier attribute="String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringformat"/>
+        <StringDetect attribute="String" String="'''" context="#pop" endRegion="Triple A-region"/>
+      </context>
+
+      <context name="Triple A-F-String" attribute="F-String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="F-String"/>
+        <DetectIdentifier attribute="F-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <StringDetect attribute="F-String" String="'''" context="#pop" endRegion="Triple A-region"/>
+      </context>
+
+      <context name="Triple A-R-String" attribute="R-String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="R-String"/>
+        <DetectIdentifier attribute="R-String"/>
+        <Detect2Chars attribute="R-String" char="\" char1="'"/>
+        <Detect2Chars attribute="R-String" char="\" char1="\"/>
+        <IncludeRules context="stringformat"/>
+        <StringDetect attribute="R-String" String="'''" context="#pop" endRegion="Triple A-region"/>
+      </context>
+
+      <context name="Triple A-S-String" attribute="S-String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="S-String"/>
+        <DetectIdentifier attribute="S-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <StringDetect attribute="S-String" String="'''" context="#pop" endRegion="Triple A-region"/>
+      </context>
+
+      <!-- Triple-quoted Q-strings -->
+      <context name="Triple Q-string" attribute="String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="String"/>
+        <DetectIdentifier attribute="String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringformat"/>
+        <StringDetect attribute="String" String="&quot;&quot;&quot;" context="#pop" endRegion="Triple Q-region"/>
+      </context>
+
+      <context name="Triple Q-F-String" attribute="F-String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="F-String"/>
+        <DetectIdentifier attribute="F-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <StringDetect attribute="F-String" String="&quot;&quot;&quot;" context="#pop" endRegion="Triple Q-region"/>
+      </context>
+
+      <context name="Triple Q-R-String" attribute="R-String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="R-String"/>
+        <DetectIdentifier attribute="R-String"/>
+        <Detect2Chars attribute="R-String" char="\" char1="&quot;"/>
+        <Detect2Chars attribute="R-String" char="\" char1="\"/>
+        <IncludeRules context="stringformat"/>
+        <StringDetect attribute="R-String" String="&quot;&quot;&quot;" context="#pop" endRegion="Triple Q-region"/>
+      </context>
+
+      <context name="Triple Q-S-String" attribute="S-String" lineEndContext="#stay" noIndentationBasedFolding="true">
+        <DetectSpaces attribute="S-String"/>
+        <DetectIdentifier attribute="S-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <StringDetect attribute="S-String" String="&quot;&quot;&quot;" context="#pop" endRegion="Triple Q-region"/>
+      </context>
+
+      <!-- Single-quoted A-strings -->
+      <context name="Single A-string" attribute="String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="String"/>
+        <DetectIdentifier attribute="String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringformat"/>
+        <DetectChar attribute="String" char="'" context="#pop"/>
+      </context>
+
+      <context name="Single A-F-String" attribute="F-String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="F-String"/>
+        <DetectIdentifier attribute="F-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <DetectChar attribute="F-String" char="'" context="#pop"/>
+      </context>
+
+      <context name="Single A-R-String" attribute="R-String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="R-String"/>
+        <DetectIdentifier attribute="R-String"/>
+        <Detect2Chars attribute="R-String" char="\" char1="'"/>
+        <Detect2Chars attribute="R-String" char="\" char1="\"/>
+        <IncludeRules context="stringformat"/>
+        <DetectChar attribute="R-String" char="'" context="#pop"/>
+        <LineContinue attribute="R-String" context="#stay"/>
+      </context>
+
+      <context name="Single A-S-String" attribute="S-String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="S-String"/>
+        <DetectIdentifier attribute="S-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <DetectChar attribute="S-String" char="'" context="#pop"/>
+      </context>
+
+      <!-- Single-quoted Q-strings -->
+      <context name="Single Q-string" attribute="String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="String"/>
+        <DetectIdentifier attribute="String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringformat"/>
+        <DetectChar attribute="String" char="&quot;" context="#pop"/>
+      </context>
+
+      <context name="Single Q-F-String" attribute="F-String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="F-String"/>
+        <DetectIdentifier attribute="F-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <DetectChar attribute="F-String" char="&quot;" context="#pop"/>
+      </context>
+
+      <context name="Single Q-R-String" attribute="R-String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="R-String"/>
+        <DetectIdentifier attribute="R-String"/>
+        <Detect2Chars attribute="R-String" char="\" char1="&quot;"/>
+        <Detect2Chars attribute="R-String" char="\" char1="\"/>
+        <IncludeRules context="stringformat"/>
+        <DetectChar attribute="R-String" char="&quot;" context="#pop"/>
+        <LineContinue attribute="R-String" context="#stay"/>
+      </context>
+
+      <context name="Single Q-S-String" attribute="S-String" lineEndContext="#pop!UnfinishedStringError">
+        <DetectSpaces attribute="S-String"/>
+        <DetectIdentifier attribute="S-String"/>
+        <IncludeRules context="stringescape"/>
+        <IncludeRules context="stringinterpolation"/>
+        <DetectChar attribute="S-String" char="&quot;" context="#pop"/>
+      </context>
+    </contexts>
+
+    <itemDatas>
+      <itemData name="Normal Text"      defStyleNum="dsNormal"   spellChecking="false" />
+
+      <itemData name="Keyword"          defStyleNum="dsKeyword"  spellChecking="false" />
+
+      <itemData name="Import"           defStyleNum="dsImport"   spellChecking="false" />
+      <itemData name="Operator"         defStyleNum="dsOperator" spellChecking="false" />
+      <itemData name="Data Type"        defStyleNum="dsDataType" spellChecking="false" />
+      <itemData name="Builtin Function" defStyleNum="dsBuiltIn"  spellChecking="false" />
+      <itemData name="Special Variable" defStyleNum="dsConstant" spellChecking="false" />
+
+      <itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
+      <itemData name="Int" defStyleNum="dsDecVal" spellChecking="false"/>
+      <itemData name="Hex" defStyleNum="dsBaseN" spellChecking="false"/>
+      <itemData name="Octal" defStyleNum="dsBaseN" spellChecking="false"/>
+      <itemData name="Binary" defStyleNum="dsBaseN" spellChecking="false"/>
+      <itemData name="Comment" defStyleNum="dsComment"/>
+      <itemData name="String" defStyleNum="dsString"/>
+      <itemData name="F-String" defStyleNum="dsSpecialString"/>
+      <itemData name="R-String" defStyleNum="dsVerbatimString"/>
+      <itemData name="S-String" defStyleNum="dsVerbatimString"/>
+      <itemData name="String Char" defStyleNum="dsChar" spellChecking="false"/>
+      <itemData name="String Substitution" defStyleNum="dsSpecialChar" spellChecking="false"/>
+      <itemData name="Annotation" defStyleNum="dsAttribute" spellChecking="false"/>
+      <itemData name="Error" defStyleNum="dsError"/>
+    </itemDatas>
+  </highlighting>
+
+  <general>
+    <folding indentationsensitive="1" />
+    <comments>
+      <comment name="singleLine" start="#" position="afterwhitespace" />
+    </comments>
+    <keywords casesensitive="1" />
+  </general>
+
+</language>
+<!-- kate: indent-width 2; tab-width 2; -->

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -16,6 +16,9 @@ an index.
   ([prql.xml](https://github.com/alecthomas/chroma/blob/master/lexers/embedded/prql.xml)).
   See the [demo](https://swapoff.org/chroma/playground/).
 
+- [CotEditor](https://coteditor.com/) — text editor for macOS. File is at
+  [`grammars/CotEditor/`](https://github.com/PRQL/prql/tree/main/grammars/CotEditor/).
+
 - [Lezer](https://lezer.codemirror.net/) — used by CodeMirror editors. The PRQL
   file is at
   [`grammars/prql-lezer/README.md`](https://github.com/PRQL/prql/tree/main/grammars/prql-lezer/README.md).

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -20,12 +20,24 @@ an index.
   file is at
   [`grammars/prql-lezer/README.md`](https://github.com/PRQL/prql/tree/main/grammars/prql-lezer/README.md).
 
+- GtkSourceView — used by GNOME Text Editor, GNOME Builder and other GTK applications.
+  File is at [`grammars/GtkSourceView/`](https://github.com/PRQL/prql/tree/main/grammars/GtkSourceView/).
+
 - [Handlebars](https://handlebarsjs.com/) — currently duplicated:
 
   - The book:
     [`book/highlight-prql.js`](https://github.com/PRQL/prql/blob/main/web/book/highlight-prql.js)
   - The website (outside of the book & playground):
     [`website/themes/prql-theme/static/plugins/highlight/prql.js`](https://github.com/PRQL/prql/blob/main/web/book/highlight-prql.js)
+
+- KSyntaxHighlighting — used by Kate, KWrite and KDevelop and other Qt applications.
+  File is at [`grammars/KSyntaxHighlighting/`](https://github.com/PRQL/prql/tree/main/grammars/KSyntaxHighlighting/).
+
+- [micro](https://micro-editor.github.io/) — used by terminal-based text editor Micro.
+  File is at [`grammars/micro/`](https://github.com/PRQL/prql/tree/main/grammars/micro/).
+
+- [nano](https://nano-editor.org/) — used by terminal-based text editor GNU nano.
+  File is at [`grammars/nano/`](https://github.com/PRQL/prql/tree/main/grammars/nano/).
 
 - Sublime Text — in the [`sublime-prql`](https://github.com/PRQL/sublime-prql/)
   repository.

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -20,8 +20,9 @@ an index.
   file is at
   [`grammars/prql-lezer/README.md`](https://github.com/PRQL/prql/tree/main/grammars/prql-lezer/README.md).
 
-- GtkSourceView — used by GNOME Text Editor, GNOME Builder and other GTK applications.
-  File is at [`grammars/GtkSourceView/`](https://github.com/PRQL/prql/tree/main/grammars/GtkSourceView/).
+- GtkSourceView — used by GNOME Text Editor, GNOME Builder and other GTK
+  applications. File is at
+  [`grammars/GtkSourceView/`](https://github.com/PRQL/prql/tree/main/grammars/GtkSourceView/).
 
 - [Handlebars](https://handlebarsjs.com/) — currently duplicated:
 
@@ -30,14 +31,17 @@ an index.
   - The website (outside of the book & playground):
     [`website/themes/prql-theme/static/plugins/highlight/prql.js`](https://github.com/PRQL/prql/blob/main/web/book/highlight-prql.js)
 
-- KSyntaxHighlighting — used by Kate, KWrite and KDevelop and other Qt applications.
-  File is at [`grammars/KSyntaxHighlighting/`](https://github.com/PRQL/prql/tree/main/grammars/KSyntaxHighlighting/).
+- KSyntaxHighlighting — used by Kate, KWrite and KDevelop and other Qt
+  applications. File is at
+  [`grammars/KSyntaxHighlighting/`](https://github.com/PRQL/prql/tree/main/grammars/KSyntaxHighlighting/).
 
-- [micro](https://micro-editor.github.io/) — used by terminal-based text editor Micro.
-  File is at [`grammars/micro/`](https://github.com/PRQL/prql/tree/main/grammars/micro/).
+- [micro](https://micro-editor.github.io/) — used by terminal-based text editor
+  Micro. File is at
+  [`grammars/micro/`](https://github.com/PRQL/prql/tree/main/grammars/micro/).
 
-- [nano](https://nano-editor.org/) — used by terminal-based text editor GNU nano.
-  File is at [`grammars/nano/`](https://github.com/PRQL/prql/tree/main/grammars/nano/).
+- [nano](https://nano-editor.org/) — used by terminal-based text editor GNU
+  nano. File is at
+  [`grammars/nano/`](https://github.com/PRQL/prql/tree/main/grammars/nano/).
 
 - Sublime Text — in the [`sublime-prql`](https://github.com/PRQL/sublime-prql/)
   repository.


### PR DESCRIPTION
Add syntax highlighting for [KSyntaxHighlighting](https://invent.kde.org/frameworks/syntax-highlighting/) which is the syntax highlight engine that powers Qt applications such as [Kate](https://kate-editor.org/), [KWrite](https://apps.kde.org/kwrite/) and [KDevelop](https://kdevelop.org/).

Hey @eitsupi this is related to issue #2213.