### PR TITLE
docs: Add Helix

### DIFF
--- a/grammars/README.md
+++ b/grammars/README.md
@@ -34,6 +34,9 @@ an index.
   - The website (outside of the book & playground):
     [`website/themes/prql-theme/static/plugins/highlight/prql.js`](https://github.com/PRQL/prql/blob/main/web/book/highlight-prql.js)
 
+- [Helix](https://helix-editor.com/) — supported. The grammar is
+  [upstream](https://github.com/helix-editor/helix/tree/master/runtime/queries/prql).
+
 - KSyntaxHighlighting — used by Kate, KWrite and KDevelop and other Qt
   applications. File is at
   [`grammars/KSyntaxHighlighting/`](https://github.com/PRQL/prql/tree/main/grammars/KSyntaxHighlighting/).


### PR DESCRIPTION
[Helix](https://helix-editor.com/) have support for syntax highlighting PRQL thanks to @matthias-Q.