### PR TITLE
feat: Add syntax highlighting for Kakoune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Add syntax highlight file for KSyntaxHighlighting. (@vanillajonathan, #5177)
 - Add syntax highlight file for Vim. (@vanillajonathan, #5185)
 - Add syntax highlight file for GNU Emacs. (@vanillajonathan, #5189)
+- [Kakoune](http://kakoune.org/), a terminal-based text editor has syntax
+  highlighting for PRQL. (@vanillajonathan)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Add syntax highlight file for KSyntaxHighlighting. (@vanillajonathan, #5177)
 - Add syntax highlight file for Vim. (@vanillajonathan, #5185)
 - Add syntax highlight file for GNU Emacs. (@vanillajonathan, #5189)
-- [Kakoune](http://kakoune.org/), a terminal-based text editor has syntax
+- [Kakoune](https://kakoune.org/), a terminal-based text editor has syntax
   highlighting for PRQL. (@vanillajonathan)
 
 **Internal changes**:

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -40,6 +40,9 @@ an index.
 - [Helix](https://helix-editor.com/) — supported. The grammar is
   [upstream](https://github.com/helix-editor/helix/tree/master/runtime/queries/prql).
 
+- [Kakoune](https://kakoune.org/) — supported. The grammar is
+  [upstream](https://github.com/mawww/kakoune/blob/master/rc/filetype/prql.kak).
+
 - KSyntaxHighlighting — used by Kate, KWrite and KDevelop and other Qt
   applications. File is at
   [`grammars/KSyntaxHighlighting/`](https://github.com/PRQL/prql/tree/main/grammars/KSyntaxHighlighting/).


### PR DESCRIPTION
[Kakoune](https://kakoune.org/), a terminal-based text editor has syntax highlighting for PRQL.

The file is upstream at:
https://github.com/mawww/kakoune/blob/master/rc/filetype/prql.kak