### PR TITLE
docs: TEA has syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 **Integrations**:
 
+- TEA 63.3.1, a Qt-based text editor has syntax syntax highlighting for PRQL.
+  (@vanillajonathan)
+
 **Internal changes**:
 
 **New Contributors**:

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -71,6 +71,9 @@ an index.
   ([prql.py](https://github.com/pygments/pygments/blob/master/pygments/lexers/prql.py)).
   See the [demo](https://pygments.org/demo/).
 
+- [TEA](https://github.com/psemiletov/tea-qt/) — supported. The grammar is
+  [upstream](https://github.com/psemiletov/tea-qt/blob/master/hls/prql.xml).
+
 - [Tree-Sitter](https://tree-sitter.github.io/tree-sitter) — used by the neovim
   and helix. The grammar can be found at
   [https://github.com/PRQL/tree-sitter-prql](https://github.com/PRQL/tree-sitter-prql).


### PR DESCRIPTION
TEA 63.3.1 was released and has syntax highlighting for PRQL.

The grammar is upstream.