### PR TITLE
fix: Correct typo "trough" to "through"

### DIFF
--- a/prqlc/bindings/dotnet/PrqlCompiler/PrqlCompilerOptions.cs
+++ b/prqlc/bindings/dotnet/PrqlCompiler/PrqlCompilerOptions.cs
@@ -9,7 +9,7 @@ namespace Prql.Compiler
     public class PrqlCompilerOptions
     {
         /// <summary>
-        /// Pass generated SQL string trough a formatter that splits it into
+        /// Pass generated SQL string through a formatter that splits it into
         /// multiple lines and prettifies indentation and spacing.
         /// </summary>
         /// <remarks>Defaults to <c>true</c>.</remarks>

--- a/prqlc/bindings/elixir/native/prql/src/lib.rs
+++ b/prqlc/bindings/elixir/native/prql/src/lib.rs
@@ -86,7 +86,7 @@ impl From<CompileOptions> for prqlc::Options {
 #[derive(Clone, NifStruct, Debug)]
 #[module = "PRQL.Native.CompileOptions"]
 pub struct CompileOptions {
-    /// Pass generated SQL string trough a formatter that splits it
+    /// Pass generated SQL string through a formatter that splits it
     /// into multiple lines and prettifies indentation and spacing.
     ///
     /// Defaults to true.

--- a/prqlc/bindings/js/src/lib.rs
+++ b/prqlc/bindings/js/src/lib.rs
@@ -54,7 +54,7 @@ pub fn rq_to_sql(rq_json: &str) -> Option<String> {
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct CompileOptions {
-    /// Pass generated SQL string trough a formatter that splits it
+    /// Pass generated SQL string through a formatter that splits it
     /// into multiple lines and prettifies indentation and spacing.
     ///
     /// Defaults to true.

--- a/prqlc/bindings/php/src/Options.php
+++ b/prqlc/bindings/php/src/Options.php
@@ -32,7 +32,7 @@ namespace Prql\Compiler;
 final class Options
 {
     /**
-     * Pass generated SQL string trough a formatter that splits it into
+     * Pass generated SQL string through a formatter that splits it into
      * multiple lines and prettifies indentation and spacing.
      */
     public bool $format = true;

--- a/prqlc/bindings/prqlc-c/prqlc.h
+++ b/prqlc/bindings/prqlc-c/prqlc.h
@@ -93,7 +93,7 @@ typedef struct CompileResult {
  */
 typedef struct Options {
   /**
-   * Pass generated SQL string trough a formatter that splits it
+   * Pass generated SQL string through a formatter that splits it
    * into multiple lines and prettifies indentation and spacing.
    *
    * Defaults to true.

--- a/prqlc/bindings/prqlc-c/prqlc.hpp
+++ b/prqlc/bindings/prqlc-c/prqlc.hpp
@@ -69,7 +69,7 @@ struct CompileResult {
 
 /// Compilation options
 struct Options {
-  /// Pass generated SQL string trough a formatter that splits it
+  /// Pass generated SQL string through a formatter that splits it
   /// into multiple lines and prettifies indentation and spacing.
   ///
   /// Defaults to true.

--- a/prqlc/bindings/prqlc-c/src/lib.rs
+++ b/prqlc/bindings/prqlc-c/src/lib.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn rq_to_sql(
 /// Compilation options
 #[repr(C)]
 pub struct Options {
-    /// Pass generated SQL string trough a formatter that splits it
+    /// Pass generated SQL string through a formatter that splits it
     /// into multiple lines and prettifies indentation and spacing.
     ///
     /// Defaults to true.

--- a/prqlc/prqlc/src/lib.rs
+++ b/prqlc/prqlc/src/lib.rs
@@ -272,7 +272,7 @@ impl FromStr for Target {
 /// Compilation options for SQL backend of the compiler.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Options {
-    /// Pass generated SQL string trough a formatter that splits it
+    /// Pass generated SQL string through a formatter that splits it
     /// into multiple lines and prettifies indentation and spacing.
     ///
     /// Defaults to true.


### PR DESCRIPTION
Co-authored-by: Claude <no-reply@anthropic.com>
