### PR TITLE
build: invalidate certain cargo-install caches, fixing Win build pt 2

### DIFF
--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -39,6 +39,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: wasm-pack
+          cache-key: 20250701-1
 
       - run: ./.github/workflows/scripts/set_version.sh
 

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -53,6 +53,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-insta
+          cache-key: 20250701-1
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-nextest

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -113,6 +113,12 @@ jobs:
         if: ${{ contains(inputs.features, 'test-dbs-external') }}
       - name: 📋 Test
         uses: clechasseur/rs-cargo@v3
+        env:
+          # https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
+          # note: this may be temporary
+          RUSTFLAGS: >-
+            -Cdebuginfo=0 ${{ inputs.target == 'x86_64-pc-windows-msvc' &&
+            '-Clink-arg=/DEBUG:NONE' || '' }}
         with:
           command: insta
           # Here, we also add:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -57,6 +57,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-nextest
+          cache-key: 20250701-1
       - run: ./.github/workflows/scripts/set_version.sh
         shell: bash
       - name: 💰 Cache


### PR DESCRIPTION
I took one last look at the Windows build failure messages, and this is another stab at maybe fixing them. Hopefully invalidating the `baptiste0928/cargo-install@v3` caches for `cargo-insta` and `wasm-pack` will let Windows rebuild and properly use those tools...