### PR TITLE
fix: Correct Claude tool permissions syntax

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,8 @@ jobs:
             actions: read
 
           # Grant Claude full permissions to execute commands
-          claude_args: "--allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch"
+          claude_args:
+            "--allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch"
 
           # Enhanced prompt with explicit CI diagnosis instructions
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,15 +41,7 @@ jobs:
             actions: read
 
           # Grant Claude full permissions to execute commands
-          allowed_tools: |
-            Bash(*),
-            Edit,
-            Read,
-            Write,
-            Glob,
-            Grep,
-            WebSearch,
-            WebFetch
+          claude_args: "--allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch"
 
           # Enhanced prompt with explicit CI diagnosis instructions
           prompt: |


### PR DESCRIPTION
## One-line fix

Change `allowed_tools` to `claude_args` with `--allowedTools` flag.

This is the correct syntax according to the Claude Code Action documentation.

*Created by Claude Code*