### PR TITLE
fix: Add GitHub token for Claude comment posting

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,30 +35,13 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.6
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # Explicitly provide GitHub token for posting comments
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
           # Grant Claude full permissions to execute commands
-          claude_args: "--allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch"
-
-          # Enhanced prompt with explicit CI diagnosis instructions
-          prompt: |
-            You are helping with the PRQL project in a GitHub Actions environment.
-            Follow the project guidelines in CLAUDE.md.
-            When making changes, ensure tests pass with `task test-all` and lints with `task test-lint`.
-
-            IMPORTANT for CI failure diagnosis:
-            - Use 'gh run list' and 'gh run view' to check CI status
-            - Look for specific error messages in failing jobs
-            - Check the test output for detailed failure information
-            - When fixing issues, verify changes with the appropriate test commands
-            
-            IMPORTANT: You are running in GitHub Actions and should provide a clear response
-            to the user's request. Your response will be automatically posted as a comment.
-
-            User comment: ${{ github.event.comment.body }}
+          # Also include system prompt with project context via claude_args
+          claude_args: |
+            --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch
+            --system-prompt "You are helping with the PRQL project in a GitHub Actions environment. Follow the project guidelines in CLAUDE.md. When making changes, ensure tests pass with 'task test-all' and lints with 'task test-lint'. For CI failure diagnosis: Use 'gh run list' and 'gh run view' to check CI status, look for specific error messages in failing jobs, check test output for detailed failure information."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,14 +35,16 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.6
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          
+          # Explicitly provide GitHub token for posting comments
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
           # Grant Claude full permissions to execute commands
-          claude_args:
-            "--allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch"
+          claude_args: "--allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch"
 
           # Enhanced prompt with explicit CI diagnosis instructions
           prompt: |
@@ -55,5 +57,8 @@ jobs:
             - Look for specific error messages in failing jobs
             - Check the test output for detailed failure information
             - When fixing issues, verify changes with the appropriate test commands
+            
+            IMPORTANT: You are running in GitHub Actions and should provide a clear response
+            to the user's request. Your response will be automatically posted as a comment.
 
             User comment: ${{ github.event.comment.body }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,11 @@ jobs:
             github.event.issue.number) || github.ref }}
           fetch-depth: 0 # Get more history for better context
 
+      - name: Configure git for Claude
+        run: |
+          git config --global user.name "Claude Code"
+          git config --global user.email "claude@anthropic.com"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        # Fix: Use specific version that has the PR context bug fixed
-        uses: anthropics/claude-code-action@v1.0.6
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
This PR adds the GitHub token parameter to the Claude Code Action configuration to enable posting responses back as comments.

## Changes
- Add explicit `github_token` parameter to provide GitHub API access
- Fix `claude_args` formatting to be on a single line
- Add instructions in prompt for Claude to provide clear responses

## Testing
After merging, test by commenting `@claude` on a PR to verify Claude posts responses.

*Created by Claude Code*