### PR TITLE
build: Enable MSRV-aware resolver v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
   "prqlc/prqlc/examples/compile-files", # An example
   "web/book",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 authors = ["PRQL Developers"]


### PR DESCRIPTION
## Summary

- Enable Cargo's MSRV-aware resolver (v3) to automatically manage dependency versions compatible with our MSRV of 1.75.0
- This prevents dependency updates from breaking our MSRV compatibility

## Changes

- Updated `Cargo.toml` to use `resolver = "3"` instead of `resolver = "2"`

## Benefits

- **Automatic MSRV enforcement**: Dependencies are now automatically constrained to versions compatible with Rust 1.75.0
- **No manual pinning needed**: The resolver handles version selection based on our declared `rust-version`
- **Future-proof**: As dependencies release new versions, the resolver will automatically select the latest compatible version

## Requirements

- Requires Cargo 1.84.0+ to understand the resolver v3 configuration
- Our development toolchain (1.89.0) fully supports this feature
- The library code itself maintains MSRV of 1.75.0

## Test plan

- [x] Build succeeds with resolver v3
- [x] `cargo update` respects MSRV constraints (shows "Locking 279 packages to latest Rust 1.75.0 compatible versions")
- [x] Tests pass with updated dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)