### PR TITLE
revert: "build: Enable MSRV-aware resolver v3"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
   "prqlc/prqlc/examples/compile-files", # An example
   "web/book",
 ]
-resolver = "3"
+resolver = "2"
 
 [workspace.package]
 authors = ["PRQL Developers"]


### PR DESCRIPTION
## Summary
- Reverts #5426 which upgraded to Cargo resolver v3
- This change appears to have broken CI but wasn't caught during the original PR
- We intend to re-revert this shortly after investigating the CI detection issue

## Context
The resolver v3 upgrade seems to have caused CI issues that weren't detected when #5426 was merged. This temporary revert allows us to:
1. Restore CI to a working state
2. Investigate why the original CI run didn't catch these issues
3. Fix the underlying problems before re-enabling resolver v3

## Test plan
- [x] CI should pass with resolver v2 restored
- [ ] Investigate which CI jobs failed to run on #5426
- [ ] Document findings for fixing the resolver v3 migration

🤖 Generated with [Claude Code](https://claude.ai/code)