### PR TITLE
ci: Add Cargo.toml to nightly filter to catch MSRV issues

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -109,6 +109,7 @@ jobs:
             nightly:
               - .github/workflows/nightly.yaml
               - .github/workflows/release.yaml
+              - Cargo.toml
               - Cargo.lock
               - rust-toolchain.toml
               - .cargo/**


### PR DESCRIPTION
## Summary
- Adds `Cargo.toml` to the nightly CI filter list to ensure MSRV tests run when build configuration changes

## Problem
PR #5426 upgraded to Cargo resolver v3, which requires Rust 1.81+ to parse the configuration. However, our project MSRV is 1.75. This broke MSRV compatibility but **wasn't caught by CI** because:

1. The `test-msrv` job only runs for changes matching the `nightly` filter
2. `Cargo.toml` wasn't in that filter list
3. Therefore, changing the resolver version didn't trigger MSRV testing

## Solution
Add `Cargo.toml` to the nightly filter list so fundamental build configuration changes trigger MSRV testing.

## Context
- #5426 - The PR that introduced resolver v3 (currently being reverted in #5428)
- The issue was only discovered after merge when CI broke
- This would have been caught if MSRV tests had run

## Test plan
- [x] Modified `.github/workflows/tests.yaml` to include `Cargo.toml` in nightly filter
- [ ] Future changes to `Cargo.toml` will now trigger `test-msrv` job
- [ ] This would have caught the resolver v3 incompatibility

🤖 Generated with [Claude Code](https://claude.ai/code)