### PR TITLE
test: Re-attempt resolver v3 upgrade to identify issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
   "prqlc/prqlc/examples/compile-files", # An example
   "web/book",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 authors = ["PRQL Developers"]


### PR DESCRIPTION
## Summary
This is a **test PR** to identify what specifically breaks with resolver v3. We intend to close this once we understand the issues.

## Context
- #5426 originally upgraded to resolver v3 but broke CI
- #5428 reverted it back to resolver v2
- #5429 added Cargo.toml to nightly filter (but not merged yet)

## Purpose
Re-enable resolver v3 to:
1. Identify which specific CI jobs fail
2. Understand the MSRV incompatibility details
3. Determine what needs to be fixed before we can use resolver v3

## Known Issues
- Resolver v3 requires Rust 1.81+ to parse the configuration
- Our MSRV is 1.75
- This will likely fail MSRV tests (if they run)

## Test plan
- [ ] Monitor which CI jobs fail
- [ ] Document specific error messages
- [ ] Identify path forward for resolver v3 adoption

🤖 Generated with [Claude Code](https://claude.ai/code)