### PR TITLE
ci: Update nightly Rust version to fix CI failures

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v4
-      - run: rustup override set nightly-2025-01-12
+      - run: rustup override set nightly-2025-09-22
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-udeps


### PR DESCRIPTION
## Summary
- Updates the nightly Rust version from `nightly-2025-01-12` to `nightly-2025-09-22`
- Fixes CI failures in the `check-unused-dependencies` job

## Context
The previous nightly version (2025-01-12) is about 8 months old and was causing the `check-unused-dependencies` job to fail with exit code 101.

Related failure: https://github.com/PRQL/prql/actions/runs/17998361909/job/51202127385

🤖 Generated with [Claude Code](https://claude.ai/code)