### PR TITLE
fix: Use dependency-groups for Python dev dependencies

### DIFF
--- a/prqlc/bindings/prqlc-python/Taskfile.yaml
+++ b/prqlc/bindings/prqlc-python/Taskfile.yaml
@@ -17,5 +17,5 @@ tasks:
   test:
     desc: A fast test used for feedback during compiler development
     cmds:
-      # uv run automatically creates and manages the virtual environment
+      # uv run automatically includes dev dependencies from dependency-groups
       - uv run pytest python/tests

--- a/prqlc/bindings/prqlc-python/noxfile.py
+++ b/prqlc/bindings/prqlc-python/noxfile.py
@@ -26,8 +26,10 @@ def _install_prqlc(session: Session) -> None:
         # plain pip of doing that (https://github.com/pypa/pip/issues/11440).
         # "--no-index",
         f"--find-links={Path('..', '..', '..', 'target', 'python')}",
-        "prqlc[dev]",
+        "prqlc",
     )
+    # Install dev dependencies separately since we're using dependency-groups
+    session.install("pytest>=7", "mypy==1.18.1")
 
 
 @nox.session(python=VERSIONS)  # type: ignore[misc]

--- a/prqlc/bindings/prqlc-python/pyproject.toml
+++ b/prqlc/bindings/prqlc-python/pyproject.toml
@@ -27,7 +27,7 @@ features = ["pyo3/extension-module"]
 module-name = "prqlc"
 python-source = "python"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "pytest >= 7",
   "mypy == 1.18.1",

--- a/prqlc/bindings/prqlc-python/uv.lock
+++ b/prqlc/bindings/prqlc-python/uv.lock
@@ -123,18 +123,19 @@ wheels = [
 name = "prqlc"
 source = { editable = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.18.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = "==1.18.1" },
+    { name = "pytest", specifier = ">=7" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "pygments"


### PR DESCRIPTION
## Summary
- Migrated from `[project.optional-dependencies]` to `[dependency-groups]` for dev dependencies
- This allows `uv run` to automatically include dev dependencies without needing `--extra dev` flag
- Fixes the issue where `task python:test` was failing after the migration to uv

## Test plan
- [x] Ran `task python:test` - passes
- [x] Verified `uv run pytest` works without `--extra dev` flag
- [x] Tests pass from clean state (no .venv directory)

🤖 Generated with [Claude Code](https://claude.ai/code)