### PR TITLE
fix: join with table with column named "source"

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/functions.rs
+++ b/prqlc/prqlc/src/semantic/resolver/functions.rs
@@ -227,6 +227,8 @@ impl Resolver<'_> {
             self.root_mod.module.shadow(NS_THIS);
             self.root_mod.module.shadow(NS_THAT);
 
+            // First, resolve all relational arguments
+            let mut resolved_relations = Vec::new();
             for (pos, (index, (param, mut arg))) in relations.into_iter().with_position() {
                 let is_last = matches!(pos, Position::Last | Position::Only);
 
@@ -241,7 +243,11 @@ impl Resolver<'_> {
                 }
                 log::debug!("resolved arg to {}", arg.kind.as_ref());
 
-                // add relation frame into scope
+                resolved_relations.push((index, arg, is_last));
+            }
+
+            // Then, add relation frames into scope
+            for (index, arg, is_last) in resolved_relations {
                 if partial_application_position.is_none() {
                     let frame = arg
                         .lineage


### PR DESCRIPTION
Attempting to fix #5015 by letting Claude to grind on it for 30 mins. My own understanding of the internals of PRQL is still very limited. Here's the report from Claude:

## Root Cause

The problem occurred in `prqlc/prqlc/src/semantic/resolver/functions.rs` in the `resolve_function_args` function. When resolving relational arguments for functions like join:

  1. Arguments were being resolved one at a time in a loop
  2. After each argument was resolved, its columns were immediately added to the `NS_THAT` namespace
  3. This meant that when resolving the second relational argument, the first argument's columns were already visible in `NS_THAT`
  4. If both arguments referenced the same variable (like `join a`), the second reference would see the first one's columns, creating a circular dependency
  5. This caused column lookups to find both the actual column AND the function parameter from the `_param` namespace, resulting in ambiguity

## The Fix

Changed the resolution order in resolve_function_args:

- Before: Resolve argument → Add to namespace → Resolve next argument → Add to namespace
- After: Resolve ALL arguments first → Then add all to namespaces

This ensures that when resolving variable references, they don't see partially-populated namespaces from other arguments being processed in the same function call.

## Testing

- Added regression test `test_join_with_param_name_collision` in `prqlc/prqlc/tests/integration/sql.rs`
- All existing tests continue to pass (394 integration tests)
- The specific example from issue #5015 now compiles successfully

The fix is minimal, surgical, and preserves all existing functionality while resolving the circular reference issue.