### PR TITLE
chore: increase CLI test slow timeout to 2s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,7 +29,7 @@ max-threads = 1
 [[profile.default.overrides]]
 # cli tests take a bit longer
 filter = 'test(cli)'
-slow-timeout = { period = "1s" }
+slow-timeout = { period = "2s" }
 
 [[profile.default.overrides]]
 filter = 'package(mdbook-prql)'


### PR DESCRIPTION
## Summary
- Increased CLI test slow timeout from 1s to 2s in nextest config

## Reason
CLI tests were consistently taking just over 1 second, causing slow test warnings during test runs. The new 2s timeout matches actual test duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)