### PR TITLE
docs: Fix binary literal example

### DIFF
--- a/web/book/src/reference/syntax/literals.md
+++ b/web/book/src/reference/syntax/literals.md
@@ -27,7 +27,7 @@ select {
     small = 1.000_000_1,
     big = 5_000_000,
     huge = 5e9,
-    binary = 0x0011,
+    binary = 0b0011,
     hex = 0x80,
     octal = 0o777,
 }

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__numbers__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__literals__numbers__0.snap
@@ -1,12 +1,12 @@
 ---
 source: web/book/tests/documentation/book.rs
-expression: "from numbers\nselect {\n    small = 1.000_000_1,\n    big = 5_000_000,\n    huge = 5e9,\n    binary = 0x0011,\n    hex = 0x80,\n    octal = 0o777,\n}\n"
+expression: "from numbers\nselect {\n    small = 1.000_000_1,\n    big = 5_000_000,\n    huge = 5e9,\n    binary = 0b0011,\n    hex = 0x80,\n    octal = 0o777,\n}\n"
 ---
 SELECT
   1.0000001 AS small,
   5000000 AS big,
   5000000000.0 AS huge,
-  17 AS "binary",
+  3 AS "binary",
   128 AS hex,
   511 AS octal
 FROM


### PR DESCRIPTION
Caveats:
- I have not built. I edited on the web.
- I manually edited the "documentation snapshot" of the line: https://github.com/PRQL/prql/pull/5475/commits/370a2223124d1103e6a5a86077774f2b3579c774 I don't know what this is, and I don't know whether it was supposed to be autogenerated instead of manually edited.