### PR TITLE
fix: revert distinct_ons change and add to typos allowlist

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -20,3 +20,5 @@ uery = "uery"
 # `wee-alloc` is a crate name
 wee = "wee"
 flate = "flate"
+# distinct_ons is correct (SQL DISTINCT ON)
+ons = "ons"

--- a/prqlc/prqlc/src/sql/gen_query.rs
+++ b/prqlc/prqlc/src/sql/gen_query.rs
@@ -115,12 +115,12 @@ fn translate_select_pipeline(
     let order_by = pipeline.pluck(|t| t.into_sort());
     let takes = pipeline.pluck(|t| t.into_take());
     let is_distinct = pipeline.iter().any(|t| matches!(t, SqlTransform::Distinct));
-    let distinct_owns = pipeline.pluck(|t| t.into_distinct_on());
+    let distinct_ons = pipeline.pluck(|t| t.into_distinct_on());
     let distinct = if is_distinct {
         Some(sql_ast::Distinct::Distinct)
-    } else if !distinct_owns.is_empty() {
+    } else if !distinct_ons.is_empty() {
         Some(sql_ast::Distinct::On(
-            distinct_owns
+            distinct_ons
                 .into_iter()
                 .exactly_one()
                 .unwrap()


### PR DESCRIPTION
## Summary
- Revert incorrect typo fix: `distinct_ons` → `distinct_owns` was wrong
- Add `ons` to typos allowlist in `.typos.toml`

The variable name `distinct_ons` is correct - it refers to SQL's DISTINCT ON clause.

## Test plan
- [x] Typos check passes
- [x] All lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)