### PR TITLE
docs: clarify cargo test command syntax in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,11 @@ returning to user:
 # Run fast tests on core packages (from project root)
 task prqlc:test
 
-# Or run specific tests you're working on
-cargo insta test -p prqlc --test integration -- date
+# Unit tests filtered by test name
+cargo insta test -p prqlc --lib -- resolver
 
-# Run unit tests for a specific module
-cargo insta test -p prqlc --lib semantic::resolver
+# Integration tests filtered by test name
+cargo insta test -p prqlc --test integration -- date
 ```
 
 **Outer loop** (comprehensive, ~1min, before returning to user):


### PR DESCRIPTION
## Summary

Improve test command examples in CLAUDE.md to prevent common cargo test syntax mistakes that Claude frequently makes.

## Changes

- Reordered inner loop examples to prioritize unit tests (faster) over integration tests
- Simplified comments to focus on correct syntax patterns without redundant parenthetical clarifications
- Demonstrated the critical `--` separator for test filtering more clearly

The examples now clearly show:
- `cargo insta test -p prqlc --lib -- resolver` for unit tests
- `cargo insta test -p prqlc --test integration -- date` for integration tests

## Motivation

Claude was repeatedly making these mistakes:
1. `cargo insta test -p prqlc-parser --test interpolation` (wrong - no test file named "interpolation")
2. `cargo insta test -p prqlc-parser --lib parser::interpolation` (wrong - module path in wrong position)
3. The correct form is `cargo insta test -p prqlc-parser --lib -- interpolation` (filter after `--`)

The updated examples make the correct patterns self-evident without needing explicit "don't do this" sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)