### PR TITLE
perf: use zero-copy slice for binary/hex/octal number parsing

### DIFF
--- a/prqlc/prqlc-parser/src/lexer/mod.rs
+++ b/prqlc/prqlc-parser/src/lexer/mod.rs
@@ -426,9 +426,9 @@ fn parse_number_with_base<'a>(
                 .repeated()
                 .at_least(1)
                 .at_most(max_digits)
-                .collect::<String>()
-                .map(move |digits| {
-                    i64::from_str_radix(&digits, base)
+                .to_slice()
+                .map(move |digits: &str| {
+                    i64::from_str_radix(digits, base)
                         .map(Literal::Integer)
                         .unwrap_or(Literal::Integer(0))
                 }),


### PR DESCRIPTION
## Summary

Use `.to_slice()` instead of `.collect::<String>()` when parsing binary, hexadecimal, and octal number literals. This eliminates one allocation per literal by passing a string slice directly to `i64::from_str_radix()` instead of allocating an intermediate String.

The change also simplifies the code by removing an unnecessary allocation step.

## Changes

```rust
// Before
.collect::<String>()
.map(move |digits| {
    i64::from_str_radix(&digits, base)

// After  
.to_slice()
.map(move |digits: &str| {
    i64::from_str_radix(digits, base)
```

## Test plan

- [x] All existing tests pass (`task prqlc:test`)
- [x] 569 tests passing, no regressions
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)