### PR TITLE
chore: Bump version to 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@
 
 **New Contributors**:
 
+## [unreleased]
+
+**Language**:
+
+**Features**:
+
+**Fixes**:
+
+**Documentation**:
+
+**Web**:
+
+**Integrations**:
+
+**Internal changes**:
+
+**New Contributors**:
+
 ## 0.13.5 — 2025-10-09
 
 0.13.5 has 237 commits from 14 contributors. Selected changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,68 @@
 
 **Fixes**:
 
-- `sort` step before an `aggregate` step no longer requires its columns in order
-  to avoid a group by clause error. (@julien-pinchelimouroux, #5347)
-
 **Documentation**:
 
 **Web**:
 
 **Integrations**:
 
-- TEA 63.3.1, a Qt-based text editor has syntax syntax highlighting for PRQL.
-  (@vanillajonathan)
-
 **Internal changes**:
 
 **New Contributors**:
 
+## 0.13.5 — 2025-10-09
+
+0.13.5 has 237 commits from 14 contributors. Selected changes:
+
+**Features**:
+
+- Support for SQL arrays as `s[...]` syntax (@Robert Valek, #5312)
+- Extract SQL column names from s-string tables when possible (@lukapeschke,
+  #5310)
+
+**Fixes**:
+
+- Sort step before an aggregate step no longer requires its columns to avoid a
+  group by clause error (@julien-pinchelimouroux, #5347)
+- Always add quotes on identifiers for Snowflake dialect
+  (@julien-pinchelimouroux, #5461)
+- Join with table containing column named "source" now works correctly (@Priit
+  Haamer, #5468)
+- Columns required by sorting are properly redirected (@lukapeschke, #5464)
+- Ensure sorts are done on columns of the right table (@lukapeschke, #5338)
+- Deduplicate selected items in gen_projection (@lukapeschke, #5305)
+- Handle complex append cases (@Elouan Poupard-Cosquer, #5366)
+- Improve requirement logic (@Elouan Poupard-Cosquer, #5357)
+- Avoid type mismatch with Postgres in append (@Elouan Poupard-Cosquer, #5343)
+- Apply column order on CTEs in append (@Elouan Poupard-Cosquer, #5323)
+
+**Documentation**:
+
+- Fix binary literal example (@ftsfranklin, #5475)
+- Use correct table in grouping tutorial (@fnuttens, #5332)
+
+**Integrations**:
+
+- TEA 63.3.1, a Qt-based text editor has syntax highlighting for PRQL
+  (@vanillajonathan, #5220)
+- Micro text editor grammar is now upstream (@vanillajonathan, #5353)
+- Add LSP stub (@vanillajonathan, #5197)
+
+**Internal changes**:
+
+- Upgrade parser and lexer to chumsky 0.11, providing a 7x performance
+  improvement (#5223, #5476, #5477)
+- Set Rust linker on win64, fix build crash (@kgutwin, #5345)
+- Integration tests compile all dialects and diff (@kgutwin, #5344)
+
+**New Contributors**:
+
+- @Elouan Poupard-Cosquer, with #5366
+- @Priit Haamer, with #5468
+- @Robert Valek, with #5312
+- @fnuttens, with #5332
+- @ftsfranklin, with #5475
 - @julien-pinchelimouroux, with #5347
 
 ## 0.13.4 — 2025-03-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "compile-files"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "prqlc",
 ]
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-prql"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "ansi-to-html",
  "anstream",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "prql"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "prqlc",
  "rustler",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "prql-java"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "jni",
  "prqlc",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anstream",
  "anyhow",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-c"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "libc",
  "prqlc",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-js"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "console_error_panic_hook",
  "prqlc",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-macros"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "prqlc",
  "syn 2.0.106",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-parser"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "chumsky 0.10.1",
  "chumsky 0.9.3",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-python"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "insta",
  "prqlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/PRQL/prql"
 # This isn't tested since `cargo-msrv` doesn't support workspaces; instead we
 # test `metadata.msrv` in `prqlc`
 rust-version = "1.75.0"
-version = "0.13.5"
+version = "0.13.6"
 
 [profile.release]
 lto = true

--- a/prqlc/bindings/elixir/native/prql/Cargo.toml
+++ b/prqlc/bindings/elixir/native/prql/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/lib.rs"
 test = false
 
 [target.'cfg(not(any(target_family="wasm")))'.dependencies]
-prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.5" }
+prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.6" }
 rustler = "0.37.0"

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prqlc",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prqlc",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -35,5 +35,5 @@
     "test": "mocha tests"
   },
   "types": "dist/node/prqlc_js.d.ts",
-  "version": "0.13.5"
+  "version": "0.13.6"
 }

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: "0.13.5"
+version: "0.13.6"
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/prqlc-macros/Cargo.toml
+++ b/prqlc/prqlc-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-prqlc = {path = "../prqlc", default-features = false, version = "0.13.5" }
+prqlc = {path = "../prqlc", default-features = false, version = "0.13.6" }
 syn = "2.0.106"
 
 [package.metadata.release]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -53,7 +53,7 @@ test-dbs-external = [
 ]
 
 [dependencies]
-prqlc-parser = { path = "../prqlc-parser", version = "0.13.5" }
+prqlc-parser = { path = "../prqlc-parser", version = "0.13.6" }
 
 anstream = { version = "0.6.21", features = ["auto"] }
 ariadne = "0.5.1"

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -343,7 +343,7 @@ mod tests {
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta name="keywords" content="prql">
-            <meta name="generator" content="prqlc 0.13.5">
+            <meta name="generator" content="prqlc 0.13.6">
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
             <title>PRQL Docs</title>
           </head>
@@ -421,7 +421,7 @@ mod tests {
 
             </main>
             <footer class="container border-top">
-              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.5.</small>
+              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.6.</small>
             </footer>
           </body>
         </html>
@@ -503,7 +503,7 @@ mod tests {
 
 
 
-        Generated with [prqlc](https://prql-lang.org/) 0.13.5.
+        Generated with [prqlc](https://prql-lang.org/) 0.13.6.
 
         ----- stderr -----
         ");

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -80,7 +80,7 @@ echo 'prql target:sql.generic
 PRQL allows specifying a version of the language in the PRQL header, like:
 
 ```prql
-prql version:"0.13.4"
+prql version:"0.13.5"
 
 from employees
 ```

--- a/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
@@ -4,7 +4,7 @@ expression: "[{version = prql.version}]\n"
 ---
 WITH table_0 AS (
   SELECT
-    '0.13.5' AS version
+    '0.13.6' AS version
 )
 SELECT
   version

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prql-playground",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prql-playground",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.30.0",
         "@monaco-editor/react": "^4.7.0",
@@ -29,7 +29,7 @@
     },
     "../../prqlc/bindings/js": {
       "name": "prqlc",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -46,5 +46,5 @@
     "prepare": "rsync -ai --checksum --delete ../../prqlc/prqlc/tests/integration/data/ public/data/ && node generateBook.cjs",
     "preview": "vite preview"
   },
-  "version": "0.13.5"
+  "version": "0.13.6"
 }


### PR DESCRIPTION
Post-release version bump after 0.13.5 release.

This PR:
- Bumps all crate versions to 0.13.6
- Adds new unreleased section to changelog
- Updates snapshot tests with new version number

🤖 Generated with [Claude Code](https://claude.com/claude-code)