### PR TITLE
build: do not allow incompatible rust-version dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ runner = 'wasm-bindgen-test-runner'
 [target.x86_64-pc-windows-msvc]
 # https://github.com/rust-lang/rust/issues/141626#issuecomment-2919988483
 linker = "rust-lld"
+
+[resolver]
+incompatible-rust-versions = "fallback"


### PR DESCRIPTION
Related to #5491 and #5492
Supersedes #5444 