### PR TITLE
docs: add comment to build-devcontainer workflow

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -1,5 +1,6 @@
 name: build-devcontainer
 
+# Multi-platform build for devcontainer base image
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary
- Add descriptive comment to the build-devcontainer workflow

This trivial change is to test the full multi-platform build and merge workflow after adding `.github/workflows/build-devcontainer.yaml` to the `devcontainer-push` path filter in #5507.

## Test plan
- [ ] Merge this PR
- [ ] Verify the merge job runs and creates the multi-platform manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)