### PR TITLE
fix: filter out attestation manifests in platform verification

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -1,5 +1,6 @@
 name: build-devcontainer
 
+# Multi-platform build for devcontainer base image
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -120,7 +120,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
           platforms=$(docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} --raw | \
-            jq -r '.manifests[].platform | "\(.os)/\(.architecture)"' | sort)
+            jq -r '.manifests[] | select(.platform.os != "unknown") | .platform | "\(.os)/\(.architecture)"' | sort)
           expected="linux/amd64
           linux/arm64"
           if [ "$platforms" != "$expected" ]; then


### PR DESCRIPTION
## Summary
- Filter out attestation manifests when verifying multi-platform manifest

## Problem
The merge job in #5508 failed because Docker build-push-action@v6 includes attestation manifests by default, which appear as "unknown/unknown" platforms. The verification script was checking all manifests including these attestation manifests.

## Solution  
Update the jq filter to exclude manifests where `platform.os == "unknown"`, which filters out the attestation manifests while keeping the actual platform manifests (linux/amd64, linux/arm64).

## Related
- Fixes the merge job failure in #5508
- Part of the ARM64 migration work from #5506

🤖 Generated with [Claude Code](https://claude.com/claude-code)