### PR TITLE
chore: pin typos to v1.37.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         # rustfmt handles rust files, and in some snapshots we expect trailing spaces.
         exclude: '.*\.(rs|snap)$'
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.37.2
     hooks:
       - id: typos
         # https://github.com/crate-ci/typos/issues/347


### PR DESCRIPTION
## Summary
- Updates typos from mutable tag v1 to concrete version v1.37.2
- Fixes pre-commit warning about mutable references

## Test plan
- [x] Pre-commit hooks run successfully without warnings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)