### PR TITLE
feat: Add support for Redshift dialect

### DIFF
--- a/prqlc/bindings/elixir/lib/prql.ex
+++ b/prqlc/bindings/elixir/lib/prql.ex
@@ -17,6 +17,7 @@ defmodule PRQL do
           | :bigquery
           | :clickhouse
           | :glaredb
+          | :redshift
           | :sqlite
           | :snowflake
   @type format_opt :: {:format, boolean()}

--- a/prqlc/bindings/elixir/lib/prql/native.ex
+++ b/prqlc/bindings/elixir/lib/prql/native.ex
@@ -26,6 +26,7 @@ defmodule PRQL.Native.CompileOptions do
           | :bigquery
           | :clickhouse
           | :glaredb
+          | :redshift
           | :sqlite
           | :snowflake
 

--- a/prqlc/bindings/elixir/native/prql/src/lib.rs
+++ b/prqlc/bindings/elixir/native/prql/src/lib.rs
@@ -22,6 +22,7 @@ mod atoms {
       mssql,
       mysql,
       postgres,
+      redshift,
       sqlite,
       snowflake
     }
@@ -61,6 +62,8 @@ fn target_from_atom(a: Atom) -> prqlc::Target {
         MySql
     } else if a == atoms::postgres() {
         Postgres
+    } else if a == atoms::redshift() {
+        Redshift
     } else if a == atoms::sqlite() {
         SQLite
     } else if a == atoms::snowflake() {

--- a/prqlc/prqlc/src/cli/test.rs
+++ b/prqlc/prqlc/src/cli/test.rs
@@ -87,6 +87,7 @@ fn get_targets() {
     sql.mssql
     sql.mysql
     sql.postgres
+    sql.redshift
     sql.sqlite
     sql.snowflake
 

--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -54,6 +54,7 @@ pub enum Dialect {
     MsSql,
     MySql,
     Postgres,
+    Redshift,
     SQLite,
     Snowflake,
 }
@@ -73,6 +74,7 @@ impl Dialect {
             Dialect::Snowflake => Box::new(SnowflakeDialect),
             Dialect::DuckDb => Box::new(DuckDbDialect),
             Dialect::Postgres => Box::new(PostgresDialect),
+            Dialect::Redshift => Box::new(RedshiftDialect),
             Dialect::GlareDb => Box::new(GlareDbDialect),
             Dialect::Ansi | Dialect::Generic => Box::new(GenericDialect),
         }
@@ -83,6 +85,7 @@ impl Dialect {
             Dialect::DuckDb
             | Dialect::SQLite
             | Dialect::Postgres
+            | Dialect::Redshift
             | Dialect::MySql
             | Dialect::Generic
             | Dialect::GlareDb
@@ -123,6 +126,8 @@ pub struct SnowflakeDialect;
 pub struct DuckDbDialect;
 #[derive(Debug)]
 pub struct PostgresDialect;
+#[derive(Debug)]
+pub struct RedshiftDialect;
 #[derive(Debug)]
 pub struct GlareDbDialect;
 
@@ -279,6 +284,71 @@ impl DialectHandler for PostgresDialect {
                 if literal.chars().any(|c| c.is_ascii_alphanumeric()) {
                     // If the literal contains alphanumeric characters, we need to quote it
                     // to avoid it being interpreted as a pattern understood by Postgres.
+                    // We hence need to put it in double quotes to force it to be interpreted as literal text
+                    format!("\"{literal}\"")
+                } else {
+                    literal.replace('\'', "''").replace('"', "\\\"")
+                }
+            }
+            Item::Space(spaces) => spaces.to_string(),
+            _ => {
+                return Err(Error::new_simple(
+                    "PRQL doesn't support this format specifier",
+                ))
+            }
+        })
+    }
+
+    fn supports_zero_columns(&self) -> bool {
+        true
+    }
+
+    fn prefers_subquery_parentheses_shorthand(&self) -> bool {
+        true
+    }
+}
+
+impl DialectHandler for RedshiftDialect {
+    fn ident_quoting_style(&self) -> IdentQuotingStyle {
+        // Use conditional quoting with dialect-specific keywords
+        IdentQuotingStyle::ConditionallyQuoted
+    }
+
+    fn requires_quotes_intervals(&self) -> bool {
+        true
+    }
+
+    fn supports_distinct_on(&self) -> bool {
+        false
+    }
+
+    // https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html
+    fn translate_chrono_item<'a>(&self, item: Item) -> Result<String> {
+        Ok(match item {
+            Item::Numeric(Numeric::Year, Pad::Zero) => "YYYY".to_string(),
+            Item::Numeric(Numeric::YearMod100, Pad::Zero) => "YY".to_string(),
+            Item::Numeric(Numeric::Month, Pad::None) => "FMMM".to_string(),
+            Item::Numeric(Numeric::Month, Pad::Zero) => "MM".to_string(),
+            Item::Numeric(Numeric::Day, Pad::None) => "FMDD".to_string(),
+            Item::Numeric(Numeric::Day, Pad::Zero) => "DD".to_string(),
+            Item::Numeric(Numeric::Hour, Pad::None) => "FMHH24".to_string(),
+            Item::Numeric(Numeric::Hour, Pad::Zero) => "HH24".to_string(),
+            Item::Numeric(Numeric::Hour12, Pad::Zero) => "HH12".to_string(),
+            Item::Numeric(Numeric::Minute, Pad::Zero) => "MI".to_string(),
+            Item::Numeric(Numeric::Second, Pad::Zero) => "SS".to_string(),
+            Item::Numeric(Numeric::Nanosecond, Pad::Zero) => "US".to_string(), // Microseconds
+            Item::Fixed(Fixed::ShortMonthName) => "Mon".to_string(),
+            // By default long names are blank-padded to 9 chars so we need to use FM prefix
+            Item::Fixed(Fixed::LongMonthName) => "FMMonth".to_string(),
+            Item::Fixed(Fixed::ShortWeekdayName) => "Dy".to_string(),
+            Item::Fixed(Fixed::LongWeekdayName) => "FMDay".to_string(),
+            Item::Fixed(Fixed::UpperAmPm) => "AM".to_string(),
+            Item::Fixed(Fixed::RFC3339) => "YYYY-MM-DD\"T\"HH24:MI:SS.USZ".to_string(),
+            Item::Literal(literal) => {
+                // literals are split at every non alphanumeric character
+                if literal.chars().any(|c| c.is_ascii_alphanumeric()) {
+                    // If the literal contains alphanumeric characters, we need to quote it
+                    // to avoid it being interpreted as a pattern understood by Redshift.
                     // We hence need to put it in double quotes to force it to be interpreted as literal text
                     format!("\"{literal}\"")
                 } else {

--- a/prqlc/prqlc/src/sql/gen_expr.rs
+++ b/prqlc/prqlc/src/sql/gen_expr.rs
@@ -834,7 +834,7 @@ pub(super) fn translate_ident_part(ident: String, ctx: &Context) -> sql_ast::Ide
     let is_bare = valid_ident().is_match(&ident);
     match ctx.dialect.ident_quoting_style() {
         IdentQuotingStyle::ConditionallyQuoted => {
-            if is_bare && !keywords::is_keyword(&ident) {
+            if is_bare && !keywords::is_keyword(&ident, &ctx.dialect_enum) {
                 sql_ast::Ident::new(ident)
             } else {
                 sql_ast::Ident::with_quote(ctx.dialect.ident_quote(), ident)

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select.snap
@@ -50,3 +50,51 @@ input_file: prqlc/prqlc/tests/integration/queries/append_select.prql
 +  LIMIT
 +    6 OFFSET 39
 +)
+
+--- generic
++++ redshift
+@@ -1,26 +1,19 @@
+-SELECT
+-  *
+-FROM
+-  (
+-    SELECT
+-      billing_country,
+-      invoice_id
+-    FROM
+-      invoices
+-    LIMIT
+-      6 OFFSET 9
+-  ) AS table_2
++(
++  SELECT
++    billing_country,
++    invoice_id
++  FROM
++    invoices
++  LIMIT
++    6 OFFSET 9
++)
+ UNION
+-ALL
+-SELECT
+-  *
+-FROM
+-  (
+-    SELECT
+-      billing_country,
+-      invoice_id
+-    FROM
+-      invoices
+-    LIMIT
+-      6 OFFSET 39
+-  ) AS table_3
++ALL (
++  SELECT
++    billing_country,
++    invoice_id
++  FROM
++    invoices
++  LIMIT
++    6 OFFSET 39
++)

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select_compute.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select_compute.snap
@@ -93,3 +93,74 @@ input_file: prqlc/prqlc/tests/integration/queries/append_select_compute.prql
 +  ROUND((invoice_id * _expr_0)::numeric, 1) AS b
  FROM
    table_1
+
+--- generic
++++ redshift
+@@ -1,41 +1,34 @@
+ WITH table_1 AS (
+-  SELECT
+-    *
+-  FROM
+-    (
+-      SELECT
+-        invoice_id,
+-        CASE
+-          WHEN total < 10 THEN total * 2
+-          ELSE total
+-        END AS _expr_0,
+-        customer_id
+-      FROM
+-        invoices
+-      LIMIT
+-        5
+-    ) AS table_3
++  (
++    SELECT
++      invoice_id,
++      CASE
++        WHEN total < 10 THEN total * 2
++        ELSE total
++      END AS _expr_0,
++      customer_id
++    FROM
++      invoices
++    LIMIT
++      5
++  )
+   UNION
+-  ALL
+-  SELECT
+-    *
+-  FROM
+-    (
+-      SELECT
+-        invoice_id,
+-        CASE
+-          WHEN unit_price < 1 THEN unit_price * 2
+-          ELSE unit_price
+-        END AS unit_price,
+-        invoice_line_id
+-      FROM
+-        invoice_items
+-      LIMIT
+-        5
+-    ) AS table_4
++  ALL (
++    SELECT
++      invoice_id,
++      CASE
++        WHEN unit_price < 1 THEN unit_price * 2
++        ELSE unit_price
++      END AS unit_price,
++      invoice_line_id
++    FROM
++      invoice_items
++    LIMIT
++      5
++  )
+ )
+ SELECT
+   customer_id * 2 AS a,
+   ROUND(invoice_id * _expr_0, 1) AS b
+ FROM
+   table_1

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select_multiple_with_null.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select_multiple_with_null.snap
@@ -73,3 +73,74 @@ input_file: prqlc/prqlc/tests/integration/queries/append_select_multiple_with_nu
 +  LIMIT
 +    5
 +)
+
+--- generic
++++ redshift
+@@ -1,40 +1,29 @@
+-SELECT
+-  *
+-FROM
+-  (
+-    SELECT
+-      billing_country,
+-      invoice_id
+-    FROM
+-      invoices
+-    LIMIT
+-      5
+-  ) AS table_4
++(
++  SELECT
++    billing_country,
++    invoice_id
++  FROM
++    invoices
++  LIMIT
++    5
++)
+ UNION
+-ALL
+-SELECT
+-  *
+-FROM
+-  (
+-    SELECT
+-      country,
+-      employee_id
+-    FROM
+-      employees
+-    LIMIT
+-      5
+-  ) AS table_5
++ALL (
++  SELECT
++    country,
++    employee_id
++  FROM
++    employees
++  LIMIT
++    5
++)
+ UNION
+-ALL
+-SELECT
+-  *
+-FROM
+-  (
+-    SELECT
+-      NULL,
+-      invoice_id
+-    FROM
+-      invoice_items
+-    LIMIT
+-      5
+-  ) AS table_6
++ALL (
++  SELECT
++    NULL,
++    invoice_id
++  FROM
++    invoice_items
++  LIMIT
++    5
++)

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select_nulls.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__append_select_nulls.snap
@@ -50,3 +50,51 @@ input_file: prqlc/prqlc/tests/integration/queries/append_select_nulls.prql
 +  LIMIT
 +    2
 +)
+
+--- generic
++++ redshift
+@@ -1,26 +1,19 @@
+-SELECT
+-  *
+-FROM
+-  (
+-    SELECT
+-      invoice_id AS an_id,
+-      NULL AS name
+-    FROM
+-      invoices
+-    LIMIT
+-      2
+-  ) AS table_2
++(
++  SELECT
++    invoice_id AS an_id,
++    NULL AS name
++  FROM
++    invoices
++  LIMIT
++    2
++)
+ UNION
+-ALL
+-SELECT
+-  *
+-FROM
+-  (
+-    SELECT
+-      NULL AS an_id,
+-      first_name AS name
+-    FROM
+-      employees
+-    LIMIT
+-      2
+-  ) AS table_3
++ALL (
++  SELECT
++    NULL AS an_id,
++    first_name AS name
++  FROM
++    employees
++  LIMIT
++    2
++)

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__arithmetic.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__arithmetic.snap
@@ -2,6 +2,7 @@
 source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom [\n    { id = 1, x_int =  13, x_float =  13.0, k_int =  5, k_float =  5.0 },\n    { id = 2, x_int = -13, x_float = -13.0, k_int =  5, k_float =  5.0 },\n    { id = 3, x_int =  13, x_float =  13.0, k_int = -5, k_float = -5.0 },\n    { id = 4, x_int = -13, x_float = -13.0, k_int = -5, k_float = -5.0 },\n]\nselect {\n    id,\n\n    x_int / k_int,\n    x_int / k_float,\n    x_float / k_int,\n    x_float / k_float,\n\n    q_ii = x_int // k_int,\n    q_if = x_int // k_float,\n    q_fi = x_float // k_int,\n    q_ff = x_float // k_float,\n\n    r_ii = x_int % k_int,\n    r_if = x_int % k_float,\n    r_fi = x_float % k_int,\n    r_ff = x_float % k_float,\n\n    (q_ii * k_int + r_ii | math.round 0),\n    (q_if * k_float + r_if | math.round 0),\n    (q_fi * k_int + r_fi | math.round 0),\n    (q_ff * k_float + r_ff | math.round 0),\n}\nsort id\n"
 input_file: prqlc/prqlc/tests/integration/queries/arithmetic.prql
+snapshot_kind: text
 ---
 --- generic
 +++ clickhouse
@@ -337,6 +338,7 @@ input_file: prqlc/prqlc/tests/integration/queries/arithmetic.prql
    table_0
  ORDER BY
    id
+
 
 --- generic
 +++ sqlite

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__constants_only.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__constants_only.snap
@@ -26,3 +26,27 @@ input_file: prqlc/prqlc/tests/integration/queries/constants_only.prql
  SELECT
    10 AS d
  FROM
+
+--- generic
++++ redshift
+@@ -1,20 +1,18 @@
+ WITH table_1 AS (
+   SELECT
+-    NULL
+   FROM
+     genres
+   LIMIT
+     10
+ ), table_0 AS (
+   SELECT
+-    NULL
+   FROM
+     table_1
+   WHERE
+     true
+   LIMIT
+     20
+ )
+ SELECT
+   10 AS d
+ FROM

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__set_ops_remove.snap
@@ -2,6 +2,7 @@
 source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nlet distinct = rel -> (from t = _param.rel | group {t.*} (take 1))\n\nfrom_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2], [2], [3]] }'\ndistinct\nremove (from_text format:json '{ \"columns\": [\"a\"], \"data\": [[1], [2]] }')\nsort a\n"
 input_file: prqlc/prqlc/tests/integration/queries/set_ops_remove.prql
+snapshot_kind: text
 ---
 --- generic
 +++ mssql
@@ -27,6 +28,7 @@ input_file: prqlc/prqlc/tests/integration/queries/set_ops_remove.prql
  FROM
    table_2
  ORDER BY
+
 
 
 

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__text_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__text_module.snap
@@ -2,6 +2,7 @@
 source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\n# glaredb:skip — TODO: started raising an error on 2024-05-20; see `window.prql`\n# for more details\nfrom albums\nselect {\n    title,\n    title_and_spaces = f\"  {title}  \",\n    low = (title | text.lower),\n    up = (title | text.upper),\n    ltrimmed = (title | text.ltrim),\n    rtrimmed = (title | text.rtrim),\n    trimmed = (title | text.trim),\n    len = (title | text.length),\n    subs = (title | text.extract 2 5),\n    replace = (title | text.replace \"al\" \"PIKA\"),\n}\nsort {title}\nfilter (title | text.starts_with \"Black\") || (title | text.contains \"Sabbath\") || (title | text.ends_with \"os\")\n"
 input_file: prqlc/prqlc/tests/integration/queries/text_module.prql
+snapshot_kind: text
 ---
 --- generic
 +++ clickhouse
@@ -157,6 +158,7 @@ input_file: prqlc/prqlc/tests/integration/queries/text_module.prql
    low,
    up,
    ltrimmed,
+
 
 --- generic
 +++ sqlite


### PR DESCRIPTION
Not 100% complete support, but solves major blockers using Redshift:

1. Prevents `DISTINCT ON` being used for `group ... take 1` deduplication.
2. Escape keywords when used as column names.