### PR TITLE
fix(redshift): use || operator over CONCAT for std.concat

### DIFF
--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -371,6 +371,12 @@ impl DialectHandler for RedshiftDialect {
     fn prefers_subquery_parentheses_shorthand(&self) -> bool {
         true
     }
+
+    // Redshift only supports CONCAT with two elements, the docs recommend to use the || operator
+    // for more than two elements: https://docs.aws.amazon.com/redshift/latest/dg/r_CONCAT.html
+    fn has_concat_function(&self) -> bool {
+        false
+    }
 }
 
 impl DialectHandler for GlareDbDialect {

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__text_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__text_module.snap
@@ -2,7 +2,6 @@
 source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\n# glaredb:skip — TODO: started raising an error on 2024-05-20; see `window.prql`\n# for more details\nfrom albums\nselect {\n    title,\n    title_and_spaces = f\"  {title}  \",\n    low = (title | text.lower),\n    up = (title | text.upper),\n    ltrimmed = (title | text.ltrim),\n    rtrimmed = (title | text.rtrim),\n    trimmed = (title | text.trim),\n    len = (title | text.length),\n    subs = (title | text.extract 2 5),\n    replace = (title | text.replace \"al\" \"PIKA\"),\n}\nsort {title}\nfilter (title | text.starts_with \"Black\") || (title | text.contains \"Sabbath\") || (title | text.ends_with \"os\")\n"
 input_file: prqlc/prqlc/tests/integration/queries/text_module.prql
-snapshot_kind: text
 ---
 --- generic
 +++ clickhouse
@@ -159,6 +158,24 @@ snapshot_kind: text
    up,
    ltrimmed,
 
+--- generic
++++ redshift
+@@ -1,14 +1,14 @@
+ WITH table_0 AS (
+   SELECT
+     title,
+-    CONCAT('  ', title, '  ') AS title_and_spaces,
++    '  ' || title || '  ' AS title_and_spaces,
+     LOWER(title) AS low,
+     UPPER(title) AS up,
+     LTRIM(title) AS ltrimmed,
+     RTRIM(title) AS rtrimmed,
+     TRIM(title) AS trimmed,
+     CHAR_LENGTH(title) AS len,
+     SUBSTRING(title, 2, 5) AS subs,
+     REPLACE(title, 'al', 'PIKA') AS "replace"
+   FROM
+     albums
 
 --- generic
 +++ sqlite

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6361,3 +6361,21 @@ FROM
         expected.trim_start()
     )
 }
+
+// Test that Redshift uses double pipe (||) over CONCAT
+#[test]
+fn test_redshift_uses_double_pipe_over_concat() {
+    assert_snapshot!(compile_with_sql_dialect(r###"
+    from invoice
+    derive {
+        concatenated = f"{col_one} + {col_two}"
+    }
+    "###, sql::Dialect::Redshift
+    ).unwrap(), @r"
+    SELECT
+      *,
+      col_one || ' + ' || col_two AS concatenated
+    FROM
+      invoice
+    ");
+}


### PR DESCRIPTION
Follow-up for @priithaamer 's work on the Redshift dialect (thanks!). I'm getting the following error from Redshift when usingg f-strings: `[SQLState 42883] ERROR:  function concat(character varying, "unknown", character varying) doe
s not exist`

The Redshift docs state that one should use nested CONCAT functions or the `||` operator to concatenate more than two elements: https://docs.aws.amazon.com/redshift/latest/dg/r_CONCAT.html