### PR TITLE
fix(redshift): fix INTERVAL quoting

### DIFF
--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -326,14 +326,10 @@ impl DialectHandler for RedshiftDialect {
     }
 
     fn interval_quoting_style(&self, dtf: &DateTimeField) -> IntervalQuotingStyle {
-        if let DateTimeField::Year
-        | DateTimeField::Years
-        | DateTimeField::Month
-        | DateTimeField::Months = dtf
-        {
-            IntervalQuotingStyle::ValueQuoted
-        } else {
+        if matches!(dtf, DateTimeField::Week(_) | DateTimeField::Weeks) {
             IntervalQuotingStyle::ValueAndUnitQuoted
+        } else {
+            IntervalQuotingStyle::ValueQuoted
         }
     }
 

--- a/prqlc/prqlc/src/sql/gen_expr.rs
+++ b/prqlc/prqlc/src/sql/gen_expr.rs
@@ -16,7 +16,7 @@ use super::{keywords, Context};
 use crate::ir::generic::{ColumnSort, SortDirection, WindowFrame, WindowKind};
 use crate::ir::pl::{self, Ident, Literal};
 use crate::ir::rq;
-use crate::sql::dialect::IdentQuotingStyle;
+use crate::sql::dialect::{IdentQuotingStyle, IntervalQuotingStyle};
 use crate::sql::pq::context::ColumnDecl;
 use crate::utils::{valid_ident, OrMap};
 use crate::{Error, Result, Span, WithErrorInfo};
@@ -428,27 +428,46 @@ pub(super) fn translate_literal(l: Literal, ctx: &Context) -> Result<sql_ast::Ex
                     )))
                 }
             };
-            if ctx.dialect.requires_quotes_intervals() {
-                //postgres requires quotes around number and unit together eg '3 WEEK'
-                let value = Box::new(sql_ast::Expr::Value(
-                    Value::SingleQuotedString(format!("{} {}", vau.n, sql_parser_datetime)).into(),
-                ));
-                sql_ast::Expr::Interval(sqlparser::ast::Interval {
-                    value,
-                    leading_field: None, //set to none since field is now contained in string
-                    leading_precision: None,
-                    last_field: None,
-                    fractional_seconds_precision: None,
-                })
-            } else {
-                let value = Box::new(translate_literal(Literal::Integer(vau.n), ctx)?);
-                sql_ast::Expr::Interval(sqlparser::ast::Interval {
-                    value,
-                    leading_field: Some(sql_parser_datetime),
-                    leading_precision: None,
-                    last_field: None,
-                    fractional_seconds_precision: None,
-                })
+            match ctx.dialect.interval_quoting_style(&sql_parser_datetime) {
+                IntervalQuotingStyle::ValueAndUnitQuoted => {
+                    //postgres requires quotes around number and unit together eg '3 WEEK'
+                    let value = Box::new(sql_ast::Expr::Value(
+                        Value::SingleQuotedString(format!("{} {}", vau.n, sql_parser_datetime))
+                            .into(),
+                    ));
+                    sql_ast::Expr::Interval(sqlparser::ast::Interval {
+                        value,
+                        leading_field: None, //set to none since field is now contained in string
+                        leading_precision: None,
+                        last_field: None,
+                        fractional_seconds_precision: None,
+                    })
+                }
+                IntervalQuotingStyle::NoQuotes => {
+                    let value = Box::new(translate_literal(Literal::Integer(vau.n), ctx)?);
+                    sql_ast::Expr::Interval(sqlparser::ast::Interval {
+                        value,
+                        leading_field: Some(sql_parser_datetime),
+                        leading_precision: None,
+                        last_field: None,
+                        fractional_seconds_precision: None,
+                    })
+                }
+                // Redshift requires quotes around the number only, otherwise months and years are
+                // not supported. eg '3' MONTH
+                IntervalQuotingStyle::ValueQuoted => {
+                    // Adding single quotes around the number
+                    let value = Box::new(sql_ast::Expr::Value(
+                        Value::SingleQuotedString(vau.n.to_string()).into(),
+                    ));
+                    sql_ast::Expr::Interval(sqlparser::ast::Interval {
+                        value,
+                        leading_field: Some(sql_parser_datetime),
+                        leading_precision: None,
+                        last_field: None,
+                        fractional_seconds_precision: None,
+                    })
+                }
             }
         }
     })

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6382,8 +6382,8 @@ fn test_redshift_uses_double_pipe_over_concat() {
 
 #[rstest]
 #[case(
-    "from t | select { inter = 2years }",
-    "SELECT\n  INTERVAL '2' YEAR AS inter\nFROM\n  t\n"
+    "from t | select { inter = 2weeks }",
+    "SELECT\n  INTERVAL '2 WEEK' AS inter\nFROM\n  t\n"
 )]
 #[case(
     "from t | select { inter = 2months }",
@@ -6391,7 +6391,7 @@ fn test_redshift_uses_double_pipe_over_concat() {
 )]
 #[case(
     "from t | select { inter = 2hours }",
-    "SELECT\n  INTERVAL '2 HOUR' AS inter\nFROM\n  t\n"
+    "SELECT\n  INTERVAL '2' HOUR AS inter\nFROM\n  t\n"
 )]
 fn test_redshift_interval_quoting(#[case] query: &str, #[case] expected: &str) {
     assert_eq!(

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6379,3 +6379,23 @@ fn test_redshift_uses_double_pipe_over_concat() {
       invoice
     ");
 }
+
+#[rstest]
+#[case(
+    "from t | select { inter = 2years }",
+    "SELECT\n  INTERVAL '2' YEAR AS inter\nFROM\n  t\n"
+)]
+#[case(
+    "from t | select { inter = 2months }",
+    "SELECT\n  INTERVAL '2' MONTH AS inter\nFROM\n  t\n"
+)]
+#[case(
+    "from t | select { inter = 2hours }",
+    "SELECT\n  INTERVAL '2 HOUR' AS inter\nFROM\n  t\n"
+)]
+fn test_redshift_interval_quoting(#[case] query: &str, #[case] expected: &str) {
+    assert_eq!(
+        compile_with_sql_dialect(query, sql::Dialect::Redshift).unwrap(),
+        expected
+    )
+}


### PR DESCRIPTION
Continuing the work in #5540 for intervals. 
Unfortunately, there is no "one size fits all" quoting that works for redshift:

`INTERVAL '1 year'` causes the following error: `Interval values with month or year parts are not supported`

`SELECT CAST((DATE_TRUNC('week', added_date) - INTERVAL '1' WEEK) AS timestamp) AS firstdayofpreviousweek` causes a syntax error: `Error occurred while trying to execute a query: [SQLState 42601] ERROR:  syntax error at or near \"WEEK\" in context \")` However, replacing `'1' WEEK` with `'1 WEEK'` here works.
