### PR TITLE
fix: Fix support for text.contains in sql.redshift target

### DIFF
--- a/prqlc/prqlc/src/sql/std.sql.prql
+++ b/prqlc/prqlc/src/sql/std.sql.prql
@@ -326,6 +326,12 @@ module postgres {
 module redshift {
   @{binding_strength=11}
   let div_f = l r -> s"({l} * 1.0 / {r:12})"
+
+  # Text functions
+  module text {
+    # https://docs.aws.amazon.com/redshift/latest/dg/r_concat_op.html
+    let contains = substr column -> s"{column:0} LIKE '%' || {substr:0} || '%'"
+  }
 }
 
 module glaredb {

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__text_module.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__text_module.snap
@@ -176,6 +176,22 @@ input_file: prqlc/prqlc/tests/integration/queries/text_module.prql
      REPLACE(title, 'al', 'PIKA') AS "replace"
    FROM
      albums
+@@ -21,14 +21,14 @@
+   ltrimmed,
+   rtrimmed,
+   trimmed,
+   len,
+   subs,
+   "replace"
+ FROM
+   table_0
+ WHERE
+   title LIKE CONCAT('Black', '%')
+-  OR title LIKE CONCAT('%', 'Sabbath', '%')
++  OR title LIKE '%' || 'Sabbath' || '%'
+   OR title LIKE CONCAT('%', 'os')
+ ORDER BY
+   title
 
 --- generic
 +++ sqlite

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6379,3 +6379,21 @@ fn test_redshift_uses_double_pipe_over_concat() {
       invoice
     ");
 }
+
+#[test]
+fn test_redshift_text_contains_uses_double_pipe() {
+    assert_snapshot!(compile_with_sql_dialect(r###"
+    from employees
+    select {
+        name,
+        has_substring = (name | text.contains "pika")
+    }
+    "###, sql::Dialect::Redshift
+    ).unwrap(), @r"
+    SELECT
+      name,
+      name LIKE '%' || 'pika' || '%' AS has_substring
+    FROM
+      employees
+    ");
+}


### PR DESCRIPTION
Redshift target does not support `CONCAT('%', token, '%')` syntax.

This allow using the more general syntax `'%' || token || '%'` when using `text.contains`.

Similiar to: https://github.com/PRQL/prql/pull/5540