### PR TITLE
fix: Lineage works with unions

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__test__append_union_different_tables.snap
+++ b/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__test__append_union_different_tables.snap
@@ -1,0 +1,29 @@
+---
+source: prqlc/prqlc/src/semantic/resolver/mod.rs
+assertion_line: 234
+expression: final_lineage
+---
+columns:
+  - Single:
+      name:
+        - employees
+        - name
+      target_id: 131
+      target_name: ~
+  - Single:
+      name:
+        - employees
+        - salary
+      target_id: 132
+      target_name: ~
+inputs:
+  - id: 129
+    name: employees
+    table:
+      - default_db
+      - employees
+  - id: 118
+    name: managers
+    table:
+      - default_db
+      - managers

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -753,18 +753,16 @@ fn append(mut top: Lineage, bottom: Lineage) -> Result<Lineage, Error> {
                     except: except_t,
                 },
                 LineageColumn::All {
-                    input_id: input_id_b,
+                    input_id: _input_id_b,
                     except: except_b,
                 },
             ) => {
-                // If both are All columns from the same input, merge the except sets
-                // Otherwise, keep the top's input_id
-                // Note: In a union, both inputs should be available, so we keep top's
+                // Merge except sets from both tables
+                // This preserves exclusion information even when input_ids differ
+                // (e.g., "from employees select !{name}" append "from managers select !{salary}")
                 let mut except = except_t;
-                if input_id_t == input_id_b {
-                    // Same input, merge except sets
-                    except.extend(except_b);
-                }
+                except.extend(except_b);
+
                 LineageColumn::All {
                     input_id: input_id_t,
                     except,

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select.snap
@@ -1,5 +1,6 @@
 ---
 source: prqlc/prqlc/tests/integration/queries.rs
+assertion_line: 149
 expression: "from invoices\nselect { customer_id, invoice_id, billing_country }\ntake 10..15\nappend (\n  from invoices\n  select { customer_id, invoice_id, billing_country }\n  take 40..45\n)\nselect { billing_country, invoice_id }\n"
 input_file: prqlc/prqlc/tests/integration/queries/append_select.prql
 ---
@@ -134,6 +135,11 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 124
+      name: invoices
+      table:
+      - default_db
+      - invoices
 - - 1:173-211
   - columns:
     - !Single
@@ -150,6 +156,11 @@ frames:
       target_name: null
     inputs:
     - id: 143
+      name: invoices
+      table:
+      - default_db
+      - invoices
+    - id: 124
       name: invoices
       table:
       - default_db

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_compute.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_compute.snap
@@ -1,5 +1,6 @@
 ---
 source: prqlc/prqlc/tests/integration/queries.rs
+assertion_line: 149
 expression: "from invoices\nderive total = case [total < 10 => total * 2, true => total]\nselect { customer_id, invoice_id, total }\ntake 5\nappend (\n  from invoice_items\n  derive unit_price = case [unit_price < 1 => unit_price * 2, true => unit_price]\n  select { invoice_line_id, invoice_id, unit_price }\n  take 5\n)\nselect { a = customer_id * 2, b = math.round 1 (invoice_id * total) }\n"
 input_file: prqlc/prqlc/tests/integration/queries/append_select_compute.prql
 ---
@@ -161,6 +162,11 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 127
+      name: invoice_items
+      table:
+      - default_db
+      - invoice_items
 - - 1:300-369
   - columns:
     - !Single
@@ -179,6 +185,11 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 127
+      name: invoice_items
+      table:
+      - default_db
+      - invoice_items
 nodes:
 - id: 127
   kind: Ident

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_multiple_with_null.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_multiple_with_null.snap
@@ -1,5 +1,6 @@
 ---
 source: prqlc/prqlc/tests/integration/queries.rs
+assertion_line: 149
 expression: "from invoices\nselect { customer_id, invoice_id, billing_country }\ntake 5\nappend (\n  from employees\n  select { employee_id, employee_id, country }\n  take 5\n)\nappend (\n  from invoice_items\n  select { invoice_line_id, invoice_id, null }\n  take 5\n)\nselect { billing_country, invoice_id }\n"
 input_file: prqlc/prqlc/tests/integration/queries/append_select_multiple_with_null.prql
 ---
@@ -130,6 +131,11 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 145
+      name: employees
+      table:
+      - default_db
+      - employees
 - - 1:189-233
   - columns:
     - !Single
@@ -204,6 +210,16 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 145
+      name: employees
+      table:
+      - default_db
+      - employees
+    - id: 124
+      name: invoice_items
+      table:
+      - default_db
+      - invoice_items
 - - 1:245-283
   - columns:
     - !Single
@@ -224,6 +240,16 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 145
+      name: employees
+      table:
+      - default_db
+      - employees
+    - id: 124
+      name: invoice_items
+      table:
+      - default_db
+      - invoice_items
 nodes:
 - id: 124
   kind: Ident

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_nulls.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_nulls.snap
@@ -1,5 +1,6 @@
 ---
 source: prqlc/prqlc/tests/integration/queries.rs
+assertion_line: 149
 expression: "from invoices\nselect {an_id = invoice_id, name = null}\ntake 2\nappend (\n  from employees\n  select {an_id = null, name = first_name}\n  take 2\n)\n"
 input_file: prqlc/prqlc/tests/integration/queries/append_select_nulls.prql
 ---
@@ -94,6 +95,11 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 121
+      name: employees
+      table:
+      - default_db
+      - employees
 nodes:
 - id: 121
   kind: Ident

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_simple.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__append_select_simple.snap
@@ -1,5 +1,6 @@
 ---
 source: prqlc/prqlc/tests/integration/queries.rs
+assertion_line: 149
 expression: "from invoices\nselect { invoice_id, billing_country }\nappend (\n  from invoices\n  select { invoice_id = `invoice_id` + 100, billing_country }\n)\nfilter (billing_country | text.starts_with(\"I\"))\n"
 input_file: prqlc/prqlc/tests/integration/queries/append_select_simple.prql
 ---
@@ -63,6 +64,11 @@ frames:
       table:
       - default_db
       - invoices
+    - id: 121
+      name: invoices
+      table:
+      - default_db
+      - invoices
 - - 1:142-190
   - columns:
     - !Single
@@ -79,6 +85,11 @@ frames:
       target_name: null
     inputs:
     - id: 135
+      name: invoices
+      table:
+      - default_db
+      - invoices
+    - id: 121
       name: invoices
       table:
       - default_db


### PR DESCRIPTION
Fixes lineage tracking for `append` (UNION) operations to correctly track inputs from both source tables.

Previously, when using `append` to union two tables, the lineage only tracked the top table's inputs. The `append` function now merges `bottom.inputs` into `top.inputs` (similar to how `join` handles inputs), ensuring both source tables are tracked.

Added test to verify both inputs are tracked and column-level lineage works correctly.