### PR TITLE
chore: Prepare release 0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@
 
 **New Contributors**:
 
+## 0.13.7 — 2025-11-08
+
+0.13.7 has 8 commits from 6 contributors. Selected changes:
+
+**Fixes**:
+
+- Fix INTERVAL quoting in Redshift (@lukapeschke, #5545)
+- Fix support for text.contains in sql.redshift target (@dimtion, #5549)
+- Fix division in Redshift produces float (@priithaamer, #5546)
+- Use || operator over CONCAT for std.concat in Redshift (@lukapeschke, #5540)
+
+**Web**:
+
+- Bump vite from 7.1.11 to 7.2.0 in playground (#5547)
+
+**Internal changes**:
+
+- Bump the patch group with 2 updates (#5542)
+- pre-commit autoupdate (#5541)
+
 ## 0.13.6 — 2025-11-01
 
 0.13.6 has 40 commits from 6 contributors. Selected changes:


### PR DESCRIPTION
## Summary

This PR prepares the release for PRQL 0.13.7:

**Fixes**:
- Fix INTERVAL quoting in Redshift (@lukapeschke, #5545)
- Fix support for text.contains in sql.redshift target (@dimtion, #5549)
- Fix division in Redshift produces float (@priithaamer, #5546)
- Use || operator over CONCAT for std.concat in Redshift (@lukapeschke, #5540)

**Web**:
- Bump vite from 7.1.11 to 7.2.0 in playground (#5547)

**Internal changes**:
- Bump the patch group with 2 updates (#5542)
- pre-commit autoupdate (#5541)

---

This PR includes 8 commits from 6 contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)