### PR TITLE
chore: Bump version to 0.13.8 for next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,6 @@
 
 - Bump vite from 7.1.11 to 7.2.0 in playground (#5547)
 
-**Internal changes**:
-
-- Bump the patch group with 2 updates (#5542)
-- pre-commit autoupdate (#5541)
-
 ## 0.13.6 — 2025-11-01
 
 0.13.6 has 40 commits from 6 contributors. Selected changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@
 
 **New Contributors**:
 
+## [unreleased]
+
+**Language**:
+
+**Features**:
+
+**Fixes**:
+
+**Documentation**:
+
+**Web**:
+
+**Integrations**:
+
+**Internal changes**:
+
+**New Contributors**:
+
 ## 0.13.7 — 2025-11-08
 
 0.13.7 has 8 commits from 6 contributors. Selected changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,24 +18,6 @@
 
 **New Contributors**:
 
-## [unreleased]
-
-**Language**:
-
-**Features**:
-
-**Fixes**:
-
-**Documentation**:
-
-**Web**:
-
-**Integrations**:
-
-**Internal changes**:
-
-**New Contributors**:
-
 ## 0.13.7 — 2025-11-08
 
 0.13.7 has 8 commits from 6 contributors. Selected changes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "compile-files"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "prqlc",
 ]
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-prql"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "ansi-to-html",
  "anstream",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "prql"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "prqlc",
  "rustler",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "prql-java"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "jni",
  "prqlc",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anstream",
  "anyhow",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-c"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "libc",
  "prqlc",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-js"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "console_error_panic_hook",
  "prqlc",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-macros"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "prqlc",
  "syn 2.0.108",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-parser"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "chumsky",
  "enum-as-inner",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-python"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "insta",
  "prqlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/PRQL/prql"
 # This isn't tested since `cargo-msrv` doesn't support workspaces; instead we
 # test `metadata.msrv` in `prqlc`
 rust-version = "1.75.0"
-version = "0.13.7"
+version = "0.13.8"
 
 [profile.release]
 lto = true

--- a/prqlc/bindings/elixir/native/prql/Cargo.toml
+++ b/prqlc/bindings/elixir/native/prql/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/lib.rs"
 test = false
 
 [target.'cfg(not(any(target_family="wasm")))'.dependencies]
-prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.7" }
+prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.8" }
 rustler = "0.37.0"

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prqlc",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prqlc",
-      "version": "0.13.7",
+      "version": "0.13.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -35,5 +35,5 @@
     "test": "mocha tests"
   },
   "types": "dist/node/prqlc_js.d.ts",
-  "version": "0.13.7"
+  "version": "0.13.8"
 }

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: "0.13.7"
+version: "0.13.8"
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/prqlc-macros/Cargo.toml
+++ b/prqlc/prqlc-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-prqlc = {path = "../prqlc", default-features = false, version = "0.13.7" }
+prqlc = {path = "../prqlc", default-features = false, version = "0.13.8" }
 syn = "2.0.108"
 
 [package.metadata.release]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -53,7 +53,7 @@ test-dbs-external = [
 ]
 
 [dependencies]
-prqlc-parser = { path = "../prqlc-parser", version = "0.13.7" }
+prqlc-parser = { path = "../prqlc-parser", version = "0.13.8" }
 
 anstream = { version = "0.6.21", features = ["auto"] }
 ariadne = "0.5.1"

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -343,7 +343,7 @@ mod tests {
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta name="keywords" content="prql">
-            <meta name="generator" content="prqlc 0.13.7">
+            <meta name="generator" content="prqlc 0.13.8">
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
             <title>PRQL Docs</title>
           </head>
@@ -421,7 +421,7 @@ mod tests {
 
             </main>
             <footer class="container border-top">
-              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.7.</small>
+              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.8.</small>
             </footer>
           </body>
         </html>
@@ -503,7 +503,7 @@ mod tests {
 
 
 
-        Generated with [prqlc](https://prql-lang.org/) 0.13.7.
+        Generated with [prqlc](https://prql-lang.org/) 0.13.8.
 
         ----- stderr -----
         ");

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -80,7 +80,7 @@ echo 'prql target:sql.generic
 PRQL allows specifying a version of the language in the PRQL header, like:
 
 ```prql
-prql version:"0.13.6"
+prql version:"0.13.7"
 
 from employees
 ```

--- a/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
@@ -4,7 +4,7 @@ expression: "[{version = prql.version}]\n"
 ---
 WITH table_0 AS (
   SELECT
-    '0.13.7' AS version
+    '0.13.8' AS version
 )
 SELECT
   version

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prql-playground",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prql-playground",
-      "version": "0.13.7",
+      "version": "0.13.8",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.30.0",
         "@monaco-editor/react": "^4.7.0",
@@ -29,7 +29,7 @@
     },
     "../../prqlc/bindings/js": {
       "name": "prqlc",
-      "version": "0.13.7",
+      "version": "0.13.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -46,5 +46,5 @@
     "prepare": "rsync -ai --checksum --delete ../../prqlc/prqlc/tests/integration/data/ public/data/ && node generateBook.cjs",
     "preview": "vite preview"
   },
-  "version": "0.13.7"
+  "version": "0.13.8"
 }


### PR DESCRIPTION
## Summary

This PR bumps the version to 0.13.8 for the next development cycle after releasing 0.13.7.

Changes:
- Updated workspace version from 0.13.7 to 0.13.8
- Updated CHANGELOG.md with unreleased section
- Updated snapshot tests with version references

This is the standard post-release version bump as per the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)