### PR TITLE
ci: Update nightly Rust version to 2025-11-10

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v5
-      - run: rustup override set nightly-2025-09-22
+      - run: rustup override set nightly-2025-11-10
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-udeps

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -572,7 +572,7 @@ jobs:
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v5
-      - run: rustup override set nightly-2025-01-12
+      - run: rustup override set nightly-2025-11-10
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"


### PR DESCRIPTION
## Summary

Update Rust nightly version in CI workflows from inconsistent versions to a unified recent version.

- `.github/workflows/nightly.yaml` - Changed `nightly-2025-09-22` → `nightly-2025-11-10`
- `.github/workflows/tests.yaml` - Changed `nightly-2025-01-12` → `nightly-2025-11-10`

This ensures consistent tooling behavior across the `check-unused-dependencies` and `test-deps-min-versions` jobs.

## Test plan

- [ ] CI passes with the new nightly version
- [ ] cargo-udeps runs successfully
- [ ] Minimal dependency version tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)