### PR TITLE
fix: DISTINCT ON to include wildcard when projection is empty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,8 @@ The test commands above with `--accept` will fill in the result automatically.
   - Use `insta::assert_snapshot!` for compact, readable test assertions
   - Fast to run, easy to review in PRs
 
-- **Use integration tests** (`prqlc/tests/integration/queries/*.prql`) only when:
+- **Use integration tests** (`prqlc/tests/integration/queries/*.prql`) only
+  when:
   - Developing large, complex features that need comprehensive testing
   - Testing end-to-end behavior across multiple compilation stages
   - The test requires external resources or multi-file scenarios

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,35 @@ insta::assert_snapshot!(result, @"");
 
 The test commands above with `--accept` will fill in the result automatically.
 
+### Test Strategy
+
+**Prefer small inline `insta` snapshot tests** over full integration tests:
+
+- **Use inline tests** for most bug fixes and small features
+  - Add `#[test]` functions in a `#[cfg(test)]` module at the end of the file
+  - Use `insta::assert_snapshot!` for compact, readable test assertions
+  - Fast to run, easy to review in PRs
+
+- **Use integration tests** (`prqlc/tests/integration/queries/*.prql`) only when:
+  - Developing large, complex features that need comprehensive testing
+  - Testing end-to-end behavior across multiple compilation stages
+  - The test requires external resources or multi-file scenarios
+
+Example of a good inline test:
+
+```rust
+#[cfg(test)]
+mod test {
+    use insta::assert_snapshot;
+
+    #[test]
+    fn test_my_feature() {
+        let query = "from employees | filter country == 'USA'";
+        assert_snapshot!(crate::tests::compile(query).unwrap(), @"");
+    }
+}
+```
+
 ## Running the CLI
 
 For viewing `prqlc` output, for any stage of the compilation process:

--- a/prqlc/prqlc/src/sql/gen_query.rs
+++ b/prqlc/prqlc/src/sql/gen_query.rs
@@ -139,11 +139,14 @@ fn translate_select_pipeline(
         if projection.len() == 1 {
             if let SelectItem::UnnamedExpr(sql_ast::Expr::Value(ref v)) = projection[0] {
                 if matches!(v.value, sql_ast::Value::Null) {
-                    projection[0] = SelectItem::Wildcard(sql_ast::WildcardAdditionalOptions::default());
+                    projection[0] =
+                        SelectItem::Wildcard(sql_ast::WildcardAdditionalOptions::default());
                 }
             }
         } else if projection.is_empty() {
-            projection.push(SelectItem::Wildcard(sql_ast::WildcardAdditionalOptions::default()));
+            projection.push(SelectItem::Wildcard(
+                sql_ast::WildcardAdditionalOptions::default(),
+            ));
         }
     }
 

--- a/prqlc/prqlc/src/sql/gen_query.rs
+++ b/prqlc/prqlc/src/sql/gen_query.rs
@@ -110,7 +110,7 @@ fn translate_select_pipeline(
         .exactly_one()
         .unwrap();
     let projection = translate_wildcards(&ctx.anchor, projection);
-    let projection = translate_select_items(projection.0, projection.1, ctx)?;
+    let mut projection = translate_select_items(projection.0, projection.1, ctx)?;
 
     let order_by = pipeline.pluck(|t| t.into_sort());
     let takes = pipeline.pluck(|t| t.into_take());
@@ -131,6 +131,21 @@ fn translate_select_pipeline(
     } else {
         None
     };
+
+    // When we have DISTINCT ON, we must have at least a wildcard in the projection
+    // (PostgreSQL requires DISTINCT ON to have a non-empty SELECT list)
+    // Replace NULL placeholder with wildcard if present, or add wildcard if empty
+    if matches!(distinct, Some(sql_ast::Distinct::On(_))) {
+        if projection.len() == 1 {
+            if let SelectItem::UnnamedExpr(sql_ast::Expr::Value(ref v)) = projection[0] {
+                if matches!(v.value, sql_ast::Value::Null) {
+                    projection[0] = SelectItem::Wildcard(sql_ast::WildcardAdditionalOptions::default());
+                }
+            }
+        } else if projection.is_empty() {
+            projection.push(SelectItem::Wildcard(sql_ast::WildcardAdditionalOptions::default()));
+        }
+    }
 
     // Split the pipeline into before & after the aggregate
     let (mut before_agg, mut after_agg) =
@@ -798,6 +813,31 @@ mod test {
           table_0
         WHERE
           _expr_0 > 3
+        ");
+    }
+
+    #[test]
+    fn test_distinct_on_with_aggregate() {
+        // #5556: DISTINCT ON with aggregate should include wildcard
+        let query = &r#"
+        prql target:sql.duckdb
+
+        from t1
+        group {id, name} (take 1)
+        aggregate {c=count this}
+        "#;
+
+        assert_snapshot!(crate::tests::compile(query).unwrap(), @r"
+        WITH table_0 AS (
+          SELECT
+            DISTINCT ON (id, name) *
+          FROM
+            t1
+        )
+        SELECT
+          COUNT(*) AS c
+        FROM
+          table_0
         ");
     }
 }

--- a/prqlc/prqlc/src/sql/gen_query.rs
+++ b/prqlc/prqlc/src/sql/gen_query.rs
@@ -820,7 +820,7 @@ mod test {
     fn test_distinct_on_with_aggregate() {
         // #5556: DISTINCT ON with aggregate should include wildcard
         let query = &r#"
-        prql target:sql.duckdb
+        prql target:sql.postgres
 
         from t1
         group {id, name} (take 1)

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -2592,7 +2592,7 @@ fn test_distinct_on_03() {
     "###).unwrap()), @r"
     WITH table_0 AS (
       SELECT
-        DISTINCT ON (col1) NULL
+        DISTINCT ON (col1) *
       FROM
         tab1
     )

--- a/web/book/book.toml
+++ b/web/book/book.toml
@@ -1,6 +1,7 @@
 [book]
 description = "Modern language for transforming data — a simple, powerful, pipelined SQL replacement"
 language = "en"
+multilingual = false
 title = "PRQL language book"
 
 [output.html]
@@ -17,7 +18,6 @@ command = "cargo run --bin mdbook-prql"
 [preprocessor.admonish]
 assets_version = "3.0.0" # do not edit: managed by `mdbook-admonish install`
 command = "mdbook-admonish"
-optional = true
 
 [preprocessor.footnote]
 # Seems to be required for footnotes to show properly.

--- a/web/book/book.toml
+++ b/web/book/book.toml
@@ -1,6 +1,7 @@
 [book]
 description = "Modern language for transforming data — a simple, powerful, pipelined SQL replacement"
 language = "en"
+multilingual = false
 title = "PRQL language book"
 
 [output.html]

--- a/web/book/book.toml
+++ b/web/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 description = "Modern language for transforming data — a simple, powerful, pipelined SQL replacement"
 language = "en"
-multilingual = false
 title = "PRQL language book"
 
 [output.html]

--- a/web/book/book.toml
+++ b/web/book/book.toml
@@ -17,6 +17,7 @@ command = "cargo run --bin mdbook-prql"
 [preprocessor.admonish]
 assets_version = "3.0.0" # do not edit: managed by `mdbook-admonish install`
 command = "mdbook-admonish"
+optional = true
 
 [preprocessor.footnote]
 # Seems to be required for footnotes to show properly.


### PR DESCRIPTION
@claude this was generated from https://github.com/PRQL/prql/issues/5556#issuecomment-3543441822

I notice the test uses `duckdb`, but the issue was for postgres. Why is that? Write a test like @fredericp 's example, make the changes to this PR