### PR TITLE
fix: Remove unsupported multilingual field from book.toml

### DIFF
--- a/web/book/book.toml
+++ b/web/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 description = "Modern language for transforming data — a simple, powerful, pipelined SQL replacement"
 language = "en"
-multilingual = false
 title = "PRQL language book"
 
 [output.html]


### PR DESCRIPTION
Removes the `multilingual = false` configuration field from book.toml as it is no longer supported in mdbook 0.5.0+.

This field was causing the nightly build to fail.

Fixes #5569

🤖 Generated with [Claude Code](https://claude.ai/code)