### PR TITLE
fix: lock mdbook to 0.4.52 to avoid breaking changes in 0.5.0

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -26,6 +26,8 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: mdbook
+          # Lock to 0.4.x - mdbook 0.5.0 has breaking changes
+          version: "0.4.52"
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: mdbook-footnote

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -420,6 +420,8 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: mdbook
+          # Lock to 0.4.x - mdbook 0.5.0 has breaking changes
+          version: "0.4.52"
       # the link checker
       - uses: baptiste0928/cargo-install@v3
         with:


### PR DESCRIPTION
## Summary

- Lock mdbook to version 0.4.52 in CI workflows to avoid breaking changes in 0.5.0
- Updated both `build-web.yaml` and `tests.yaml` workflows
- Added inline comments explaining the version lock

## Context

mdbook 0.5.0 was recently released with several breaking changes:
- Unknown config fields now error instead of being ignored
- Removed `curly-quotes` setting (use `output.html.smart-punctuation` instead)
- Preprocessor `command` paths now relative to book root
- API split into multiple crates
- Smart punctuation and file hashing enabled by default

Locking to 0.4.52 (latest 0.4.x release) provides CI stability until the book configuration can be migrated to support 0.5.x.

## Test plan

- [x] CI should pass with mdbook 0.4.52
- [ ] `check-links-book` job should complete successfully
- [ ] `build-web` job should complete successfully

## Future work

Consider creating a follow-up issue to track migration to mdbook 0.5.x and removal of this version pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)