### PR TITLE
chore: add worktrunk config with CoW for target directory

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,20 @@
+# Worktrunk configuration for PRQL
+#
+# Available template variables:
+#   {{ repo }}      - Repository name
+#   {{ branch }}    - Branch name (slashes replaced with dashes)
+#   {{ worktree }}  - Path to the new worktree
+#   {{ repo_root }} - Path to the main repository root
+
+# Seed compiled dependencies from main worktree using CoW (copy-on-write)
+# Copies essential files, skipping incremental build objects
+# Result: warm-start builds instead of cold compiles
+# macOS: uses cp -c (clonefile on APFS)
+# Linux: would need cp --reflink=auto
+post-start = """
+[ -d {{ repo_root }}/target/debug/deps ] && [ ! -e {{ worktree }}/target ] &&
+mkdir -p {{ worktree }}/target/debug/deps &&
+cp -c {{ repo_root }}/target/debug/deps/*.rlib {{ repo_root }}/target/debug/deps/*.rmeta {{ worktree }}/target/debug/deps/ 2>/dev/null;
+cp -cR {{ repo_root }}/target/debug/.fingerprint {{ repo_root }}/target/debug/build {{ worktree }}/target/debug/ 2>/dev/null;
+true
+"""


### PR DESCRIPTION
## Summary
- Add `.config/wt.toml` for worktrunk worktree management
- Seeds compiled dependencies (`target/debug/deps`) from main worktree using copy-on-write
- Gives warm-start builds instead of cold compiles when creating new worktrees

## Test plan
- [ ] CI passes
- [ ] New worktrees get seeded `target/` directory via `wt switch --create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)