### PR TITLE
fix: Add ORDER BY fallback for Snowflake window functions

### DIFF
--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -244,6 +244,12 @@ pub(super) trait DialectHandler: Any + Debug {
     fn prefers_subquery_parentheses_shorthand(&self) -> bool {
         false
     }
+
+    /// Whether window functions require an ORDER BY clause.
+    /// Snowflake requires ORDER BY for ranking functions like ROW_NUMBER().
+    fn requires_order_by_in_window_function(&self) -> bool {
+        false
+    }
 }
 
 impl dyn DialectHandler {
@@ -605,6 +611,12 @@ impl DialectHandler for SnowflakeDialect {
     fn set_ops_distinct(&self) -> bool {
         // https://docs.snowflake.com/en/sql-reference/operators-query.html
         false
+    }
+
+    fn requires_order_by_in_window_function(&self) -> bool {
+        // https://docs.snowflake.com/en/sql-reference/functions/row_number
+        // ROW_NUMBER() requires ORDER BY in window specification
+        true
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `ORDER BY 1` fallback for Snowflake window functions when no explicit sort is specified
- Snowflake requires an ORDER BY clause for ranking functions like ROW_NUMBER()
- Adds `requires_order_by_in_window_function()` method to `DialectHandler` trait

Fixes #5580

## Test plan

- [x] Added `test_snowflake_row_number_requires_order_by` - verifies ORDER BY 1 is added when no sort specified
- [x] Added `test_snowflake_row_number_with_explicit_sort` - verifies user-provided sort is preserved
- [x] Verified other dialects (PostgreSQL, DuckDB, Generic, MySQL) are unaffected
- [x] All 616 tests passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)