### PR TITLE
fix: Handle lineage correctly when group pipeline simplifies to non-TransformCall

### DIFF
--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6523,3 +6523,21 @@ fn test_snowflake_row_number_with_explicit_sort() {
       "_expr_0" <= 1
     "#);
 }
+
+#[test]
+fn test_group_with_only_sort() {
+    // Issue #5092: group with only sort (no take) should not cause ICE.
+    // The sort inside a group without take is semantically a no-op,
+    // so it should compile to just the table.
+    assert_snapshot!(compile(r###"
+    from a = employees
+    group { a.department } (
+        sort a.salary
+    )
+    "###).unwrap(), @r"
+    SELECT
+      *
+    FROM
+      employees AS a
+    ");
+}


### PR DESCRIPTION
## Summary

Fixes #5092: ICE when using `group` with only `sort` (no `take`).

- When `sort_undone` is true (inside a group), sorts are dropped
- The original GROUP lineage was preserved with stale `target_id` references to expressions that no longer exist in the tree
- This caused `lookup_cid` in lowering to fail with error code 3870

The fix conditionally chooses the lineage:
- If pipeline remains a `TransformCall` (e.g., `group + aggregate`), use GROUP lineage which includes `by` columns
- If pipeline simplified to non-`TransformCall` (e.g., sort dropped), use pipeline lineage to avoid stale references

## Test plan

- [x] Added `test_group_with_only_sort` test case verifying the fix
- [x] All existing tests pass (615 tests)
- [x] Lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)