### PR TITLE
fix: error when table variable used in scalar context

### DIFF
--- a/prqlc/prqlc/src/semantic/lowering.rs
+++ b/prqlc/prqlc/src/semantic/lowering.rs
@@ -935,6 +935,17 @@ impl Lowerer {
                     .try_collect()?,
             ),
             pl::ExprKind::RqOperator { name, args } => {
+                // Check for relation types used as operator arguments
+                for arg in &args {
+                    if arg.ty.as_ref().is_some_and(|x| x.is_relation()) {
+                        return Err(Error::new_simple(
+                            "table variable cannot be used as a scalar value",
+                        )
+                        .push_hint("use a join instead, or inline the subquery")
+                        .with_span(arg.span));
+                    }
+                }
+
                 let args = args.into_iter().map(|x| self.lower_expr(x)).try_collect()?;
 
                 rq::ExprKind::Operator { name, args }

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -4054,6 +4054,30 @@ fn test_direct_table_references() {
 }
 
 #[test]
+fn test_table_variable_in_scalar_context() {
+    // https://github.com/PRQL/prql/issues/5158
+    assert_snapshot!(compile(
+        r#"
+    let mod_id = (from users | filter login == "nightpool" | select id | take 1)
+
+    from modlog
+    filter actor_id == mod_id
+    "#,
+    )
+    .unwrap_err(), @r#"
+    Error:
+       ╭─[ :5:24 ]
+       │
+     5 │     filter actor_id == mod_id
+       │                        ───┬──
+       │                           ╰──── table variable cannot be used as a scalar value
+       │
+       │ Help: use a join instead, or inline the subquery
+    ───╯
+    "#);
+}
+
+#[test]
 fn test_name_shadowing() {
     assert_snapshot!(compile(
         r###"


### PR DESCRIPTION
## Summary
- Table variables defined with subqueries were silently discarded when used in scalar contexts (e.g., `filter actor_id == mod_id`), producing invalid SQL with literal identifiers
- Added check in `RqOperator` handling to error when relation types are used as operator arguments
- Clear error message with helpful hint: "use a join instead, or inline the subquery"

Fixes #5158

## Test plan
- [x] Added `test_table_variable_in_scalar_context` test case
- [x] All 441 prqlc tests pass
- [x] Pre-commit lints pass
- [x] Verified existing s-string table interpolation tests still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)