### PR TITLE
chore: Lock mdbook dependencies to versions compatible with 0.4.x

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -45,8 +45,11 @@ vars:
     rust-lang.rust-analyzer
   cargo_crates: >
     bacon cbindgen cargo-audit cargo-insta cargo-llvm-cov cargo-release
-    cargo-nextest default-target mdbook mdbook-admonish mdbook-footnote
-    mdbook-toc wasm-bindgen-cli wasm-opt
+    cargo-nextest default-target wasm-bindgen-cli wasm-opt
+  # Lock mdbook and plugins to versions compatible with mdbook 0.4.x
+  # (mdbook 0.5.0 has breaking changes)
+  mdbook_crates: >
+    mdbook@0.4.52 mdbook-admonish@1.18.0 mdbook-footnote@0.1.1
   # wasm-pack waiting on https://github.com/rustwasm/wasm-pack/issues/1426
   #
   # Excluding `elixir` atm given it's not enabled on Mac and currently unsupported
@@ -129,6 +132,7 @@ tasks:
       # `--locked` installs from the underlying lock files (which is not the
       # default...)
       - "cargo install --locked {{.cargo_crates}}"
+      - "cargo install --locked {{.mdbook_crates}}"
       - cargo install wasm-pack
 
   install-cargo-tools-binstall:
@@ -136,6 +140,7 @@ tasks:
       - cmd: cargo install --locked cargo-binstall
         platforms: [linux, darwin]
       - "cargo binstall -y --locked {{.cargo_crates}}"
+      - "cargo binstall -y --locked {{.mdbook_crates}}"
       - cargo binstall -y wasm-pack
 
   check-vscode-extensions:


### PR DESCRIPTION
## Summary
- Pin mdbook and plugins to specific versions that work with mdbook 0.4.x, matching CI
- Removes unused `mdbook-toc` dependency

## Test plan
- [ ] CI passes (setup-dev task installs correct versions)
- [ ] `task setup-dev` installs mdbook 0.4.52, mdbook-admonish 1.18.0, mdbook-footnote 0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)