### PR TITLE
chore: Update macOS runners to version 15

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# Custom runner labels not yet recognized by actionlint
+self-hosted-runner:
+  labels:
+    - macos-15-intel

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,12 +50,12 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
-          - os: macos-14
+          - os: macos-15
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          # Still building for intel but can disable when runners go away
-          - os: macos-13
+          # Intel macOS build
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             features: default,test-dbs
     permissions:
@@ -101,7 +101,7 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
-          - os: macos-14
+          - os: macos-15
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -283,7 +283,7 @@ jobs:
         target: [x86_64]
         include:
           # MacOS with universal builds
-          - os: macos-14
+          - os: macos-15
             package: prqlc-python
             target: universal2-apple-darwin
           # Also produce more targets for ubuntu:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -86,8 +86,8 @@ jobs:
           save-if:
             ${{ github.ref == 'refs/heads/main' && inputs.features != '' }}
       - uses: actions/setup-python@v6
-        # python isn't natively installed on macos-14, so we need to install it
-        if: ${{ inputs.os == 'macos-14' }}
+        # python isn't natively installed on macos-15, so we need to install it
+        if: ${{ inputs.os == 'macos-15' }}
         with:
           python-version: "3.11"
       - name: Free up disk space

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -211,7 +211,7 @@ jobs:
       # 20 workflow limit.
       oss:
         ${{ (needs.rules.outputs.python == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-24.04", "macos-14", "windows-latest"]' ||
+        == 'true') && '["ubuntu-24.04", "macos-15", "windows-latest"]' ||
         '["ubuntu-24.04"]' }}
 
   test-js:
@@ -222,7 +222,7 @@ jobs:
       # Only run on ubuntu unless there's a lang-specific change or we're running nightly.
       oss:
         ${{ (needs.rules.outputs.js == 'true' || needs.rules.outputs.nightly ==
-        'true') && '["ubuntu-24.04", "macos-14", "windows-latest"]' ||
+        'true') && '["ubuntu-24.04", "macos-15", "windows-latest"]' ||
         '["ubuntu-24.04"]' }}
 
   test-dotnet:
@@ -244,7 +244,7 @@ jobs:
       # Currently we never run windows
       oss:
         ${{ (needs.rules.outputs.java == 'true' || needs.rules.outputs.nightly
-        == 'true') && '["ubuntu-24.04", "macos-14"]' || '["ubuntu-24.04"]' }}
+        == 'true') && '["ubuntu-24.04", "macos-15"]' || '["ubuntu-24.04"]' }}
 
   test-elixir:
     needs: rules
@@ -272,7 +272,7 @@ jobs:
   #   if: |
   #     needs.rules.outputs.taskfile == 'true' ||
   #     needs.rules.outputs.nightly-upstream == 'true'
-  #   runs-on: macos-14
+  #   runs-on: macos-15
   #   steps:
   #     - name: 📂 Checkout code
   #       uses: actions/checkout@v5
@@ -309,7 +309,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
+          - os: macos-15
             target: aarch64-apple-darwin
             features: default,test-dbs
           - os: windows-latest
@@ -681,7 +681,7 @@ jobs:
           #
           # - os: ubuntu-24.04
           #   target: aarch64-unknown-linux-musl
-          - os: macos-14
+          - os: macos-15
             target: aarch64-apple-darwin
             features: default,test-dbs
           - os: windows-latest
@@ -714,7 +714,7 @@ jobs:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             features: default
-          - os: macos-14
+          - os: macos-15
             target: aarch64-apple-darwin
             features: default,test-dbs
           - os: windows-latest


### PR DESCRIPTION
## Summary
- Update Intel macOS build from deprecated `macos-13` to `macos-15-intel`
- Update ARM macOS builds from `macos-14` to `macos-15`
- Add `actionlint.yaml` to allow `macos-15-intel` as a custom runner label

Per GitHub's deprecation notice: https://github.com/actions/runner-images/issues/13046

## Test plan
- [ ] CI passes on the new runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)