### PR TITLE
fix: Close HTML comment in sort.md documentation

### DIFF
--- a/web/book/src/reference/stdlib/transforms/sort.md
+++ b/web/book/src/reference/stdlib/transforms/sort.md
@@ -115,4 +115,4 @@ take 42
 
 ```admonish info
 Check out [DuckDB #7174](https://github.com/duckdb/duckdb/pull/7174) for a survey of various databases' implementations.
-```
+``` -->


### PR DESCRIPTION
## Summary
- Closes the HTML comment that wraps the "Nulls" section in the sort.md documentation
- The comment opened with `<!--` but was missing its closing `-->`

## Test plan
- [x] Lints pass
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)