### PR TITLE
fix: Add --dnd flag to cargo insta for nextest doctest compatibility

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -128,13 +128,24 @@ jobs:
           # - Test runner - `--test-runner=nextest` when not targeting wasm32.
           # - Skip doc tests on Windows due to LNK1318 PDB errors
           args: >
-            test --target=${{ inputs.target }} --no-default-features
+            test --dnd --target=${{ inputs.target }} --no-default-features
             --features=${{ inputs.features }} ${{ contains(inputs.features,
             'test-dbs') && inputs.target == 'x86_64-unknown-linux-gnu' &&
             '--unreferenced=auto' || '' }} ${{ inputs.target !=
             'wasm32-unknown-unknown' && '--test-runner=nextest' || '' }} ${{
             inputs.os == 'windows-latest' && '--lib --bins --tests --examples'
             || '' }}
+      - name: 📋 Doctest
+        # Skip doctests on Windows (LNK1318 PDB errors) and wasm32
+        if:
+          inputs.os != 'windows-latest' && inputs.target !=
+          'wasm32-unknown-unknown'
+        uses: clechasseur/rs-cargo@v4
+        with:
+          command: test
+          args: >
+            --doc --target=${{ inputs.target }} --no-default-features
+            --features=${{ inputs.features }}
       - name: 📎 Clippy
         uses: clechasseur/rs-cargo@v4
         with:

--- a/prqlc/Taskfile.yaml
+++ b/prqlc/Taskfile.yaml
@@ -27,7 +27,9 @@ tasks:
       NEXTEST_FINAL_STATUS_LEVEL: slow
       NEXTEST_HIDE_PROGRESS_BAR: "true"
     cmds:
-      - cargo insta test --accept {{.packages_core}} --test-runner=nextest
+      # --dnd: nextest doesn't support doctests, so we run them separately below
+      - cargo insta test --accept --dnd {{.packages_core}} --test-runner=nextest
+      - cargo test --doc {{.packages_core}}
       - cargo clippy --fix --allow-dirty --allow-staged {{.packages_core}}
 
   test-all:
@@ -37,8 +39,10 @@ tasks:
       NEXTEST_FINAL_STATUS_LEVEL: slow
       NEXTEST_HIDE_PROGRESS_BAR: "true"
     cmds:
-      - cargo insta test --accept --features=default,test-dbs
+      - cargo insta test --accept --dnd --features=default,test-dbs
         --test-runner=nextest --unreferenced=auto {{.packages_core}}
+        {{.packages_addon}} {{.packages_bindings}}
+      - cargo test --doc --features=default,test-dbs {{.packages_core}}
         {{.packages_addon}} {{.packages_bindings}}
       - cargo llvm-cov --lcov --output-path lcov.info
         --features=default,test-dbs nextest {{.packages_core}}


### PR DESCRIPTION
## Summary

- Add `--dnd` (disable-nextest-doctest) flag to `cargo insta test` commands in Taskfile and CI
- Add separate `cargo test --doc` steps to ensure doctests continue running
- Prepares for upcoming insta behavior change where it won't run a separate doctest process when using nextest

## Test plan

- [x] `task prqlc:test` passes with both nextest tests and doctests
- [x] `pre-commit run --all-files` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)