### PR TITLE
fix: Return error instead of panicking when window rows/range is not a range

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -202,9 +202,29 @@ impl Resolver<'_> {
                     })?
                 };
 
-                let rows = into_literal_range(try_restrict_range(rows).unwrap())?;
+                let rows = {
+                    let range_tuple = try_restrict_range(rows).map_err(|expr| {
+                        Error::new(Reason::Expected {
+                            who: Some("parameter `rows`".to_string()),
+                            expected: "a range".to_string(),
+                            found: write_pl(expr.clone()),
+                        })
+                        .with_span(expr.span)
+                    })?;
+                    into_literal_range(range_tuple)?
+                };
 
-                let range = into_literal_range(try_restrict_range(range).unwrap())?;
+                let range = {
+                    let range_tuple = try_restrict_range(range).map_err(|expr| {
+                        Error::new(Reason::Expected {
+                            who: Some("parameter `range`".to_string()),
+                            expected: "a range".to_string(),
+                            found: write_pl(expr.clone()),
+                        })
+                        .with_span(expr.span)
+                    })?;
+                    into_literal_range(range_tuple)?
+                };
 
                 let (kind, start, end) = if expanding {
                     (WindowKind::Rows, None, Some(0))

--- a/prqlc/prqlc/tests/integration/error_messages.rs
+++ b/prqlc/prqlc/tests/integration/error_messages.rs
@@ -449,3 +449,33 @@ fn empty_tuple_or_array_from() {
     ───╯
     ");
 }
+
+#[test]
+fn window_rows_expects_range() {
+    // Issue #5601: window with invalid rows parameter should produce error, not panic
+    assert_snapshot!(compile(r###"
+    from t
+    group sid (window rows:2 (sid))
+    "###).unwrap_err(), @r"
+    Error:
+       ╭─[ :3:28 ]
+       │
+     3 │     group sid (window rows:2 (sid))
+       │                            ┬
+       │                            ╰── parameter `rows` expected a range, but found 2
+    ───╯
+    ");
+
+    assert_snapshot!(compile(r###"
+    from t
+    group sid (window range:2 (sid))
+    "###).unwrap_err(), @r"
+    Error:
+       ╭─[ :3:29 ]
+       │
+     3 │     group sid (window range:2 (sid))
+       │                             ┬
+       │                             ╰── parameter `range` expected a range, but found 2
+    ───╯
+    ");
+}


### PR DESCRIPTION
## Summary
- Fixes #5601 - The compiler panicked when `window rows:2` was used instead of a range like `rows:0..2`
- Changed `.unwrap()` calls to proper error handling with user-friendly error messages
- Now produces a clear error: `parameter 'rows' expected a range, but found 2`

## Test plan
- [x] Added regression tests for both `rows` and `range` parameters
- [x] Ran `task test-all` locally - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)