### PR TITLE
fix: Snowflake interval quoting style

### DIFF
--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -613,6 +613,12 @@ impl DialectHandler for SnowflakeDialect {
         false
     }
 
+    fn interval_quoting_style(&self, _dtf: &DateTimeField) -> IntervalQuotingStyle {
+        // Snowflake requires quotes around value and unit together
+        // https://docs.snowflake.com/en/sql-reference/data-types-datetime#interval-constants
+        IntervalQuotingStyle::ValueAndUnitQuoted
+    }
+
     fn requires_order_by_in_window_function(&self) -> bool {
         // https://docs.snowflake.com/en/sql-reference/functions/row_number
         // ROW_NUMBER() requires ORDER BY in window specification

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -1591,6 +1591,20 @@ fn test_interval() {
     FROM
       projects
     "#);
+
+    let query = r###"
+    prql target:sql.snowflake
+
+    from projects
+    derive first_check_in = start + 10days
+    "###;
+    assert_snapshot!((compile(query).unwrap()), @r#"
+    SELECT
+      *,
+      "start" + INTERVAL '10 DAY' AS "first_check_in"
+    FROM
+      "projects"
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
Snowflake likes value-and-unit quote style for its intervals.