### PR TITLE
build: Use OIDC for npm publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -326,6 +326,9 @@ jobs:
 
   publish-js:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v5
@@ -353,12 +356,11 @@ jobs:
       - run: npm install
         working-directory: prqlc/bindings/js/
 
-      - run:
-          npm publish ${{ (github.event_name != 'release') && '--dry-run' || ''
-          }}
+      - name: Publish to npm
+        run:
+          npm publish --provenance --access public ${{ (github.event_name !=
+          'release') && '--dry-run' || '' }}
         working-directory: prqlc/bindings/js/
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-to-cargo:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Switch from `NPM_TOKEN` secret to GitHub OIDC for npm authentication
- More secure - no token rotation needed
- Adds provenance attestation to published packages

## Changes
- Add `id-token: write` permission to `publish-js` job
- Use `--provenance --access public` flags for OIDC-based publishing
- Remove `NPM_TOKEN` secret usage

## Context
The 0.13.8 npm release failed because the NPM_TOKEN expired. OIDC eliminates this failure mode.

## Test plan
- [ ] CI passes
- [ ] Nightly dry-run succeeds (will run overnight or can be triggered manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)