### PR TITLE
chore: Prepare release 0.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 
 **New Contributors**:
 
+## 0.13.9 — 2025-12-12
+
+0.13.9 is a re-release of 0.13.8 with fixed npm publishing.
+
+**Internal changes**:
+
+- Use OIDC for npm publishing (@max-sixty, #5609)
+
 ## 0.13.8 — 2025-12-12
 
 0.13.8 has 47 commits from 6 contributors. Selected changes:


### PR DESCRIPTION
## Summary
Re-release of 0.13.8 with fixed npm publishing via OIDC.

The 0.13.8 npm release failed due to an expired NPM_TOKEN. This release uses OIDC authentication instead, which doesn't require token rotation.

## Changes
- Updated CHANGELOG.md for 0.13.9

## After merge
Create a GitHub release with tag `0.13.9` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)