### PR TITLE
fix: text.length on Snowflake

### DIFF
--- a/prqlc/prqlc/src/sql/std.sql.prql
+++ b/prqlc/prqlc/src/sql/std.sql.prql
@@ -392,4 +392,10 @@ module snowflake {
   # https://docs.snowflake.com/en/sql-reference/operators-arithmetic#division
   @{binding_strength=11}
   let div_f = l r -> s"({l} / {r:12})"
+
+  # Text functions
+  module text {
+    # https://docs.snowflake.com/en/sql-reference/functions-string
+    let length = column -> s"LENGTH({column:0})"
+  }
 }

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6623,6 +6623,23 @@ fn test_snowflake_row_number_with_explicit_sort() {
 }
 
 #[test]
+fn test_snowflake_text_length_uses_length() {
+    // Snowflake should use LENGTH instead of CHAR_LENGTH
+    assert_snapshot!(compile_with_sql_dialect(r###"
+    from employees
+    select {
+        name_length = (name | text.length)
+    }
+    "###, sql::Dialect::Snowflake
+    ).unwrap(), @r#"
+    SELECT
+      LENGTH("name") AS "name_length"
+    FROM
+      "employees"
+    "#);
+}
+
+#[test]
 fn test_group_with_only_sort() {
     // Issue #5092: group with only sort (no take) should not cause ICE.
     // The sort inside a group without take is semantically a no-op,


### PR DESCRIPTION
Using `text.length` was resolved to `CHAR_LENGTH` which is not a thing on Snowflake. Use `LENGTH` instead.