### PR TITLE
build: Upgrade to Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -339,7 +339,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          # Node 24+ includes npm 11.5.1+ required for OIDC trusted publishing
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - run: ./.github/workflows/scripts/set_version.sh


### PR DESCRIPTION
## Summary
- Upgrades Node.js from 20.x to 24.x in the publish-js workflow
- Node 24+ includes npm 11.5.1+ which is required for OIDC trusted publishing
- This allows publishing without long-lived NPM_TOKEN secrets

## Test plan
- [ ] CI passes
- [ ] Trigger workflow_dispatch to verify OIDC dry-run works
- [ ] Rerun 0.13.8 release or create 0.13.9 to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)