### PR TITLE
chore: Prepare release 0.13.10

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -405,6 +405,8 @@ jobs:
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
       - run: git push origin HEAD:web --force
 
   push-devcontainer:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,21 @@
 # PRQL Changelog
 
-## [unreleased]
+## 0.13.10 — 2025-12-16
 
-**Language**:
-
-**Features**:
-
-**Fixes**:
-
-**Documentation**:
-
-**Web**:
-
-**Integrations**:
-
-**Internal changes**:
-
-**New Contributors**:
-
-## [unreleased]
-
-**Language**:
+0.13.10 completes the npm OIDC publishing fix from 0.13.9.
 
 **Features**:
 
+- Add `read_json` support for DuckDB and ClickHouse (@adamnemecek, #5608)
+
 **Fixes**:
 
-**Documentation**:
-
-**Web**:
-
-**Integrations**:
+- Fix `text.length` on Snowflake (@priithaamer, #5614)
 
 **Internal changes**:
 
-**New Contributors**:
+- Fix npm OIDC publishing by upgrading to Node 24 (@max-sixty, #5619)
+- Fix push-web-branch workflow permissions (@max-sixty, #5620)
 
 ## 0.13.9 — 2025-12-12
 

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -460,7 +460,10 @@ Currently we release in a semi-automated way:
    `cargo release version $version -x && cargo release replace -x && task prqlc:test-all`
    to bump the version, and PR the resulting commit.
 
-3. After merging, go to
+3. Ensure all changes intended for the release are merged to `main`. Then create
+   the release (which creates the tag on the latest commit on `main`):
+
+   **Web UI:** Go to
    [Draft a new release](https://github.com/PRQL/prql/releases/new){{footnote: Only
        maintainers have access to this page.}},
    copy the changelog entry into the release
@@ -469,6 +472,15 @@ Currently we release in a semi-automated way:
         editing the markdown to look reasonable than manually editing the text
         or asking LLM to help.}}, enter the tag to be created, and hit
    "Publish".
+
+   **CLI:**
+
+   ```sh
+   gh release create $version --title "$version" --notes "$(cat <<'EOF'
+   <paste changelog entry here>
+   EOF
+   )"
+   ```
 
 4. From there, both the tag and release is created and all packages are
    published automatically based on our


### PR DESCRIPTION
## Summary

Prepares release 0.13.10 which completes the npm OIDC publishing fix from 0.13.9.

### Changes

- **Fix push-web-branch workflow**: Use `PRQL_BOT_GITHUB_TOKEN` PAT instead of default `GITHUB_TOKEN` to allow pushing commits that contain workflow files (required `workflows` scope)
- **Changelog updates**: Added recent features and fixes with contributor credits
- **Release docs clarification**: Added note about tag target defaulting to latest commit on main

### Why 0.13.9 npm publish failed

The 0.13.9 release was tagged at the "prepare release" commit, but the Node 24 upgrade (required for npm OIDC - needs npm 11.5.1+) was merged *after* that commit. The tagged workflow still used Node 20.x with npm 10.8.2, which doesn't support OIDC trusted publishing.

### Release checklist

After merging:
- [ ] Verify npm trusted publisher is configured at npmjs.com/package/prqlc/access
- [ ] Create release at GitHub (tag will be created automatically)
- [ ] Monitor CI for successful npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)