### PR TITLE
chore: Bump version to 0.13.11 for next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # PRQL Changelog
 
+## [unreleased]
+
+**Language**:
+
+**Features**:
+
+**Fixes**:
+
+**Documentation**:
+
+**Web**:
+
+**Integrations**:
+
+**Internal changes**:
+
+**New Contributors**:
+
 ## 0.13.10 — 2025-12-16
 
 0.13.10 completes the npm OIDC publishing fix from 0.13.9.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "compile-files"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "prqlc",
 ]
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-prql"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "ansi-to-html",
  "anstream",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "prql"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "prqlc",
  "rustler",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "prql-java"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "jni",
  "prqlc",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anstream",
  "anyhow",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-c"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "libc",
  "prqlc",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-js"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "console_error_panic_hook",
  "prqlc",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-macros"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "prqlc",
  "syn 2.0.111",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-parser"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "chumsky",
  "enum-as-inner",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-python"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "insta",
  "prqlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/PRQL/prql"
 # This isn't tested since `cargo-msrv` doesn't support workspaces; instead we
 # test `metadata.msrv` in `prqlc`
 rust-version = "1.75.0"
-version = "0.13.10"
+version = "0.13.11"
 
 [profile.release]
 lto = true

--- a/prqlc/bindings/elixir/native/prql/Cargo.toml
+++ b/prqlc/bindings/elixir/native/prql/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/lib.rs"
 test = false
 
 [target.'cfg(not(any(target_family="wasm")))'.dependencies]
-prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.10" }
+prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.11" }
 rustler = "0.37.0"

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prqlc",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prqlc",
-      "version": "0.13.10",
+      "version": "0.13.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -35,5 +35,5 @@
     "test": "mocha tests"
   },
   "types": "dist/node/prqlc_js.d.ts",
-  "version": "0.13.10"
+  "version": "0.13.11"
 }

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: "0.13.10"
+version: "0.13.11"
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/prqlc-macros/Cargo.toml
+++ b/prqlc/prqlc-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-prqlc = {path = "../prqlc", default-features = false, version = "0.13.10" }
+prqlc = {path = "../prqlc", default-features = false, version = "0.13.11" }
 syn = "2.0.111"
 
 [package.metadata.release]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -54,7 +54,7 @@ test-dbs-external = [
 ]
 
 [dependencies]
-prqlc-parser = { path = "../prqlc-parser", version = "0.13.10" }
+prqlc-parser = { path = "../prqlc-parser", version = "0.13.11" }
 
 anstream = { version = "0.6.21", features = ["auto"] }
 ariadne = "0.5.1"

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -343,7 +343,7 @@ mod tests {
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta name="keywords" content="prql">
-            <meta name="generator" content="prqlc 0.13.10">
+            <meta name="generator" content="prqlc 0.13.11">
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
             <title>PRQL Docs</title>
           </head>
@@ -421,7 +421,7 @@ mod tests {
 
             </main>
             <footer class="container border-top">
-              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.10.</small>
+              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.11.</small>
             </footer>
           </body>
         </html>
@@ -503,7 +503,7 @@ mod tests {
 
 
 
-        Generated with [prqlc](https://prql-lang.org/) 0.13.10.
+        Generated with [prqlc](https://prql-lang.org/) 0.13.11.
 
         ----- stderr -----
         ");

--- a/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
@@ -4,7 +4,7 @@ expression: "[{version = prql.version}]\n"
 ---
 WITH table_0 AS (
   SELECT
-    '0.13.10' AS version
+    '0.13.11' AS version
 )
 SELECT
   version

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prql-playground",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prql-playground",
-      "version": "0.13.10",
+      "version": "0.13.11",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.30.0",
         "@monaco-editor/react": "^4.7.0",
@@ -29,7 +29,7 @@
     },
     "../../prqlc/bindings/js": {
       "name": "prqlc",
-      "version": "0.13.10",
+      "version": "0.13.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",
@@ -2456,14 +2456,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -46,5 +46,5 @@
     "prepare": "rsync -ai --checksum --delete ../../prqlc/prqlc/tests/integration/data/ public/data/ && node generateBook.cjs",
     "preview": "vite preview"
   },
-  "version": "0.13.10"
+  "version": "0.13.11"
 }


### PR DESCRIPTION
## Summary

- Bump version from 0.13.10 to 0.13.11 for next development cycle
- Add `[unreleased]` section to CHANGELOG.md
- Update inline snapshot tests with new version

This fixes the nightly CI failures caused by attempting to publish version 0.13.10 which was already released to npm and crates.io.

Closes #5621

## Test plan

- [x] `task test-all` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)