### PR TITLE
ci: Use anthropic_api_key instead of oauth_token

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -70,7 +70,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
 
           # This is an optional setting that allows Claude to read CI results on PRs


### PR DESCRIPTION
## Summary
- The API key format (`sk-ant-api03-...`) requires `anthropic_api_key` input
- `claude_code_oauth_token` expects an OAuth token from `claude /login`, not an API key

## Test plan
- [ ] Merge and trigger @claude on test issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)