### PR TITLE
fix: Prevent DISTINCT ON internal sorting from leaking past joins

### DIFF
--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -3299,7 +3299,7 @@ fn test_prql_to_sql_table() {
     "#;
     let sql = compile(query).unwrap();
     assert_snapshot!(sql,
-        @r"
+        @"
     WITH newest_employees AS (
       SELECT
         *
@@ -6338,7 +6338,7 @@ fn test_sort_cast_filter_join_select() {
     join side:left artists (this.`artist_id` == that.`artist_id`)
     select {this.`artist_id`, this.`title`, this.`name`}
     "###
-    ).unwrap(), @r"
+    ).unwrap(), @"
     WITH table_1 AS (
       SELECT
         CAST(artist_id AS double precision) AS artist_id,
@@ -6394,7 +6394,7 @@ fn test_sort_filter_derive_join_select() {
     ) (this.`artist_id` == that.`artist_id_right`)
     select {this.`artist_id`, this.`title`}
     "###
-    ).unwrap(), @r"
+    ).unwrap(), @"
     WITH table_2 AS (
       SELECT
         CAST(artist_id AS double precision) AS artist_id,
@@ -6442,7 +6442,7 @@ fn test_sort_cast_filter_join_select_with_alias() {
     join side:left artists (this.`double_artist_id` == that.`artist_id`)
     select {this.`double_artist_id`, this.`title`, this.`name`}
     "###
-    ).unwrap(), @r"
+    ).unwrap(), @"
     WITH table_1 AS (
       SELECT
         CAST(artist_id AS double precision) AS double_artist_id,


### PR DESCRIPTION
## Summary

Fixes #4633 - sort inside group should not leak to outer query after join.

Per the PRQL spec, `group` resets the order. When using `group (sort x | take 1)`, the sorting is for **row selection** (which row to keep per group), not output ordering. Previously, this internal DISTINCT ON sorting was incorrectly propagating to the outer query after a join.

**Changes:**
- Track whether sorting originated from DISTINCT ON (internal row selection)
- Clear such sorting at join boundaries, while preserving explicit user sorts
- Add regression tests for both the bug fix and edge cases

**Why DISTINCT ON specifically?**
- DISTINCT ON creates a separate `SqlTransform::Sort` followed by `DistinctOn`
- ROW_NUMBER (used for `take > 1` or non-Postgres) embeds sorting in the window function, so it doesn't have this issue

## Test plan

- [x] New regression test verifies no ORDER BY in outer query after join
- [x] New test verifies explicit sorts after group are preserved
- [x] Existing tests pass (including snapshot updates for correct behavior)
- [x] `task prqlc:pull-request` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)