### PR TITLE
fix: Return proper error for bare lambda expressions

### DIFF
--- a/prqlc/prqlc/tests/integration/bad_error_messages.rs
+++ b/prqlc/prqlc/tests/integration/bad_error_messages.rs
@@ -211,11 +211,17 @@ fn nested_groups() {
 
 #[test]
 fn a_arrow_b() {
-    // This is fairly low priority, given how idiosyncratic the query is. If
-    // we find other cases, we should increase the priority.
     assert_snapshot!(compile(r###"
     x -> y
-    "###).unwrap_err(), @"Error: internal compiler error; tracked at https://github.com/PRQL/prql/issues/4280");
+    "###).unwrap_err(), @r"
+    Error:
+       ╭─[ :2:5 ]
+       │
+     2 │     x -> y
+       │     ───┬──
+       │        ╰──── expected a table, but found a function
+    ───╯
+    ");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace internal compiler error with user-facing error message when a bare lambda like `x -> y` is used at the top level
- Now produces clear error: "expected a table, but found a function"

## Test plan
- [x] Updated snapshot test in `bad_error_messages.rs`
- [x] All 630 tests pass
- [x] Lints pass

Fixes #4280

🤖 Generated with [Claude Code](https://claude.com/claude-code)