### PR TITLE
fix: Preserve sort with empty group `{}`

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/flatten.rs
+++ b/prqlc/prqlc/src/semantic/resolver/flatten.rs
@@ -77,7 +77,11 @@ impl PlFold for Flattener {
                     }
                     TransformKind::Group { by, pipeline } => {
                         let sort_undone = self.sort_undone;
-                        self.sort_undone = true;
+                        // Only mark sort as undone if there's an actual partition.
+                        // Empty group {} should preserve sort (fixes #5100).
+                        if !matches!(by.kind, ExprKind::Tuple(ref fields) if fields.is_empty()) {
+                            self.sort_undone = true;
+                        }
 
                         let input = self.fold_expr(*t.input)?;
 

--- a/prqlc/prqlc/tests/integration/bad_error_messages.rs
+++ b/prqlc/prqlc/tests/integration/bad_error_messages.rs
@@ -211,11 +211,17 @@ fn nested_groups() {
 
 #[test]
 fn a_arrow_b() {
-    // This is fairly low priority, given how idiosyncratic the query is. If
-    // we find other cases, we should increase the priority.
     assert_snapshot!(compile(r###"
     x -> y
-    "###).unwrap_err(), @"Error: internal compiler error; tracked at https://github.com/PRQL/prql/issues/4280");
+    "###).unwrap_err(), @r"
+    Error:
+       ╭─[ :2:5 ]
+       │
+     2 │     x -> y
+       │     ───┬──
+       │        ╰──── expected a table, but found a function
+    ───╯
+    ");
 }
 
 #[test]

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6720,3 +6720,24 @@ fn test_group_with_only_sort() {
       employees AS a
     ");
 }
+
+#[test]
+fn test_group_empty_preserves_sort() {
+    // Issue #5100: Empty group {} should preserve inner sort.
+    assert_snapshot!(compile(r###"
+    from foo
+    group {} (
+        sort a
+        take 1
+    )
+    "###).unwrap(), @r"
+    SELECT
+      *
+    FROM
+      foo
+    ORDER BY
+      a
+    LIMIT
+      1
+    ");
+}


### PR DESCRIPTION
## Summary
- Fix sorting being incorrectly dropped when using `group {} (sort a | take 1)`
- Empty group `{}` should preserve inner sort since there's no actual partitioning

**Before:**
```sql
SELECT * FROM foo LIMIT 1
```

**After:**
```sql
SELECT * FROM foo ORDER BY a LIMIT 1
```

## Test plan
- [x] Added test `test_group_empty_preserves_sort`
- [x] Verified non-empty groups still work correctly (sort stays internal to partition)
- [x] All 631 tests pass
- [x] Lints pass

Fixes #5100

🤖 Generated with [Claude Code](https://claude.com/claude-code)