### PR TITLE
fix: Restore mdbook to cargo_crates and add devcontainer smoke test

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -58,6 +58,25 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
+      # Smoke test: build local image and verify tools work
+      - name: Build local image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .devcontainer/base-image
+          build-args: cargo_crates=${{ env.cargo_crates }}
+          load: true
+          tags: devcontainer-test:latest
+          cache-from: type=gha,scope=${{ matrix.platform }}
+
+      - name: Smoke test - run tests and build book
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
+            devcontainer-test:latest bash -c "
+              set -euxo pipefail
+              cargo test
+              mdbook build web/book/
+            "
+
       - name: Export digest
         if: inputs.push
         run: |

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -45,11 +45,8 @@ vars:
     rust-lang.rust-analyzer
   cargo_crates: >
     bacon cbindgen cargo-audit cargo-insta cargo-llvm-cov cargo-release
-    cargo-nextest default-target wasm-bindgen-cli wasm-opt
-  # Lock mdbook and plugins to versions compatible with mdbook 0.4.x
-  # (mdbook 0.5.0 has breaking changes)
-  mdbook_crates: >
-    mdbook@0.4.52 mdbook-admonish@1.18.0 mdbook-footnote@0.1.1
+    cargo-nextest default-target mdbook mdbook-admonish mdbook-footnote
+    mdbook-toc wasm-bindgen-cli wasm-opt
   # wasm-pack waiting on https://github.com/rustwasm/wasm-pack/issues/1426
   #
   # Excluding `elixir` atm given it's not enabled on Mac and currently unsupported
@@ -132,7 +129,6 @@ tasks:
       # `--locked` installs from the underlying lock files (which is not the
       # default...)
       - "cargo install --locked {{.cargo_crates}}"
-      - "cargo install --locked {{.mdbook_crates}}"
       - cargo install wasm-pack
 
   install-cargo-tools-binstall:
@@ -140,7 +136,6 @@ tasks:
       - cmd: cargo install --locked cargo-binstall
         platforms: [linux, darwin]
       - "cargo binstall -y --locked {{.cargo_crates}}"
-      - "cargo binstall -y --locked {{.mdbook_crates}}"
       - cargo binstall -y wasm-pack
 
   check-vscode-extensions:


### PR DESCRIPTION
## Summary

- Reverts the `mdbook_crates` split from #5586 which inadvertently broke the devcontainer by not updating the build workflow
- Restores mdbook tools to `cargo_crates` where they were originally
- Adds smoke test to devcontainer build that runs `cargo test` and `mdbook build web/book/` to catch similar issues

## Test plan

- [ ] CI passes
- [ ] Devcontainer build includes smoke test validation

Closes #5644

🤖 Generated with [Claude Code](https://claude.com/claude-code)