### PR TITLE
chore: Add micro 2.0.15 release to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 **Integrations**:
 
-- [micro](https://micro-editor.github.io/) 2.0.15 has syntax highlighting for PRQL. (@vanillajonathan)
+- [micro](https://micro-editor.github.io/) 2.0.15 has syntax highlighting for
+  PRQL. (@vanillajonathan)
 
 **Internal changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 **Integrations**:
 
+- [micro](https://micro-editor.github.io/) 2.0.15 has syntax highlighting for PRQL. (@vanillajonathan)
+
 **Internal changes**:
 
 **New Contributors**:


### PR DESCRIPTION
Add entry for micro 2.0.15 with PRQL syntax highlighting.

https://github.com/zyedidia/micro/releases/tag/v2.0.15