### PR TITLE
chore: use chumsky 0.12.0 for all targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,15 +151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ar_archive_writer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
-dependencies = [
- "object 0.32.2",
-]
-
-[[package]]
 name = "ariadne"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,7 +373,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.7",
+ "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -2442,15 +2433,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
@@ -2805,7 +2787,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "stacker",
  "strum 0.27.2",
 ]
 
@@ -2817,16 +2798,6 @@ dependencies = [
  "prqlc",
  "pyo3",
  "pyo3-build-config",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
-dependencies = [
- "ar_archive_writer",
- "cc",
 ]
 
 [[package]]
@@ -3660,19 +3631,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "stacker"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "stringprep"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,19 +583,6 @@ dependencies = [
 
 [[package]]
 name = "chumsky"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc17a6284abccac6e50db35c1cee87f605474a72939b959a3a67d9371800efd"
-dependencies = [
- "hashbrown 0.15.5",
- "regex-automata 0.3.9",
- "serde",
- "unicode-ident",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "chumsky"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba4a05c9ce83b07de31b31c874e87c069881ac4355db9e752e3a55c11ec75a6"
@@ -603,7 +590,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "regex-automata 0.3.9",
  "serde",
- "stacker",
  "unicode-ident",
  "unicode-segmentation",
 ]
@@ -2809,8 +2795,7 @@ dependencies = [
 name = "prqlc-parser"
 version = "0.13.11"
 dependencies = [
- "chumsky 0.11.2",
- "chumsky 0.12.0",
+ "chumsky",
  "enum-as-inner",
  "insta",
  "itertools 0.14.0",

--- a/prqlc/prqlc-parser/Cargo.toml
+++ b/prqlc/prqlc-parser/Cargo.toml
@@ -13,6 +13,10 @@ bench = false
 doctest = false
 
 [dependencies]
+chumsky = { version = "0.12.0", default-features = false, features = [
+    "std",
+    "pratt",
+] }
 enum-as-inner = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
@@ -22,18 +26,9 @@ serde = { workspace = true }
 serde_yaml = { workspace = true, optional = true }
 strum = { workspace = true }
 
-# Chumsky's default features have issues when running in wasm (though we only
-# see it when compiling on macOS), so we only include features when running
-# outside wasm.
-[target.'cfg(not(target_family="wasm"))'.dependencies]
-chumsky = { version = "0.12.0", features = ["pratt"] }
 # Not direct dependencies, but pinning because of bugs in previous versions
+[target.'cfg(not(target_family="wasm"))'.dependencies]
 stacker = "0.1.22"
-[target.'cfg(target_family="wasm")'.dependencies]
-chumsky = { version = "0.11.2", features = [
-    "std",
-    "pratt",
-], default-features = false }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/prqlc/prqlc-parser/Cargo.toml
+++ b/prqlc/prqlc-parser/Cargo.toml
@@ -26,10 +26,6 @@ serde = { workspace = true }
 serde_yaml = { workspace = true, optional = true }
 strum = { workspace = true }
 
-# Not direct dependencies, but pinning because of bugs in previous versions
-[target.'cfg(not(target_family="wasm"))'.dependencies]
-stacker = "0.1.22"
-
 [dev-dependencies]
 insta = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Remove target-specific chumsky dependency (0.11.2 for wasm, 0.12.0 for non-wasm) and use chumsky 0.12.0 with default-features=false for all targets.

Follow-up to #5656

Generated with [Claude Code](https://claude.ai/code)