### PR TITLE
fix: handle partial application of transforms in user-defined functions

### DIFF
--- a/web/book/src/reference/declarations/functions.md
+++ b/web/book/src/reference/declarations/functions.md
@@ -107,3 +107,44 @@ derive {
   overhead_share = (cost_share overhead),
 }
 ```
+
+## Partial application
+
+Functions can be partially applied, which is useful for creating reusable
+transform wrappers. When a function returns a partially-applied transform, the
+missing parameters are automatically propagated.
+
+For example, we can create a `top_n` function that wraps `take`:
+
+```prql
+let top_n = n -> take n
+
+from invoices
+top_n 10
+```
+
+This works because `take` requires two arguments (the count and the relation),
+but `top_n` only provides one. The relation parameter is automatically filled in
+from the pipeline.
+
+We can also compose multiple partial applications:
+
+```prql
+let top_n = n -> take n
+let add_constant = x -> derive {constant = x}
+
+let my_pipeline = (top_n 5 | add_constant 42)
+
+from invoices
+my_pipeline
+```
+
+Or store a fully-configured transform for reuse:
+
+```prql
+let top_n = n -> take n
+let top_5 = top_n 5
+
+from invoices
+top_5
+```

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__partial-application__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__partial-application__0.snap
@@ -1,0 +1,10 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "let top_n = n -> take n\n\nfrom invoices\ntop_n 10\n"
+---
+SELECT
+  *
+FROM
+  invoices
+LIMIT
+  10

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__partial-application__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__partial-application__1.snap
@@ -1,0 +1,11 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "let top_n = n -> take n\nlet add_constant = x -> derive {constant = x}\n\nlet my_pipeline = (top_n 5 | add_constant 42)\n\nfrom invoices\nmy_pipeline\n"
+---
+SELECT
+  *,
+  42 AS constant
+FROM
+  invoices
+LIMIT
+  5

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__partial-application__2.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__declarations__functions__partial-application__2.snap
@@ -1,0 +1,10 @@
+---
+source: web/book/tests/documentation/book.rs
+expression: "let top_n = n -> take n\nlet top_5 = top_n 5\n\nfrom invoices\ntop_5\n"
+---
+SELECT
+  *
+FROM
+  invoices
+LIMIT
+  5


### PR DESCRIPTION
## Summary

Fixes #5661.

- Fix crash when using partial application of transforms in user-defined functions (e.g., `let foo = a -> take a`)
- Add documentation for partial application in the book
- Add regression tests

The bug was in `materialize_function`: when wrapping a partially-applied inner function, the code was incorrectly truncating `inner_closure.params`. The fix keeps params intact and creates wrapper params with substitute argument expressions.

## Test plan

- [x] `task prqlc:pull-request` passes
- [x] New regression test `test_partial_application_of_transform` validates the fix
- [x] Tested various partial application scenarios: `take`, `derive`, `filter`, composed pipelines

🤖 Generated with [Claude Code](https://claude.ai/code)