### PR TITLE
chore: Prepare 0.13.11 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,30 @@
 # PRQL Changelog
 
-## [unreleased]
+## 0.13.11 — 2026-03-19
 
-**Language**:
+0.13.11 has 75 commits from 7 contributors. Selected changes:
 
 **Features**:
 
+- Add support for `date.to_text` for BigQuery (@segv, #5712)
+
 **Fixes**:
+
+- Prevent panic on bare `*` in `select` (@max-sixty, #5696)
+- Handle partial application of transforms in user-defined functions
+  (@max-sixty, #5663; reported by @Rafferty97)
+- Keep Computes with Aggregate when Filter follows (@max-sixty, #5639; reported
+  by @matiastoro)
+- Preserve sort before take in CTE (@max-sixty, #5638; reported by @lukapeschke)
+- Preserve sort with empty group `{}` (@max-sixty, #5635)
+- Return proper error for bare lambda expressions (@max-sixty, #5634)
+- Prevent DISTINCT ON internal sorting from leaking past joins (@max-sixty,
+  #5633; reported by @annashmatko)
+- Fix invalid MSSQL SQL when DISTINCT and FETCH are combined (@max-sixty, #5630)
 
 **Documentation**:
 
-**Web**:
+- Editorial tweaks (@richb-hanover, #5645)
 
 **Integrations**:
 
@@ -19,7 +33,13 @@
 
 **Internal changes**:
 
+- Use chumsky 0.12.0 for all targets (#5659)
+- Update rust toolchain version (#5673)
+- Fix mdbook admonition syntax for mdBook 0.5 native support (#5649)
+
 **New Contributors**:
+
+- @segv, with #5712
 
 ## 0.13.10 — 2025-12-16
 

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -464,6 +464,10 @@ Currently we release in a semi-automated way:
    echo "It has $(git rev-list --count $(git rev-list --tags --max-count=1)..) commits from $(git shortlog --summary $(git rev-list --tags --max-count=1).. | wc -l | tr -d '[:space:]') contributors. Selected changes:"
    ```
 
+   When a fix closes an issue reported by someone other than the PR author,
+   thank them in the changelog entry, e.g.
+   `(@pr-author, #5639; reported by @issue-reporter)`.
+
 2. If the current version is correct, then skip ahead. But if the version needs
    to be changed — for example, we had planned on a patch release, but instead
    require a minor release — then run


### PR DESCRIPTION
Populates the 0.13.11 changelog with all user-facing changes since 0.13.10 (75 commits, 7 contributors).

Also adds guidance to the release checklist about thanking issue reporters in changelog entries.

> _This was written by Claude Code on behalf of @max-sixty_