### PR TITLE
chore: Bump version to 0.13.12 for next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # PRQL Changelog
 
+## [unreleased]
+
+**Language**:
+
+**Features**:
+
+**Fixes**:
+
+**Documentation**:
+
+**Web**:
+
+**Integrations**:
+
+**Internal changes**:
+
+**New Contributors**:
+
 ## 0.13.11 — 2026-03-19
 
 0.13.11 has 75 commits from 7 contributors. Selected changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,30 @@
 # PRQL Changelog
 
-## [unreleased]
+## 0.13.11 — 2026-03-19
 
-**Language**:
+0.13.11 has 75 commits from 7 contributors. Selected changes:
 
 **Features**:
 
+- Add support for `date.to_text` for BigQuery (@segv, #5712)
+
 **Fixes**:
+
+- Prevent panic on bare `*` in `select` (@max-sixty, #5696)
+- Handle partial application of transforms in user-defined functions
+  (@max-sixty, #5663; reported by @Rafferty97)
+- Keep Computes with Aggregate when Filter follows (@max-sixty, #5639; reported
+  by @matiastoro)
+- Preserve sort before take in CTE (@max-sixty, #5638; reported by @lukapeschke)
+- Preserve sort with empty group `{}` (@max-sixty, #5635)
+- Return proper error for bare lambda expressions (@max-sixty, #5634)
+- Prevent DISTINCT ON internal sorting from leaking past joins (@max-sixty,
+  #5633; reported by @annashmatko)
+- Fix invalid MSSQL SQL when DISTINCT and FETCH are combined (@max-sixty, #5630)
 
 **Documentation**:
 
-**Web**:
+- Editorial tweaks (@richb-hanover, #5645)
 
 **Integrations**:
 
@@ -19,7 +33,13 @@
 
 **Internal changes**:
 
+- Use chumsky 0.12.0 for all targets (#5659)
+- Update rust toolchain version (#5673)
+- Fix mdbook admonition syntax for mdBook 0.5 native support (#5649)
+
 **New Contributors**:
+
+- @segv, with #5712
 
 ## 0.13.10 — 2025-12-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "compile-files"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "prqlc",
 ]
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-prql"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "ansi-to-html",
  "anstream 1.0.0",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "prql"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "prqlc",
  "rustler",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "prql-java"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "jni",
  "prqlc",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anstream 1.0.0",
  "anyhow",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-c"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "libc",
  "prqlc",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-js"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "console_error_panic_hook",
  "prqlc",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-macros"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "prqlc",
  "syn 2.0.117",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-parser"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "chumsky",
  "enum-as-inner",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-python"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "insta",
  "prqlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/PRQL/prql"
 # This isn't tested since `cargo-msrv` doesn't support workspaces; instead we
 # test `metadata.msrv` in `prqlc`
 rust-version = "1.75.0"
-version = "0.13.11"
+version = "0.13.12"
 
 [profile.release]
 lto = true

--- a/prqlc/bindings/elixir/native/prql/Cargo.toml
+++ b/prqlc/bindings/elixir/native/prql/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/lib.rs"
 test = false
 
 [target.'cfg(not(any(target_family="wasm")))'.dependencies]
-prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.11" }
+prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.12" }
 rustler = "0.37.0"

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prqlc",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prqlc",
-      "version": "0.13.11",
+      "version": "0.13.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -35,5 +35,5 @@
     "test": "mocha tests"
   },
   "types": "dist/node/prqlc_js.d.ts",
-  "version": "0.13.11"
+  "version": "0.13.12"
 }

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: "0.13.11"
+version: "0.13.12"
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/prqlc-macros/Cargo.toml
+++ b/prqlc/prqlc-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-prqlc = {path = "../prqlc", default-features = false, version = "0.13.11" }
+prqlc = {path = "../prqlc", default-features = false, version = "0.13.12" }
 syn = "2.0.117"
 
 [package.metadata.release]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -54,7 +54,7 @@ test-dbs-external = [
 ]
 
 [dependencies]
-prqlc-parser = { path = "../prqlc-parser", version = "0.13.11" }
+prqlc-parser = { path = "../prqlc-parser", version = "0.13.12" }
 
 anstream = { version = "1.0.0", features = ["auto"] }
 ariadne = "0.5.1"

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -343,7 +343,7 @@ mod tests {
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta name="keywords" content="prql">
-            <meta name="generator" content="prqlc 0.13.11">
+            <meta name="generator" content="prqlc 0.13.12">
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
             <title>PRQL Docs</title>
           </head>
@@ -421,7 +421,7 @@ mod tests {
 
             </main>
             <footer class="container border-top">
-              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.11.</small>
+              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.12.</small>
             </footer>
           </body>
         </html>
@@ -448,7 +448,7 @@ mod tests {
         type user_id = int
         ";
 
-        assert_cmd_snapshot!(prqlc_command().args(["experimental", "doc"]).pass_stdin(input), @r"
+        assert_cmd_snapshot!(prqlc_command().args(["experimental", "doc"]).pass_stdin(input), @"
         success: true
         exit_code: 0
         ----- stdout -----
@@ -503,7 +503,7 @@ mod tests {
 
 
 
-        Generated with [prqlc](https://prql-lang.org/) 0.13.11.
+        Generated with [prqlc](https://prql-lang.org/) 0.13.12.
 
         ----- stderr -----
         ");

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -464,6 +464,10 @@ Currently we release in a semi-automated way:
    echo "It has $(git rev-list --count $(git rev-list --tags --max-count=1)..) commits from $(git shortlog --summary $(git rev-list --tags --max-count=1).. | wc -l | tr -d '[:space:]') contributors. Selected changes:"
    ```
 
+   When a fix closes an issue reported by someone other than the PR author,
+   thank them in the changelog entry, e.g.
+   `(@pr-author, #5639; reported by @issue-reporter)`.
+
 2. If the current version is correct, then skip ahead. But if the version needs
    to be changed — for example, we had planned on a patch release, but instead
    require a minor release — then run

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -80,7 +80,7 @@ echo 'prql target:sql.generic
 PRQL allows specifying a version of the language in the PRQL header, like:
 
 ```prql
-prql version:"0.13.10"
+prql version:"0.13.12"
 
 from employees
 ```

--- a/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
@@ -4,7 +4,7 @@ expression: "[{version = prql.version}]\n"
 ---
 WITH table_0 AS (
   SELECT
-    '0.13.11' AS version
+    '0.13.12' AS version
 )
 SELECT
   version

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prql-playground",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prql-playground",
-      "version": "0.13.11",
+      "version": "0.13.12",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.32.0",
         "@monaco-editor/react": "^4.7.0",
@@ -29,7 +29,7 @@
     },
     "../../prqlc/bindings/js": {
       "name": "prqlc",
-      "version": "0.13.11",
+      "version": "0.13.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -46,5 +46,5 @@
     "prepare": "rsync -ai --checksum --delete ../../prqlc/prqlc/tests/integration/data/ public/data/ && node generateBook.cjs",
     "preview": "vite preview"
   },
-  "version": "0.13.11"
+  "version": "0.13.12"
 }


### PR DESCRIPTION
Post-release version bump after 0.13.11.

> _This was written by Claude Code on behalf of @max-sixty_