### PR TITLE
fix: correct SQLite div_i formula for small dividends

### DIFF
--- a/prqlc/prqlc/src/sql/std.sql.prql
+++ b/prqlc/prqlc/src/sql/std.sql.prql
@@ -419,7 +419,7 @@ module sqlite {
   let div_f = l r -> s"({l} * 1.0 / {r:12})"
 
   @{binding_strength=100}
-  let div_i = l r -> s"ROUND(ABS({l:11} / {r:12}) - 0.5) * SIGN({l:0}) * SIGN({r:0})"
+  let div_i = l r -> s"CAST(ABS({l:11} * 1.0 / {r:12}) AS INTEGER) * SIGN({l:0}) * SIGN({r:0})"
 
   # Text functions
   module text {

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__arithmetic.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__compileall__arithmetic.snap
@@ -2,8 +2,8 @@
 source: prqlc/prqlc/tests/integration/queries.rs
 expression: "# mssql:test\nfrom [\n    { id = 1, x_int =  13, x_float =  13.0, k_int =  5, k_float =  5.0 },\n    { id = 2, x_int = -13, x_float = -13.0, k_int =  5, k_float =  5.0 },\n    { id = 3, x_int =  13, x_float =  13.0, k_int = -5, k_float = -5.0 },\n    { id = 4, x_int = -13, x_float = -13.0, k_int = -5, k_float = -5.0 },\n]\nselect {\n    id,\n\n    x_int / k_int,\n    x_int / k_float,\n    x_float / k_int,\n    x_float / k_float,\n\n    q_ii = x_int // k_int,\n    q_if = x_int // k_float,\n    q_fi = x_float // k_int,\n    q_ff = x_float // k_float,\n\n    r_ii = x_int % k_int,\n    r_if = x_int % k_float,\n    r_fi = x_float % k_int,\n    r_ff = x_float % k_float,\n\n    (q_ii * k_int + r_ii | math.round 0),\n    (q_if * k_float + r_if | math.round 0),\n    (q_fi * k_int + r_fi | math.round 0),\n    (q_ff * k_float + r_ff | math.round 0),\n}\nsort id\n"
 input_file: prqlc/prqlc/tests/integration/queries/arithmetic.prql
-snapshot_kind: text
 ---
+
 --- generic
 +++ clickhouse
 @@ -25,42 +25,36 @@
@@ -396,32 +396,32 @@ snapshot_kind: text
 +  (x_int * 1.0 / k_float),
 +  (x_float * 1.0 / k_int),
 +  (x_float * 1.0 / k_float),
-+  ROUND(ABS(x_int / k_int) - 0.5) * SIGN(x_int) * SIGN(k_int) AS q_ii,
-+  ROUND(ABS(x_int / k_float) - 0.5) * SIGN(x_int) * SIGN(k_float) AS q_if,
-+  ROUND(ABS(x_float / k_int) - 0.5) * SIGN(x_float) * SIGN(k_int) AS q_fi,
-+  ROUND(ABS(x_float / k_float) - 0.5) * SIGN(x_float) * SIGN(k_float) AS q_ff,
++  CAST(ABS(x_int * 1.0 / k_int) AS INTEGER) * SIGN(x_int) * SIGN(k_int) AS q_ii,
++  CAST(ABS(x_int * 1.0 / k_float) AS INTEGER) * SIGN(x_int) * SIGN(k_float) AS q_if,
++  CAST(ABS(x_float * 1.0 / k_int) AS INTEGER) * SIGN(x_float) * SIGN(k_int) AS q_fi,
++  CAST(ABS(x_float * 1.0 / k_float) AS INTEGER) * SIGN(x_float) * SIGN(k_float) AS q_ff,
    x_int % k_int AS r_ii,
    x_int % k_float AS r_if,
    x_float % k_int AS r_fi,
    x_float % k_float AS r_ff,
    ROUND(
 -    FLOOR(ABS(x_int / k_int)) * SIGN(x_int) * SIGN(k_int) * k_int + x_int % k_int,
-+    ROUND(ABS(x_int / k_int) - 0.5) * SIGN(x_int) * SIGN(k_int) * k_int + x_int % k_int,
++    CAST(ABS(x_int * 1.0 / k_int) AS INTEGER) * SIGN(x_int) * SIGN(k_int) * k_int + x_int % k_int,
      0
    ),
    ROUND(
 -    FLOOR(ABS(x_int / k_float)) * SIGN(x_int) * SIGN(k_float) * k_float + x_int % k_float,
-+    ROUND(ABS(x_int / k_float) - 0.5) * SIGN(x_int) * SIGN(k_float) * k_float + x_int % k_float,
++    CAST(ABS(x_int * 1.0 / k_float) AS INTEGER) * SIGN(x_int) * SIGN(k_float) * k_float + x_int % k_float,
      0
    ),
    ROUND(
 -    FLOOR(ABS(x_float / k_int)) * SIGN(x_float) * SIGN(k_int) * k_int + x_float % k_int,
-+    ROUND(ABS(x_float / k_int) - 0.5) * SIGN(x_float) * SIGN(k_int) * k_int + x_float % k_int,
++    CAST(ABS(x_float * 1.0 / k_int) AS INTEGER) * SIGN(x_float) * SIGN(k_int) * k_int + x_float % k_int,
      0
    ),
    ROUND(
 -    FLOOR(ABS(x_float / k_float)) * SIGN(x_float) * SIGN(k_float) * k_float + x_float % k_float,
-+    ROUND(ABS(x_float / k_float) - 0.5) * SIGN(x_float) * SIGN(k_float) * k_float + x_float % k_float,
++    CAST(ABS(x_float * 1.0 / k_float) AS INTEGER) * SIGN(x_float) * SIGN(k_float) * k_float + x_float % k_float,
      0
    )
  FROM

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -452,6 +452,24 @@ fn test_precedence_division() {
 }
 
 #[test]
+fn test_sqlite_integer_division() {
+    // Regression test: SQLite div_i formula must produce correct results
+    // when |dividend| < |divisor| (result should be 0).
+    // The old formula ROUND(ABS(l/r) - 0.5) * SIGN(l) * SIGN(r) was wrong
+    // because SQLite integer division gives 0 for |l| < |r|, and
+    // ROUND(ABS(0) - 0.5) = ROUND(-0.5) = -1 in SQLite.
+    assert_snapshot!(compile_with_sql_dialect(r#"
+    from t
+    select { x = a // b }
+    "#, sql::Dialect::SQLite).unwrap(), @r"
+    SELECT
+      CAST(ABS(a * 1.0 / b) AS INTEGER) * SIGN(a) * SIGN(b) AS x
+    FROM
+      t
+    ");
+}
+
+#[test]
 fn test_precedence_01() {
     assert_snapshot!((compile(r###"
     from artists

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__stdlib__README__standard-library__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__stdlib__README__standard-library__1.snap
@@ -9,6 +9,6 @@ WITH table_0 AS (
 )
 SELECT
   (x * 1.0 / y) AS quotient,
-  ROUND(ABS(x / y) - 0.5) * SIGN(x) * SIGN(y) AS int_quotient
+  CAST(ABS(x * 1.0 / y) AS INTEGER) * SIGN(x) * SIGN(y) AS int_quotient
 FROM
   table_0

--- a/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__division-and-integer-division__0.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__reference__syntax__operators__division-and-integer-division__0.snap
@@ -14,6 +14,6 @@ WITH table_0 AS (
 )
 SELECT
   (a * 1.0 / b) AS div_out,
-  ROUND(ABS(a / b) - 0.5) * SIGN(a) * SIGN(b) AS int_div_out
+  CAST(ABS(a * 1.0 / b) AS INTEGER) * SIGN(a) * SIGN(b) AS int_div_out
 FROM
   table_0


### PR DESCRIPTION
## Summary

- Fixes the SQLite `div_i` formula which produced wrong results (e.g., `-1` instead of `0`) when `|dividend| < |divisor|`
- Replaces `ROUND(ABS(l/r) - 0.5)` with `CAST(ABS(l * 1.0 / r) AS INTEGER)` for correct truncation-towards-zero semantics
- Adds a regression test for this case

Fixes #5735

## Root Cause

The old SQLite formula `ROUND(ABS({l} / {r}) - 0.5) * SIGN({l}) * SIGN({r})` broke when both operands were integers and `|l| < |r|`:

1. SQLite integer division: `1 / 2 = 0`
2. `ABS(0) - 0.5 = -0.5`
3. `ROUND(-0.5) = -1` (SQLite rounds away from zero)
4. Result: `-1` instead of expected `0`

Verified with actual SQLite: the old formula gave wrong results for `1//2`, `-1//2`, `3//7`, `-3//7`, etc.

## Fix

Force float division with `* 1.0`, then use `CAST(... AS INTEGER)` which truncates towards zero in SQLite -- exactly matching integer division semantics.

## Test plan

- [x] Verified fix produces correct results for all test cases in actual SQLite
- [x] Added `test_sqlite_integer_division` regression test
- [x] All 449 existing prqlc tests pass
- [x] Updated `compileall` snapshot for arithmetic test

Generated with [Claude Code](https://claude.com/claude-code)