### PR TITLE
fix: BETWEEN optimization now triggers by comparing expr kind, not span

### DIFF
--- a/prqlc/prqlc/src/sql/gen_expr.rs
+++ b/prqlc/prqlc/src/sql/gen_expr.rs
@@ -432,7 +432,9 @@ fn try_into_between(expr: rq::Expr, ctx: &mut Context) -> Result<Option<sql_ast:
 
                     // We need for the values on each arm to be the same; e.g. x
                     // > 3 and x < 5
-                    if a_l == b_l {
+                    // Compare only `kind` (not `span`) since the same column
+                    // referenced at two source positions has different spans.
+                    if a_l.kind == b_l.kind {
                         return Ok(Some(sql_ast::Expr::Between {
                             expr: Box::new(
                                 translate_operand(a_l, true, 0, Associativity::Both, ctx)?

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -481,6 +481,22 @@ fn test_sqlite_integer_division() {
 }
 
 #[test]
+fn test_between_optimization() {
+    // Regression test: >= and <= on same column should produce BETWEEN
+    assert_snapshot!(compile(r#"
+    from t
+    filter (a >= 5 && a <= 10)
+    "#).unwrap(), @r"
+    SELECT
+      *
+    FROM
+      t
+    WHERE
+      a BETWEEN 5 AND 10
+    ");
+}
+
+#[test]
 fn test_precedence_01() {
     assert_snapshot!((compile(r###"
     from artists


### PR DESCRIPTION
## Summary

- Fixes the `try_into_between` optimization which was dead code since it compared `rq::Expr` values including their `span` field
- Changes comparison from `a_l == b_l` (full Expr including span) to `a_l.kind == b_l.kind` (semantic content only)
- Adds regression test verifying BETWEEN is now generated

Fixes #5737

## Before

```
from t | filter (a >= 5 && a <= 10)
```
Generated:
```sql
SELECT * FROM t WHERE a >= 5 AND a <= 10
```

## After

```sql
SELECT * FROM t WHERE a BETWEEN 5 AND 10
```

## Root Cause

`rq::Expr` derives `PartialEq` which includes the `span` field. The same column `a` referenced at two different source positions has the same `CId` but different `Span` values, so the equality check `a_l == b_l` always failed.

## Test plan

- [x] Added `test_between_optimization` regression test
- [x] All 450 prqlc tests pass (including new test)
- [x] Change is a one-line fix in the comparison logic

Generated with [Claude Code](https://claude.com/claude-code)