### PR TITLE
chore: fix tend 0.0.9 workflow drift and update skill

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -13,6 +13,6 @@ error conventions, etc. are in `CLAUDE.md` — don't duplicate them here.
 ## CI structure
 
 - Main CI workflow: `tests` (watched by tend-ci-fix)
-- Dependency management: Dependabot (tend-renovate is disabled)
+- Dependency management: Dependabot (tend-weekly is disabled)
 - Automerge: `pull-request-target.yaml` auto-merges single-commit `prql-bot` PRs
   once CI passes

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Re-ran `uvx tend@0.0.9 init` to add missing `ref: main` in ci-fix and nightly checkout steps that were lost during the previous merge. Updated running-tend skill to reference `tend-weekly` (renamed from `tend-renovate` in 0.0.9).

> _This was written by Claude Code on behalf of @max-sixty_