### PR TITLE
feat: add oracle_sql dialect support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 **Features**:
 
+- Add a very early `sql.oracle` dialect. It currently only forces identifier
+  quoting to accommodate Oracle's case-folding rules; most other features fall
+  back to generic SQL. (@julien-pinchelimouroux, #5821)
+
 **Fixes**:
 
 **Documentation**:

--- a/prqlc/bindings/elixir/lib/prql.ex
+++ b/prqlc/bindings/elixir/lib/prql.ex
@@ -18,6 +18,7 @@ defmodule PRQL do
           | :clickhouse
           | :duckdb
           | :glaredb
+          | :oracle_sql
           | :redshift
           | :sqlite
           | :snowflake

--- a/prqlc/bindings/elixir/lib/prql.ex
+++ b/prqlc/bindings/elixir/lib/prql.ex
@@ -18,7 +18,7 @@ defmodule PRQL do
           | :clickhouse
           | :duckdb
           | :glaredb
-          | :oracle_sql
+          | :oracle
           | :redshift
           | :sqlite
           | :snowflake
@@ -40,7 +40,7 @@ defmodule PRQL do
 
     * `:target` - Dialect used for generate SQL. Accepted values are
     `:generic`, `:mssql`, `:mysql`, `:postgres`, `:ansi`, `:bigquery`,
-    `:clickhouse`, `:duckdb`, `:glaredb`, `:redshift`, `:sqlite`, `:snowflake`
+    `:clickhouse`, `:duckdb`, `:glaredb`, `:oracle`, `:redshift`, `:sqlite`, `:snowflake`
 
     * `:format` - Formats the output, defaults to `true`
 

--- a/prqlc/bindings/elixir/lib/prql/native.ex
+++ b/prqlc/bindings/elixir/lib/prql/native.ex
@@ -26,6 +26,7 @@ defmodule PRQL.Native.CompileOptions do
           | :bigquery
           | :clickhouse
           | :glaredb
+          | :oracle_sql
           | :redshift
           | :sqlite
           | :snowflake

--- a/prqlc/bindings/elixir/lib/prql/native.ex
+++ b/prqlc/bindings/elixir/lib/prql/native.ex
@@ -26,7 +26,7 @@ defmodule PRQL.Native.CompileOptions do
           | :bigquery
           | :clickhouse
           | :glaredb
-          | :oracle_sql
+          | :oracle
           | :redshift
           | :sqlite
           | :snowflake

--- a/prqlc/bindings/elixir/native/prql/src/lib.rs
+++ b/prqlc/bindings/elixir/native/prql/src/lib.rs
@@ -22,7 +22,7 @@ mod atoms {
       generic,
       mssql,
       mysql,
-      oracle_sql,
+      oracle,
       postgres,
       redshift,
       sqlite,
@@ -64,8 +64,8 @@ fn target_from_atom(a: Atom) -> prqlc::Target {
         MsSql
     } else if a == atoms::mysql() {
         MySql
-    } else if a == atoms::oracle_sql() {
-        OracleSql
+    } else if a == atoms::oracle() {
+        Oracle
     } else if a == atoms::postgres() {
         Postgres
     } else if a == atoms::redshift() {

--- a/prqlc/bindings/elixir/native/prql/src/lib.rs
+++ b/prqlc/bindings/elixir/native/prql/src/lib.rs
@@ -22,6 +22,7 @@ mod atoms {
       generic,
       mssql,
       mysql,
+      oracle_sql,
       postgres,
       redshift,
       sqlite,
@@ -63,6 +64,8 @@ fn target_from_atom(a: Atom) -> prqlc::Target {
         MsSql
     } else if a == atoms::mysql() {
         MySql
+    } else if a == atoms::oracle_sql() {
+        OracleSql
     } else if a == atoms::postgres() {
         Postgres
     } else if a == atoms::redshift() {

--- a/prqlc/prqlc/src/cli/test.rs
+++ b/prqlc/prqlc/src/cli/test.rs
@@ -86,7 +86,7 @@ fn get_targets() {
     sql.glaredb
     sql.mssql
     sql.mysql
-    sql.oracle_sql
+    sql.oracle
     sql.postgres
     sql.redshift
     sql.sqlite

--- a/prqlc/prqlc/src/cli/test.rs
+++ b/prqlc/prqlc/src/cli/test.rs
@@ -145,18 +145,18 @@ fn compile_help() {
 
       -t, --target <TARGET>
               Target to compile to
-
+              
               [env: PRQLC_TARGET=]
               [default: sql.any]
 
           --debug-log <DEBUG_LOG>
               File path into which to write the debug log to
-
+              
               [env: PRQLC_DEBUG_LOG=]
 
           --color <WHEN>
               Controls when to use color
-
+              
               [default: auto]
               [possible values: auto, always, never]
 

--- a/prqlc/prqlc/src/cli/test.rs
+++ b/prqlc/prqlc/src/cli/test.rs
@@ -86,6 +86,7 @@ fn get_targets() {
     sql.glaredb
     sql.mssql
     sql.mysql
+    sql.oracle_sql
     sql.postgres
     sql.redshift
     sql.sqlite
@@ -144,18 +145,18 @@ fn compile_help() {
 
       -t, --target <TARGET>
               Target to compile to
-              
+
               [env: PRQLC_TARGET=]
               [default: sql.any]
 
           --debug-log <DEBUG_LOG>
               File path into which to write the debug log to
-              
+
               [env: PRQLC_DEBUG_LOG=]
 
           --color <WHEN>
               Controls when to use color
-              
+
               [default: auto]
               [possible values: auto, always, never]
 

--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -89,7 +89,7 @@ pub enum Dialect {
     GlareDb,
     MsSql,
     MySql,
-    OracleSql,
+    Oracle,
     Postgres,
     Redshift,
     SQLite,
@@ -113,7 +113,7 @@ impl Dialect {
             Dialect::Postgres => Box::new(PostgresDialect),
             Dialect::Redshift => Box::new(RedshiftDialect),
             Dialect::GlareDb => Box::new(GlareDbDialect),
-            Dialect::OracleSql => Box::new(OracleSqlDialect),
+            Dialect::Oracle => Box::new(OracleDialect),
             Dialect::Ansi | Dialect::Generic => Box::new(GenericDialect),
         }
     }
@@ -132,7 +132,7 @@ impl Dialect {
             | Dialect::Ansi
             | Dialect::BigQuery
             | Dialect::Snowflake
-            | Dialect::OracleSql => SupportLevel::Unsupported,
+            | Dialect::Oracle => SupportLevel::Unsupported,
         }
     }
 
@@ -171,7 +171,7 @@ pub struct RedshiftDialect;
 #[derive(Debug)]
 pub struct GlareDbDialect;
 #[derive(Debug)]
-pub struct OracleSqlDialect;
+pub struct OracleDialect;
 
 pub(super) enum ColumnExclude {
     Exclude,
@@ -742,7 +742,7 @@ impl DialectHandler for DuckDbDialect {
     }
 }
 
-impl DialectHandler for OracleSqlDialect {
+impl DialectHandler for OracleDialect {
     fn ident_quoting_style(&self) -> IdentQuotingStyle {
         // Due to oraclesql identifier casing rules, identifiers are always quoted
         // https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/Database-Object-Names-and-Qualifiers.html

--- a/prqlc/prqlc/src/sql/dialect.rs
+++ b/prqlc/prqlc/src/sql/dialect.rs
@@ -89,6 +89,7 @@ pub enum Dialect {
     GlareDb,
     MsSql,
     MySql,
+    OracleSql,
     Postgres,
     Redshift,
     SQLite,
@@ -112,6 +113,7 @@ impl Dialect {
             Dialect::Postgres => Box::new(PostgresDialect),
             Dialect::Redshift => Box::new(RedshiftDialect),
             Dialect::GlareDb => Box::new(GlareDbDialect),
+            Dialect::OracleSql => Box::new(OracleSqlDialect),
             Dialect::Ansi | Dialect::Generic => Box::new(GenericDialect),
         }
     }
@@ -126,9 +128,11 @@ impl Dialect {
             | Dialect::Generic
             | Dialect::GlareDb
             | Dialect::ClickHouse => SupportLevel::Supported,
-            Dialect::MsSql | Dialect::Ansi | Dialect::BigQuery | Dialect::Snowflake => {
-                SupportLevel::Unsupported
-            }
+            Dialect::MsSql
+            | Dialect::Ansi
+            | Dialect::BigQuery
+            | Dialect::Snowflake
+            | Dialect::OracleSql => SupportLevel::Unsupported,
         }
     }
 
@@ -166,6 +170,8 @@ pub struct PostgresDialect;
 pub struct RedshiftDialect;
 #[derive(Debug)]
 pub struct GlareDbDialect;
+#[derive(Debug)]
+pub struct OracleSqlDialect;
 
 pub(super) enum ColumnExclude {
     Exclude,
@@ -733,6 +739,14 @@ impl DialectHandler for DuckDbDialect {
                 ))
             }
         })
+    }
+}
+
+impl DialectHandler for OracleSqlDialect {
+    fn ident_quoting_style(&self) -> IdentQuotingStyle {
+        // Due to oraclesql identifier casing rules, identifiers are always quoted
+        // https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/Database-Object-Names-and-Qualifiers.html
+        IdentQuotingStyle::AlwaysQuoted
     }
 }
 

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -240,6 +240,17 @@ FROM
   "employees"
 "#
 )]
+#[case::oracle_sql(
+    sql::Dialect::OracleSql,
+    r#"
+SELECT
+  "a",
+  "b",
+  "col space"
+FROM
+  "employees"
+"#
+)]
 fn test_quoting_style(#[case] dialect: sql::Dialect, #[case] expected_sql: &'static str) {
     let query = r#"
   from employees

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -240,8 +240,8 @@ FROM
   "employees"
 "#
 )]
-#[case::oracle_sql(
-    sql::Dialect::OracleSql,
+#[case::oracle(
+    sql::Dialect::Oracle,
     r#"
 SELECT
   "a",

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -51,6 +51,7 @@ additional dialects.
 - `sql.ansi`
 - `sql.bigquery`
 - `sql.snowflake`
+- `sql.oracle`
 
 ## Priority of targets
 

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -51,7 +51,9 @@ additional dialects.
 - `sql.ansi`
 - `sql.bigquery`
 - `sql.snowflake`
-- `sql.oracle`
+- `sql.oracle` — very early; currently only ensures identifiers are quoted to
+  accommodate Oracle's case-folding rules. Most other language features fall
+  back to generic SQL and may not execute correctly against Oracle.
 
 ## Priority of targets
 


### PR DESCRIPTION
Add basic support for Oracle SQL dialect to force quotes on identifiers. 