### PR TITLE
fix(prqlc/deps): loosen chrono constraint from 0.4.44 to 0.4

### DIFF
--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -58,7 +58,7 @@ prqlc-parser = { path = "../prqlc-parser", version = "0.13.12" }
 
 anstream = { version = "1.0.0", features = ["auto"] }
 ariadne = "0.5.1"
-chrono = "0.4.44"
+chrono = "0.4"
 csv = "1.4.0"
 enum-as-inner = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
depending on the latest chrono version causes conflicts with other libs relying on older versions, such as polars: https://github.com/pola-rs/polars/blob/693c52035689e150c2c70fc6d48c952c564ec940/Cargo.toml#L44