### PR TITLE
chore: Bump version to 0.13.13 for next development cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "compile-files"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "prqlc",
 ]
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-prql"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "ansi-to-html",
  "anstream",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "prql"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "prqlc",
  "rustler",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "prql-java"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "jni",
  "prqlc",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anstream",
  "anyhow",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-c"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "libc",
  "prqlc",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-js"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "console_error_panic_hook",
  "prqlc",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-macros"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "prqlc",
  "syn 2.0.117",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-parser"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "chumsky",
  "enum-as-inner",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-python"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "insta",
  "prqlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/PRQL/prql"
 # This isn't tested since `cargo-msrv` doesn't support workspaces; instead we
 # test `metadata.msrv` in `prqlc`
 rust-version = "1.75.0"
-version = "0.13.12"
+version = "0.13.13"
 
 [profile.release]
 lto = true

--- a/prqlc/bindings/elixir/native/prql/Cargo.toml
+++ b/prqlc/bindings/elixir/native/prql/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/lib.rs"
 test = false
 
 [target.'cfg(not(any(target_family="wasm")))'.dependencies]
-prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.12" }
+prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.13" }
 rustler = "0.37.0"

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prqlc",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prqlc",
-      "version": "0.13.12",
+      "version": "0.13.13",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -35,5 +35,5 @@
     "test": "mocha tests"
   },
   "types": "dist/node/prqlc_js.d.ts",
-  "version": "0.13.12"
+  "version": "0.13.13"
 }

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: "0.13.12"
+version: "0.13.13"
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/prqlc-macros/Cargo.toml
+++ b/prqlc/prqlc-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-prqlc = {path = "../prqlc", default-features = false, version = "0.13.12" }
+prqlc = {path = "../prqlc", default-features = false, version = "0.13.13" }
 syn = "2.0.117"
 
 [package.metadata.release]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -54,7 +54,7 @@ test-dbs-external = [
 ]
 
 [dependencies]
-prqlc-parser = { path = "../prqlc-parser", version = "0.13.12" }
+prqlc-parser = { path = "../prqlc-parser", version = "0.13.13" }
 
 anstream = { version = "1.0.0", features = ["auto"] }
 ariadne = "0.5.1"

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -343,7 +343,7 @@ mod tests {
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta name="keywords" content="prql">
-            <meta name="generator" content="prqlc 0.13.12">
+            <meta name="generator" content="prqlc 0.13.13">
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
             <title>PRQL Docs</title>
           </head>
@@ -421,7 +421,7 @@ mod tests {
 
             </main>
             <footer class="container border-top">
-              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.12.</small>
+              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.13.</small>
             </footer>
           </body>
         </html>
@@ -503,7 +503,7 @@ mod tests {
 
 
 
-        Generated with [prqlc](https://prql-lang.org/) 0.13.12.
+        Generated with [prqlc](https://prql-lang.org/) 0.13.13.
 
         ----- stderr -----
         ");

--- a/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
@@ -4,7 +4,7 @@ expression: "[{version = prql.version}]\n"
 ---
 WITH table_0 AS (
   SELECT
-    '0.13.12' AS version
+    '0.13.13' AS version
 )
 SELECT
   version

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prql-playground",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prql-playground",
-      "version": "0.13.12",
+      "version": "0.13.13",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.32.0",
         "@monaco-editor/react": "^4.7.0",
@@ -29,7 +29,7 @@
     },
     "../../prqlc/bindings/js": {
       "name": "prqlc",
-      "version": "0.13.12",
+      "version": "0.13.13",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -46,5 +46,5 @@
     "prepare": "rsync -ai --checksum --delete ../../prqlc/prqlc/tests/integration/data/ public/data/ && node generateBook.cjs",
     "preview": "vite preview"
   },
-  "version": "0.13.12"
+  "version": "0.13.13"
 }


### PR DESCRIPTION
Post-0.13.12 release version bump.

Generated by `cargo release patch --no-publish --no-push --execute --no-verify --no-confirm --no-tag` plus `task prqlc:test-all` to refresh version-bearing snapshots.

> _This was written by Claude Code on behalf of @max-sixty_