### PR TITLE
ci: trigger nightly path filter on any Cargo.toml change

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -110,7 +110,7 @@ jobs:
             nightly:
               - .github/workflows/nightly.yaml
               - .github/workflows/release.yaml
-              - Cargo.toml
+              - "**/Cargo.toml"
               - Cargo.lock
               - rust-toolchain.toml
               - .cargo/**


### PR DESCRIPTION
The `nightly:` path filter in `tests.yaml` had `Cargo.toml` (root-only) where it should have had `**/Cargo.toml`. PR #5834 only touched `prqlc/prqlc/Cargo.toml`, so `test-deps-min-versions` was skipped on its CI run, letting the `chrono = "0.4"` minimum-version regression land on main (now being fixed in #5841).

Audited the rest of the `changes:` block — every other filter that should match nested files already uses a `**` glob. `Cargo.lock` (only one in the workspace), `rust-toolchain.toml`, and the bare `Taskfile.yaml` in the devcontainer filters (intentionally root-only) are unchanged.

> _This was written by Claude Code on behalf of @max-sixty_