### PR TITLE
fix: catch CLI compile panic to ensure debug log is generated

### DIFF
--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -5,6 +5,7 @@ use std::env;
 use std::fs::File;
 use std::io::{self, BufWriter, Read, Write};
 use std::ops::Range;
+use std::panic;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::str::FromStr;
@@ -468,18 +469,24 @@ impl Command {
                     .with_signature_comment(*signature_comment)
                     .with_format(*format);
 
-                let res = prql_to_pl_tree(sources)
-                    .and_then(|pl| {
-                        pl_to_rq_tree(pl, &main_path, &[semantic::NS_DEFAULT_DB.to_string()])
-                    })
-                    .and_then(|rq| rq_to_sql(rq, &opts))
-                    .map_err(|e| e.composed(sources));
+                // catch any panic during compilation so that we can still produce a debug log
+                let res = panic::catch_unwind(|| {
+                    return prql_to_pl_tree(sources)
+                        .and_then(|pl| {
+                            pl_to_rq_tree(pl, &main_path, &[semantic::NS_DEFAULT_DB.to_string()])
+                        })
+                        .and_then(|rq| rq_to_sql(rq, &opts))
+                        .map_err(|e| e.composed(sources));
+                });
 
                 if let Some(path) = debug_log {
                     write_log(path)?;
                 }
 
-                res?.as_bytes().to_vec()
+                match res {
+                    Ok(r) => r?.as_bytes().to_vec(),
+                    Err(_) => Vec::new(),
+                }
             }
             _ => unreachable!("Other commands shouldn't reach `execute`"),
         })

--- a/prqlc/prqlc/src/cli/mod.rs
+++ b/prqlc/prqlc/src/cli/mod.rs
@@ -471,12 +471,12 @@ impl Command {
 
                 // catch any panic during compilation so that we can still produce a debug log
                 let res = panic::catch_unwind(|| {
-                    return prql_to_pl_tree(sources)
+                    prql_to_pl_tree(sources)
                         .and_then(|pl| {
                             pl_to_rq_tree(pl, &main_path, &[semantic::NS_DEFAULT_DB.to_string()])
                         })
                         .and_then(|rq| rq_to_sql(rq, &opts))
-                        .map_err(|e| e.composed(sources));
+                        .map_err(|e| e.composed(sources))
                 });
 
                 if let Some(path) = debug_log {
@@ -485,7 +485,7 @@ impl Command {
 
                 match res {
                     Ok(r) => r?.as_bytes().to_vec(),
-                    Err(_) => Vec::new(),
+                    Err(payload) => panic::resume_unwind(payload),
                 }
             }
             _ => unreachable!("Other commands shouldn't reach `execute`"),


### PR DESCRIPTION
I was troubleshooting an instance where the CLI compiler was panicking due to an `.unwrap()`. I tried to use the `--debug-log` option to generate log output, but nothing was generated, because the panic happened before the log output could be saved to disk.

This PR wraps the main steps of compilation via the CLI inside a `panic::catch_unwind` handler. This still results in the panic being displayed, but allows the CLI to continue through to output the debug log, making it much easier to trace the sequence of events leading up to the panic.