### PR TITLE
fix: fold exprs within tuple_map evaluation

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -328,10 +328,16 @@ impl Resolver<'_> {
                 let list_items = list_items
                     .into_iter()
                     .map(|item| {
-                        Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
+                        let expr = Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
                             func.clone(),
                             vec![item],
-                        )))
+                        )));
+
+                        // fold the map item now
+                        match self.fold_expr(expr.clone()) {
+                            Ok(result) => result,
+                            Err(_) => expr,
+                        }
                     })
                     .collect_vec();
 

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -328,18 +328,12 @@ impl Resolver<'_> {
                 let list_items = list_items
                     .into_iter()
                     .map(|item| {
-                        let expr = Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
+                        self.fold_expr(Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
                             func.clone(),
                             vec![item],
-                        )));
-
-                        // fold the map item now
-                        match self.fold_expr(expr.clone()) {
-                            Ok(result) => result,
-                            Err(_) => expr,
-                        }
+                        ))))
                     })
-                    .collect_vec();
+                    .collect::<Result<Vec<_>>>()?;
 
                 return Ok(Expr {
                     kind: ExprKind::Tuple(list_items),

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -7275,3 +7275,22 @@ fn test_partial_application_of_transform() {
       10
     ");
 }
+
+#[test]
+fn test_tuple_map() {
+    assert_snapshot!(compile(r###"
+    let add_four = func a -> a + 4
+
+    from foo
+    select {x, y}
+    derive (tuple_map add_four foo.*)
+    "###).unwrap(), @"
+    SELECT
+      x,
+      y,
+      x + 4,
+      y + 4
+    FROM
+      foo
+    ");
+}


### PR DESCRIPTION
The following PRQL fails with a panic during compilation:

```
let add_four = func a -> a + 4

from foo
select {x, y}
derive (tuple_map add_four foo.*)
```

The error is:

```
The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: prqlc/prqlc/src/semantic/resolver/transforms.rs:978
```

The ultimate cause is that the invocation of `tuple_map` does not directly produce a tuple of evaluated results, but rather produces a tuple of `ExprKind::FuncCall` instances. Those FuncCall instances are not expected at time of lineage calculation (where the panic happens in `transforms.rs`). 

The only place where `tuple_map` is currently used is in `std.prql`, for example:
https://github.com/PRQL/prql/blob/2c0465adea29a28c7691334fb64dc001474a4796/prqlc/prqlc/src/semantic/std.prql#L122-L126

In the above case, `tuple_map` is being wrapped in `tuple_every`, which effectively triggers a fold of the FuncCall instances that it returns (somehow... I'm not sure how, exactly). However, when `tuple_map` is used on its own, those FuncCall instances are not evaluated as expected.

This PR updates the implementation of `tuple_map` so that the FuncCall instances generated through the map process are folded immediately after they are created, ensuring that they are not propagated through to lineage calculation.