### PR TITLE
feat: replace tuple_every with tuple_reduce

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -313,8 +313,8 @@ impl Resolver<'_> {
 
                 let mut res = init.clone();
 
-                if let Ok(init_val) = init.kind.into_literal() {
-                    if init_val.to_string().as_str() == "\"__missing\"" {
+                if let ExprKind::Literal(Literal::String(init_val)) = &init.kind {
+                    if init_val == "__missing" {
                         match num_items {
                             0 => return Err(Error::new(Reason::Expected {
                                 who: Some("tuple".to_string()),

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -303,18 +303,45 @@ impl Resolver<'_> {
                 .with_span(pattern.span));
             }
 
-            "tuple_every" => {
+            "tuple_reduce" => {
                 // yes, this is not a transform, but this is the most appropriate place for it
 
-                let [list] = unpack::<1>(func.args);
-                let list = list.kind.into_tuple().unwrap();
+                let [init, func, list] = unpack::<3>(func.args);
+                let list_items = list.kind.into_tuple().unwrap();
+                let num_items = list_items.len();
+                let mut list_iter = list_items.into_iter();
 
-                let mut res = None;
-                for item in list {
-                    res = maybe_binop(res, &["std", "and"], Some(item));
+                let mut res = init.clone();
+
+                if let Ok(init_val) = init.kind.into_literal() {
+                    if init_val.to_string().as_str() == "\"__missing\"" {
+                        match num_items {
+                            0 => return Err(Error::new(Reason::Expected {
+                                who: Some("tuple".to_string()),
+                                expected:
+                                    "to have at least one entry when initial value is not provided"
+                                        .to_string(),
+                                found: "empty tuple".to_string(),
+                            })
+                            .with_span(list.span)
+                            .push_hint("try adding an initial:<value> parameter")),
+                            1 => {
+                                let item = list_iter.next().unwrap();
+                                return Ok(item);
+                            }
+                            _ => {
+                                res = list_iter.next().unwrap();
+                            }
+                        }
+                    }
                 }
-                let res =
-                    res.unwrap_or_else(|| Expr::new(ExprKind::Literal(Literal::Boolean(true))));
+
+                for item in list_iter {
+                    res = self.fold_expr(Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
+                        func.clone(),
+                        vec![res, item],
+                    ))))?;
+                }
 
                 return Ok(res);
             }

--- a/prqlc/prqlc/src/semantic/std.prql
+++ b/prqlc/prqlc/src/semantic/std.prql
@@ -121,13 +121,13 @@ let window = func
 let append = `default_db.bottom`<relation> top<relation> -> <relation> internal append
 let intersect = `default_db.bottom`<relation> top<relation> -> <relation> (
   t = top
-  join (b = bottom) (tuple_every (tuple_map _eq (tuple_zip t.* b.*)))
+  join (b = bottom) (tuple_reduce std.and (tuple_map _eq (tuple_zip t.* b.*)))
   select t.*
 )
 let remove = `default_db.bottom`<relation> top<relation> -> <relation> (
   t = top
-  join side:left (b = bottom) (tuple_every (tuple_map _eq (tuple_zip t.* b.*)))
-  filter (tuple_every (tuple_map _is_null b.*))
+  join side:left (b = bottom) (tuple_reduce std.and (tuple_map _eq (tuple_zip t.* b.*)))
+  filter (tuple_reduce std.and (tuple_map _is_null b.*))
   select t.*
 )
 let loop = func
@@ -199,7 +199,7 @@ let as = `noresolve.type` column -> internal std.as
 let in = pattern value -> <bool> internal in
 
 ## Tuple functions
-let tuple_every = func list -> <bool> internal tuple_every
+let tuple_reduce = func initial:"__missing" fn <func> list -> internal tuple_reduce
 let tuple_map = func fn <func> list -> internal tuple_map
 let tuple_zip = func a b -> internal tuple_zip
 let _eq = func a -> internal _eq

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
@@ -18,7 +18,7 @@ frames:
       table:
       - default_db
       - _literal_127
-- - 0:3163-3240
+- - 0:3172-3258
   - columns:
     - !Single
       name:
@@ -43,7 +43,7 @@ frames:
       table:
       - default_db
       - _literal_122
-- - 0:3243-3288
+- - 0:3261-3315
   - columns:
     - !Single
       name:
@@ -74,7 +74,7 @@ frames:
       name:
       - t
       - a
-      target_id: 207
+      target_id: 213
       target_name: null
     inputs:
     - id: 127
@@ -93,7 +93,7 @@ frames:
       name:
       - t
       - a
-      target_id: 207
+      target_id: 213
       target_name: null
     inputs:
     - id: 127
@@ -110,7 +110,7 @@ nodes:
 - id: 122
   kind: Array
   span: 1:173-237
-  parent: 189
+  parent: 192
 - id: 127
   kind: Array
   span: 1:36-55
@@ -135,11 +135,11 @@ nodes:
   children:
   - 127
   - 155
-  parent: 189
+  parent: 192
 - id: 155
   kind: Literal
   parent: 154
-- id: 178
+- id: 181
   kind: Ident
   ident: !Ident
   - this
@@ -147,7 +147,7 @@ nodes:
   - a
   targets:
   - 136
-- id: 181
+- id: 184
   kind: Ident
   ident: !Ident
   - that
@@ -155,48 +155,48 @@ nodes:
   - a
   targets:
   - 122
-- id: 187
+- id: 190
   kind: RqOperator
-  span: 0:3192-3239
+  span: 0:3201-3257
   targets:
-  - 178
   - 181
-  parent: 189
-- id: 189
+  - 184
+  parent: 192
+- id: 192
   kind: 'TransformCall: Join'
-  span: 0:3163-3240
+  span: 0:3172-3258
   children:
   - 154
   - 122
-  - 187
-  parent: 205
-- id: 197
+  - 190
+  parent: 211
+- id: 203
   kind: Ident
-  span: 0:5981-5989
+  span: 0:6033-6041
   ident: !Ident
   - this
   - b
   - a
   targets:
   - 122
-- id: 201
-  kind: RqOperator
-  span: 0:3251-3287
-  targets:
-  - 197
-  - 204
-  parent: 205
-- id: 204
-  kind: Literal
-  span: 0:5993-5997
-- id: 205
-  kind: 'TransformCall: Filter'
-  span: 0:3243-3288
-  children:
-  - 189
-  - 201
-  parent: 209
 - id: 207
+  kind: RqOperator
+  span: 0:3269-3314
+  targets:
+  - 203
+  - 210
+  parent: 211
+- id: 210
+  kind: Literal
+  span: 0:6045-6049
+- id: 211
+  kind: 'TransformCall: Filter'
+  span: 0:3261-3315
+  children:
+  - 192
+  - 207
+  parent: 215
+- id: 213
   kind: Ident
   ident: !Ident
   - this
@@ -204,21 +204,21 @@ nodes:
   - a
   targets:
   - 136
-  parent: 208
-- id: 208
+  parent: 214
+- id: 214
   kind: Tuple
-  span: 0:3298-3301
+  span: 0:3325-3328
   children:
-  - 207
-  parent: 209
-- id: 209
+  - 213
+  parent: 215
+- id: 215
   kind: 'TransformCall: Select'
   span: 1:165-238
   children:
-  - 205
-  - 208
-  parent: 212
-- id: 210
+  - 211
+  - 214
+  parent: 218
+- id: 216
   kind: Ident
   span: 1:244-245
   ident: !Ident
@@ -226,14 +226,14 @@ nodes:
   - t
   - a
   targets:
-  - 207
-  parent: 212
-- id: 212
+  - 213
+  parent: 218
+- id: 218
   kind: 'TransformCall: Sort'
   span: 1:239-245
   children:
-  - 209
-  - 210
+  - 215
+  - 216
 ast:
   name: Project
   stmts:

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -6231,6 +6231,54 @@ fn test_import() {
 }
 
 #[test]
+fn test_tuple_reduce() {
+    assert_snapshot!(compile(
+        r###"
+from foo
+select {
+  with_initial = tuple_reduce initial:4 add {1, 2, 3},
+  with_initial_one = tuple_reduce initial:4 add {3},
+  with_initial_zero = tuple_reduce initial:4 add {},
+  no_initial = tuple_reduce add {1, 2, 3},
+  no_initial_one = tuple_reduce add {3},
+}
+        "###,
+    )
+    .unwrap(), @"
+SELECT
+  4 + 1 + 2 + 3 AS with_initial,
+  4 + 3 AS with_initial_one,
+  4 AS with_initial_zero,
+  1 + 2 + 3 AS no_initial,
+  3 AS no_initial_one
+FROM
+  foo
+    ");
+}
+
+#[test]
+fn test_tuple_reduce_err() {
+    assert_snapshot!(compile(
+        r###"
+from foo
+select {
+  no_initial_err = tuple_reduce add {}
+}
+"###,
+    ).unwrap_err(), @r###"
+    Error:
+       ╭─[ :4:37 ]
+       │
+     4 │   no_initial_err = tuple_reduce add {}
+       │                                     ─┬
+       │                                      ╰── tuple expected to have at least one entry when initial value is not provided, but found empty tuple
+       │
+       │ Help: try adding an initial:<value> parameter
+    ───╯
+    "###);
+}
+
+#[test]
 fn unstable_ordering() {
     // https://github.com/PRQL/prql/issues/5053
     assert_snapshot!(compile(r###"


### PR DESCRIPTION
As I was looking at the `tuple_*` functions in the std lib, I noticed that `tuple_every` is a fairly straightforward function which essentially applies an "AND" reduce operation across its single tuple-value parameter. This PR replaces that single-purpose function with `tuple_reduce`, capable of performing a reduce across a tuple using any operator or two-parameter function. 

It behaves very similar to the Python [`functools.reduce()`](https://docs.python.org/3/library/functools.html#functools.reduce) function, in that it takes a function, tuple, and an optional `initial` named parameter. When the `initial` parameter is provided, the first step of the reduction uses the initial value as the first parameter to the reduction operation. If the provided tuple is empty, the initial value will be returned. When the `initial` parameter is omitted, if the tuple is empty, an error is raised. If the tuple has one entry, its value will be returned; otherwise, the reduce operation will proceed as normal.

Example usage:

```
from foo
select {bar, baz, quux}
select { 
  mysum = tuple_reduce initial:0 add {1, 2, 3},
  all_true = tuple_reduce std.and foo.*,
}
```

produces:

```sql
SELECT
  0 + 1 + 2 + 3 AS mysum,
  bar
  AND baz
  AND quux AS all_true
FROM
  foo
```

If we want to preserve `tuple_every` for backwards compatibility, it could be defined in the std lib as:

```
let tuple_every = func list -> <bool> tuple_reduce initial:true std.and list
```

However, I wasn't sure that this was necessary, since apparently only the other std lib functions `intersect` and `remove` use `tuple_every`, and those were easily ported over to use `tuple_reduce`.