### PR TITLE
ci: skip build-devcontainer on dependabot PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -533,7 +533,12 @@ jobs:
 
   build-devcontainer:
     needs: rules
-    if: needs.rules.outputs.devcontainer-build == 'true'
+    # Skip on dependabot PRs — they don't get access to the DOCKERHUB_*
+    # secrets, so the docker login step fails before the bumped action can be
+    # exercised.
+    if:
+      needs.rules.outputs.devcontainer-build == 'true' && github.actor !=
+      'dependabot[bot]'
     uses: ./.github/workflows/build-devcontainer.yaml
     secrets: inherit
     # One problem with this setup is that if another commit is merged to main,


### PR DESCRIPTION
Dependabot PRs don't get access to repo secrets, so `build-devcontainer.yaml`'s `docker/login-action` step errors with `Username and password required` and the action being bumped never runs.

This blocked recent action-version bumps that touch `build-devcontainer.yaml`:
- #5888 (download-artifact 6→8)
- #5889 (upload-artifact 5→7)
- #5890 (docker/metadata-action 5→6)

Skipped jobs count as success via `re-actors/alls-green`, so `check-ok-to-merge` clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)