### PR TITLE
chore(security): scope release secrets to a protected environment

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,6 +1,12 @@
 bot_name: prql-bot
 secrets:
   bot_token: PRQL_BOT_GITHUB_TOKEN
+  # Docker Hub login is needed by test-rust.yaml on internal PRs (external-DB
+  # tests); it's a low-value pull token, so it's intentionally repo-level.
+  # Release secrets (cargo/snapcraft) live in the `release` environment instead.
+  allowed:
+    - DOCKERHUB_TOKEN
+    - DOCKERHUB_USERNAME
 setup:
   - uses: ./.github/actions/tend-setup
 workflows:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -373,7 +373,11 @@ jobs:
 
   publish-to-cargo:
     runs-on: ubuntu-24.04
-    environment: release
+    # This job runs unconditionally as a `--no-verify` dry-run smoke test when
+    # `release.yaml` is reused from `nightly.yaml` on PRs; only apply the
+    # `release` environment (and its tag-restricted secret) on actual releases,
+    # otherwise the deployment-branch policy denies the dry-run on branch refs.
+    environment: ${{ github.event_name == 'release' && 'release' || '' }}
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -253,6 +253,7 @@ jobs:
 
   build-and-publish-snap:
     runs-on: ubuntu-24.04
+    environment: release
     if: ${{ github.event_name == 'release' }}
     steps:
       - name: 📂 Checkout code
@@ -268,6 +269,9 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS:
             ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          # Credentials are Candid-format (`snapcraft export-login`); snapcraft
+          # requires this to use them.
+          SNAPCRAFT_STORE_AUTH: candid
         with:
           snap: ${{ steps.build.outputs.snap }}
           release: stable
@@ -369,6 +373,7 @@ jobs:
 
   publish-to-cargo:
     runs-on: ubuntu-24.04
+    environment: release
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Addresses the `repo-secret-allowlist` finding from #5907: release secrets were repo-level, so they were exposed to every workflow including PR-triggered ones.

Changes:

- A tag-restricted `release` GitHub environment was created (deployments only from version tags `*.*.*`), and `CARGO_REGISTRY_TOKEN` / `SNAPCRAFT_STORE_CREDENTIALS` were moved into it. The `build-and-publish-snap` and `publish-to-cargo` jobs now declare `environment: release`.
- `SNAPCRAFT_STORE_AUTH: candid` is set on the snap publish step — the regenerated snapcraft credentials are Candid-format and don't work without it.
- `.config/tend.yaml` allowlists `DOCKERHUB_TOKEN` / `DOCKERHUB_USERNAME`, which `test-rust.yaml` legitimately needs on internal PRs for the external-DB tests; they're a low-value pull login, so they intentionally stay repo-level.
- The unused repo-level `CODECOV_TOKEN` secret was deleted out-of-band — the Codecov upload token is the public literal already in `tests.yaml`, not that secret.

After this lands, repo-level secrets are exactly `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `DOCKERHUB_TOKEN`, `DOCKERHUB_USERNAME` — all within tend's effective allowlist.

The other finding in #5907 (`secrets` / `PRQL_BOT_GITHUB_TOKEN`, HTTP 403 on org secrets) is an audit-PAT scope matter and is not addressed here, so this references rather than closes the issue.

Ref #5907

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

Follow-up `9724014a`: `publish-to-cargo` had `environment: release` applied unconditionally, which broke the `--no-verify` dry-run that `nightly.yaml` runs as a smoke test on PRs (env policy is tag-only; PR refs are branches). The environment is now applied only on real release events.
