### PR TITLE
chore(tend): drop redundant overrides

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,6 +1,5 @@
 bot_name: prql-bot
 secrets:
-  bot_token: PRQL_BOT_GITHUB_TOKEN
   # Docker Hub login is needed by test-rust.yaml on internal PRs (external-DB
   # tests); it's a low-value pull token, so it's intentionally repo-level.
   # Release secrets (cargo/snapcraft) live in the `release` environment instead.
@@ -13,5 +12,3 @@ workflows:
   ci-fix:
     watched_workflows:
       - tests
-  weekly:
-    enabled: true


### PR DESCRIPTION
## Summary

After tend 0.0.23, two overrides in `.config/tend.yaml` are now redundant:

- `secrets.bot_token: PRQL_BOT_GITHUB_TOKEN` — `TEND_BOT_TOKEN` is the new default. The repo secret is already populated with the prql-bot PAT.
- `workflows.weekly.enabled: true` — weekly is enabled by default (only `ci-fix` is opt-in).

Nightly will regenerate `tend-*.yaml` to reference `${{ secrets.TEND_BOT_TOKEN }}` on its next run.

## Test plan

- [ ] Wait for nightly to regenerate `tend-*.yaml`. The regen will rewrite `${{ secrets.PRQL_BOT_GITHUB_TOKEN }}` → `${{ secrets.TEND_BOT_TOKEN }}` in every workflow.
- [ ] After the regen PR merges, the org-level `PRQL_BOT_GITHUB_TOKEN` secret can stay or be removed depending on whether anything else references it.

> _This was written by Claude Code on behalf of @max-sixty_

Co-authored-by: Claude <noreply@anthropic.com>