### PR TITLE
feat: tuple_map propagates aliases from its input

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -355,10 +355,13 @@ impl Resolver<'_> {
                 let list_items = list_items
                     .into_iter()
                     .map(|item| {
-                        self.fold_expr(Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
-                            func.clone(),
-                            vec![item],
-                        ))))
+                        self.fold_expr(Expr {
+                            alias: item.clone().alias,
+                            ..Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
+                                func.clone(),
+                                vec![item],
+                            )))
+                        })
                     })
                     .collect::<Result<Vec<_>>>()?;
 

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -356,7 +356,7 @@ impl Resolver<'_> {
                     .into_iter()
                     .map(|item| {
                         self.fold_expr(Expr {
-                            alias: item.clone().alias,
+                            alias: item.alias.clone(),
                             ..Expr::new(ExprKind::FuncCall(FuncCall::new_simple(
                                 func.clone(),
                                 vec![item],

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -7403,3 +7403,22 @@ fn test_tuple_map() {
       foo
     ");
 }
+
+#[test]
+fn test_tuple_map_aliases() {
+    assert_snapshot!(compile(r###"
+    let add_four = func a -> a + 4
+
+    from foo
+    select {x, y}
+    derive (tuple_map add_four {c = x, d = y})
+    "###).unwrap(), @r###"
+    SELECT
+      x,
+      y,
+      x + 4 AS c,
+      y + 4 AS d
+    FROM
+      foo
+    "###);
+}


### PR DESCRIPTION
This change to `tuple_map` allows it to propagate the aliases from its input tuple to its output.

The PRQL:
```prql
let add_four = func a -> a + 4

from foo
select {x, y}
derive (tuple_map add_four {c = x, d = y})
```

now produces the SQL:

```sql
SELECT
  x,
  y,
  x + 4 AS c,
  y + 4 AS d
FROM
  foo
```

Prior to this pull request, the `x + 4` / `y + 4` columns would have no aliases.