### PR TITLE
chore: replace org bot token with repo-scoped TEND_BOT_TOKEN

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -6,17 +6,6 @@ secrets:
   allowed:
     - DOCKERHUB_TOKEN
     - DOCKERHUB_USERNAME
-    # Org-level secrets (visibility: all org repos) — administered at the org,
-    # so this repo can't environment-scope them. PRQL_BOT_GITHUB_TOKEN is the
-    # 2023 org bot token still used by tests.yaml, pull-request-target.yaml,
-    # release.yaml, and other PRQL repos (tend itself uses the repo-scoped
-    # TEND_BOT_TOKEN). SNAPCRAFT_STORE_CREDENTIALS is used by release.yaml;
-    # HEX_API_KEY is unused here (other org repos). Narrowing these requires
-    # org-admin action: scope visibility to selected repos or migrate to
-    # environment-scoped repo secrets.
-    - HEX_API_KEY
-    - PRQL_BOT_GITHUB_TOKEN
-    - SNAPCRAFT_STORE_CREDENTIALS
 setup:
   - uses: ./.github/actions/tend-setup
 workflows:

--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -62,7 +62,7 @@ jobs:
       - uses: tibdex/backport@v2
         with:
           # This is a personal access token from the @prql-bot
-          github_token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           # Docs are at https://github.com/tibdex/backport/blob/main/action.yml
           # We only use `web` atm
           label_pattern: "^pr-backport-(?<base>([^ ]+))$"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.TEND_BOT_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'prql',
@@ -133,7 +133,7 @@ jobs:
           identifier: PRQL.prqlc
           version: ${{ github.ref_name }}
           installers-regex: '^prqlc-.*-windows-.*\.zip$'
-          token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
           fork-user: prql-bot
 
   build-deb-package:
@@ -419,7 +419,7 @@ jobs:
       - name: 📂 Checkout code
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
       - run: git push origin HEAD:web --force
 
   push-devcontainer:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -794,7 +794,7 @@ jobs:
           # Use prql-bot PAT so that opening the issue triggers downstream
           # workflows (notably tend-triage). Events from the default
           # GITHUB_TOKEN do not cascade to other workflows.
-          GITHUB_TOKEN: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           LINK:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
             github.run_id }}
@@ -820,4 +820,4 @@ jobs:
           minor-version-delta: 1
           toolchain-path: "./rust-toolchain.toml"
           pr-title: "build: Update rust toolchain version"
-          token: ${{ secrets.PRQL_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}


### PR DESCRIPTION
## What

Moves the six remaining `secrets.PRQL_BOT_GITHUB_TOKEN` references (nightly-failure issue creation, rust-toolchain PR, `web` backport, homebrew dispatch, winget publish, `web`-branch push) to `secrets.TEND_BOT_TOKEN`, so the org-level `PRQL_BOT_GITHUB_TOKEN` (2023, visible to every PRQL repo) can be deleted. Both secrets are prql-bot PATs; the repo-scoped one has the scopes these jobs need (`repo`, `workflow`).

Also reverts the allowlisting of the three org-level secrets added in #5993: `PRQL_BOT_GITHUB_TOKEN` goes away with this PR, `SNAPCRAFT_STORE_CREDENTIALS`'s org copy is a leftover duplicate of the `release`-environment secret (#5910) and gets deleted, and `HEX_API_KEY` is referenced nowhere in the org.

The only other consumer, PRQL/pyprql, now has a repo-level `PRQL_BOT_GITHUB_TOKEN` secret carrying the same PAT, so its release workflow is unaffected.

> _This was written by Claude Code on behalf of max_
