### PR TITLE
chore: switch tend harness to claude-interactive

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,4 +1,5 @@
 bot_name: prql-bot
+harness: claude-interactive
 secrets:
   # Docker Hub login is needed by test-rust.yaml on internal PRs (external-DB
   # tests); it's a low-value pull token, so it's intentionally repo-level.

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/tend-setup
 
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -209,7 +209,7 @@ jobs:
         env:
           EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/tend-setup
 
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: ./.github/actions/tend-setup
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/tend-setup
 
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: ./.github/actions/tend-setup
 
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: ./.github/actions/tend-setup
 
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/tend-setup
 
-      - uses: max-sixty/tend@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Anthropic is changing how `claude -p` (the headless Agent SDK path) is handled, so this moves tend off it. The `claude-interactive` harness runs the official `claude` binary under a PTY supervisor instead of going through the Agent SDK; everything upstream of the action ref stays the same.

Sets `harness: claude-interactive` in `.config/tend.yaml` and regenerates the `tend-*.yaml` workflows. The only change in the generated files is the action ref: `max-sixty/tend@0.1.4` → `max-sixty/tend/interactive@0.1.4`. Both are Claude-family harnesses reading the same `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`, so secrets and bot config are unchanged.

> _This was written by Claude Code on behalf of max_
