### PR TITLE
chore: Prepare 0.13.13 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,56 @@
 
 **Integrations**:
 
+**Internal changes**:
+
+**New Contributors**:
+
+## 0.13.13 — 2026-06-14
+
+0.13.13 has 127 commits from 5 contributors. Selected changes:
+
+**Fixes**:
+
+- Correctly resolve wildcards on `this` and carry column aliases through natural
+  joins, by fixing how the compiler's internal `tuple_map` applies redirects,
+  folds expressions, and propagates aliases. (@kgutwin, #5875, #5877, #5980)
+- Resolve identifiers up the parent module chain. (@prql-bot, #5976)
+- Return a compiler error instead of panicking in `lookup_cid`. (@prql-bot,
+  #5938)
+- Catch a panic in the CLI's compile path so the debug log is still written.
+  (@kgutwin, #5869)
+- Set the minimum `chrono` version to `0.4.40` for compatibility with
+  `arrow-arith`. (@prql-bot, #5841)
+
+**Documentation**:
+
+- Numerous typo, grammar, and stale-content fixes across the book, tutorials,
+  bindings docs, and code comments.
+
+**Integrations**:
+
 - Fix several FFI defects in the .NET binding that prevented it from working
   correctly on 64-bit platforms or returning more than one diagnostic: map
   `size_t` as `UIntPtr` (was `int`), advance the pointer when iterating the
   messages array, dereference indirect string fields and `Span` / `Location`
   pointers, call `result_destroy` to free native memory, and tighten exception
   types and doc references. Also guard `result_destroy` in `prqlc-c` against a
-  null `messages` pointer, which is set on the success path. (@prql-bot, #5847)
+  null `messages` pointer, which is set on the success path. (@prql-bot, #5848)
+- Modernize the .NET binding to net10.0 using `LibraryImport` source generators.
+  (@prql-bot, #5850)
+- Throw a Java exception instead of panicking in the JNI bindings. (@prql-bot,
+  #5934)
+- Exit the LSP server only on the `exit` notification, matching the LSP spec.
+  (@prql-bot, #6001)
 
 **Internal changes**:
 
-**New Contributors**:
+- Update the tend (Claude-powered CI) workflows; most of this release's
+  bot-authored fixes were filed by tend.
+- Scope release secrets to a protected GitHub environment. (@prql-bot, #5910)
+- Replace the internal `tuple_every` helper with a more general `tuple_reduce`.
+  (@kgutwin, #5878)
+- Update the Rust toolchain version. (#5966)
 
 ## 0.13.12 — 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 
 - Update the tend (Claude-powered CI) workflows; most of this release's
   bot-authored fixes were filed by tend.
-- Scope release secrets to a protected GitHub environment. (@prql-bot, #5910)
+- Scope release secrets to a protected GitHub environment. (@max-sixty, #5910)
 - Replace the internal `tuple_every` helper with a more general `tuple_reduce`.
   (@kgutwin, #5878)
 - Update the Rust toolchain version. (#5966)


### PR DESCRIPTION
Prepares the `CHANGELOG.md` for the 0.13.13 release. This is step 1 of the release runbook (the changelog PR); publishing the tag and GitHub release happens after this merges.

Since 0.13.12 there are 127 commits from 5 contributors. The cycle was dominated by bot automation (tend, Dependabot, pre-commit.ci), so the curated "Selected changes" focuses on the user-facing work: the compiler correctness fixes for wildcard-on-`this` and natural-join alias handling (@kgutwin), identifier resolution up the parent module chain, several panic→error hardening fixes, and binding fixes for .NET, Java/JNI, and the LSP server. Documentation and internal/tooling changes are summarized rather than enumerated. No new contributors this cycle.

The existing `[unreleased]` .NET FFI entry referenced issue `#5847`; I corrected it to the fixing PR `#5848`.

The version is already at 0.13.13 (bumped in #5839), so there's no version change here.

> _This was written by Claude Code on behalf of max_
