### PR TITLE
docs: refresh README Current Status and clarify release changelog step

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more on the language, more examples & comparisons with SQL, visit
 [prql-lang.org][prql website]. To experiment with PRQL in the browser, check out
 [PRQL Playground][prql playground].
 
-## Current Status - December 2025
+## Current Status - June 2026
 
 PRQL is ready to use by the intrepid, either with our supported integrations, or
 within your own tools, using one of our supported language bindings.
@@ -72,9 +72,9 @@ within your own tools, using one of our supported language bindings.
 PRQL still has some bugs and some missing features, and is probably only ready
 to be rolled out to non-technical teams for fairly simple queries.
 
-Development has slowed in the past few months as we decide how to work on a new
-resolver, which will let us squash many bugs and simplify our code a lot. It'll
-also let us scale the language without scaling the complexity of the compiler.
+Development has slowed as we decide how to work on a new resolver, which will
+let us squash many bugs and simplify our code a lot. It'll also let us scale the
+language without scaling the complexity of the compiler.
 
 While we figure that out, we're also thinking about:
 
@@ -85,13 +85,13 @@ While we figure that out, we're also thinking about:
 - Filling remaining feature gaps, so that PRQL is possible to use for almost all
   standard SQL queries.
 - Expanding our set of supported features — we are working to add experimental
-  support for modules / multi-file projects, and for auto-formatting.
+  support for modules / multi-file projects.
 
 And:
 
 - Making it really easy to start using PRQL. We're doing that by building
   integrations with tools that folks already use; for example a VS Code
-  extension, Jupyter integration, and the recent
+  extension, Jupyter integration, and the
   [QStudio](https://www.timestored.com/qstudio/prql-ide) integration. If there
   are tools you're familiar with that you think would be open to integrating
   with PRQL, please let us know in an issue.

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -502,9 +502,10 @@ Currently we release in a semi-automated way:
 
 5. Run
    `cargo release patch --no-publish --no-push --execute --no-verify --no-confirm --no-tag && task prqlc:test-all`
-   to bump the versions and add a new Changelog section; then PR the resulting
-   commit. Note this currently contains `task prqlc:test-all` to update snapshot
-   tests which contain the version.
+   to bump the versions, then PR the resulting commit. `task prqlc:test-all`
+   refreshes the snapshot tests that embed the version. Step 1 already added the
+   `## [unreleased]` section, so `cargo release` inserts a second, duplicate
+   one; remove it, leaving the CHANGELOG unchanged in this commit.
 
 <!-- Note we used to have `cargo release version patch -x --no-confirm && cargo release replace -x --no-confirm && task prqlc:test-all`, which was simpler, but in order for `prev_version` to work, we can't separate the `patch` and `replace`, and we need `prev_version` for the prqlc version constraint (search for `prev_version` if unclear). If we moved back to upgrading the tags at the time of release rather than after, we could go back to that. -->
 


### PR DESCRIPTION
Two documentation fixes following the 0.13.13 release.

**README Current Status**: refreshes the heading date (December 2025 → June 2026) and removes now-stale details: drops auto-formatting from the "working to add" list since it shipped as `prqlc fmt`, and removes the "recent" qualifier on the QStudio integration. I kept the "development has slowed / new resolver" framing since I couldn't verify it has changed; let me know if you'd like it reframed.

**Release runbook** (`development.md` step 5): documents that `cargo release` inserts a second `## [unreleased]` block (because the changelog-prep step already added one), which must be removed so the CHANGELOG is unchanged in the bump commit. This wasn't obvious and is easy to miss.

> _This was written by Claude Code on behalf of max_
