### PR TITLE
docs: run /code-review in tend PR review, scaled to change core-ness

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -17,6 +17,18 @@ permission first) still applies when the target shows no agent signals.
 - No scope required (e.g., `fix: resolve date parsing` not `fix(parser): ...`)
 - Dependabot PRs use `chore:` prefix
 
+## PR review
+
+Reviewing a PR includes a `/code-review` pass, at an effort matched to how core
+the change is:
+
+- Peripheral or mechanical changes (docs, config, dependency bumps, test-only):
+  `low` or `medium`.
+- Core compiler changes (the `prqlc` parser; the semantic resolver, covering
+  name resolution and the type system; SQL generation; `std.prql`): `high` or
+  `max`. Bugs there corrupt query results silently rather than failing loudly,
+  so the broader-coverage tiers earn their cost.
+
 ## CI structure
 
 - Main CI workflow: `tests` (watched by tend-ci-fix)


### PR DESCRIPTION
## What

When tend reviews a PR, the review now includes a structured `/code-review` pass over the diff, with the effort tier calibrated to how core the change is. The mapping lives in the `running-tend` skill:

- Peripheral or mechanical changes (docs, config, dependency bumps, test-only) → `/code-review low` or `medium`.
- Core compiler changes (the `prqlc` parser, the semantic resolver covering name resolution and the type system, SQL generation, `std.prql`) → `/code-review high` or `max`.

## Why

prql-bot recently reviewed a PR adding `append by:name` and approved it on a happy-path read: it confirmed the feature against the documented snapshot but never exercised adversarial inputs. Two correctness bugs slipped through, both silent — wrong results rather than an error:

- `from a | select {x, x + 1} | append by:name (from b | select {x, y})` silently drops the unnamed `x + 1` column.
- `from a | append by:name (from b)` (unknown schemas) compiles to a plain position-based `UNION ALL`, ignoring `by:name`.

A manual happy-path read is structurally unlikely to catch these. A `/code-review` pass at an effort matched to the change being core compiler semantics is far more likely to surface them, which is why the mapping ties the top tiers to the parser, resolver, SQL generation, and `std.prql`.

`/code-review` is a built-in Claude Code command (verified present in the `claude` binary version tend pins, 2.1.195), and the tend review harness allows the `Skill` tool and already loads skills mid-session, so the pass runs within the existing review job.

> _This was written by Claude Code on behalf of max_
