### PR TITLE
fix: from_text sets relation type earlier

### DIFF
--- a/prqlc/prqlc-parser/src/parser/pr/types.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/types.rs
@@ -3,7 +3,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 
-use crate::error::Error;
 use crate::parser::pr::ident::Ident;
 use crate::span::Span;
 
@@ -146,11 +145,5 @@ impl From<PrimitiveSet> for TyKind {
 impl From<TyFunc> for TyKind {
     fn from(value: TyFunc) -> Self {
         TyKind::Function(Some(value))
-    }
-}
-
-impl From<TyKind> for Error {
-    fn from(value: TyKind) -> Error {
-        Error::new_simple(format!("unexpected type {value:#?}"))
     }
 }

--- a/prqlc/prqlc-parser/src/parser/pr/types.rs
+++ b/prqlc/prqlc-parser/src/parser/pr/types.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 
+use crate::error::Error;
 use crate::parser::pr::ident::Ident;
 use crate::span::Span;
 
@@ -145,5 +146,11 @@ impl From<PrimitiveSet> for TyKind {
 impl From<TyFunc> for TyKind {
     fn from(value: TyFunc) -> Self {
         TyKind::Function(Some(value))
+    }
+}
+
+impl From<TyKind> for Error {
+    fn from(value: TyKind) -> Error {
+        Error::new_simple(format!("unexpected type {value:#?}"))
     }
 }

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -548,6 +548,8 @@ impl Resolver<'_> {
         // In other words, I hope to make our type system powerful enough to express return
         // type of all std module functions.
 
+        let bad_type = |t| Error::new_assert(format!("unexpected type {t:#?}"));
+
         Ok(match transform_call.kind.as_ref() {
             TransformKind::Select { assigns } => assigns
                 .ty
@@ -558,7 +560,7 @@ impl Resolver<'_> {
                 let input = input.into_relation().unwrap();
 
                 let derived = assigns.ty.clone().unwrap();
-                let derived = derived.kind.into_tuple()?;
+                let derived = derived.kind.into_tuple().map_err(bad_type)?;
 
                 Some(Ty::new(TyKind::Array(Some(Box::new(Ty::new(
                     ty_tuple_kind([input, derived].concat()),
@@ -579,8 +581,8 @@ impl Resolver<'_> {
                 let with_name = with.alias.clone();
                 let with_span = with.span;
                 let with = with.ty.clone().unwrap();
-                let with = with.kind.into_array()?.ok_or(
-                    Error::new_simple("No columns found in joining relation").with_span(with_span),
+                let with = with.kind.into_array().map_err(bad_type)?.ok_or(
+                    Error::new_assert("no columns found in joining relation").with_span(with_span),
                 )?;
                 let with = TyTupleField::Single(with_name, Some(*with));
 
@@ -590,16 +592,17 @@ impl Resolver<'_> {
             }
             TransformKind::Group { pipeline, by } => {
                 let by = by.ty.clone().unwrap();
-                let by = by.kind.into_tuple()?;
+                let by = by.kind.into_tuple().map_err(bad_type)?;
 
                 let pipeline_span = pipeline.span;
                 let pipeline = pipeline.ty.clone().unwrap();
                 let pipeline = pipeline
                     .kind
-                    .into_function()?
-                    .ok_or(Error::new_simple("Expected function").with_span(pipeline_span))?;
+                    .into_function()
+                    .map_err(bad_type)?
+                    .ok_or(Error::new_assert("expected function").with_span(pipeline_span))?;
                 let pipeline = pipeline.return_ty.unwrap().into_relation().ok_or(
-                    Error::new_simple("Function must return relation").with_span(pipeline_span),
+                    Error::new_assert("function must return relation").with_span(pipeline_span),
                 )?;
 
                 Some(Ty::new(TyKind::Array(Some(Box::new(Ty::new(
@@ -611,8 +614,9 @@ impl Resolver<'_> {
                 let pipeline = pipeline.ty.clone().unwrap();
                 let pipeline = pipeline
                     .kind
-                    .into_function()?
-                    .ok_or(Error::new_simple("Expected function").with_span(pipeline_span))?;
+                    .into_function()
+                    .map_err(bad_type)?
+                    .ok_or(Error::new_assert("expected function").with_span(pipeline_span))?;
                 pipeline.return_ty.map(|x| *x)
             }
             TransformKind::Append(bottom) => {

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -446,6 +446,7 @@ impl Resolver<'_> {
                     .map(|x| TyTupleField::Single(Some(x), None))
                     .collect();
 
+                let frame_ty = Ty::relation(columns.clone());
                 let frame =
                     self.declare_table_for_literal(expr_id, Some(columns), Some(input_name));
 
@@ -464,6 +465,7 @@ impl Resolver<'_> {
                 let res = Expr {
                     lineage: Some(frame),
                     id: text_expr.id,
+                    ty: Some(frame_ty),
                     ..res
                 };
                 return Ok(res);
@@ -556,7 +558,7 @@ impl Resolver<'_> {
                 let input = input.into_relation().unwrap();
 
                 let derived = assigns.ty.clone().unwrap();
-                let derived = derived.kind.into_tuple().unwrap();
+                let derived = derived.kind.into_tuple()?;
 
                 Some(Ty::new(TyKind::Array(Some(Box::new(Ty::new(
                     ty_tuple_kind([input, derived].concat()),
@@ -575,8 +577,11 @@ impl Resolver<'_> {
                 let input = input.into_relation().unwrap();
 
                 let with_name = with.alias.clone();
+                let with_span = with.span;
                 let with = with.ty.clone().unwrap();
-                let with = with.kind.into_array().unwrap().unwrap();
+                let with = with.kind.into_array()?.ok_or(
+                    Error::new_simple("No columns found in joining relation").with_span(with_span),
+                )?;
                 let with = TyTupleField::Single(with_name, Some(*with));
 
                 Some(Ty::new(TyKind::Array(Some(Box::new(Ty::new(
@@ -585,19 +590,29 @@ impl Resolver<'_> {
             }
             TransformKind::Group { pipeline, by } => {
                 let by = by.ty.clone().unwrap();
-                let by = by.kind.into_tuple().unwrap();
+                let by = by.kind.into_tuple()?;
 
+                let pipeline_span = pipeline.span;
                 let pipeline = pipeline.ty.clone().unwrap();
-                let pipeline = pipeline.kind.into_function().unwrap().unwrap();
-                let pipeline = pipeline.return_ty.unwrap().into_relation().unwrap();
+                let pipeline = pipeline
+                    .kind
+                    .into_function()?
+                    .ok_or(Error::new_simple("Expected function").with_span(pipeline_span))?;
+                let pipeline = pipeline.return_ty.unwrap().into_relation().ok_or(
+                    Error::new_simple("Function must return relation").with_span(pipeline_span),
+                )?;
 
                 Some(Ty::new(TyKind::Array(Some(Box::new(Ty::new(
                     ty_tuple_kind([by, pipeline].concat()),
                 ))))))
             }
             TransformKind::Window { pipeline, .. } | TransformKind::Loop(pipeline) => {
+                let pipeline_span = pipeline.span;
                 let pipeline = pipeline.ty.clone().unwrap();
-                let pipeline = pipeline.kind.into_function().unwrap().unwrap();
+                let pipeline = pipeline
+                    .kind
+                    .into_function()?
+                    .ok_or(Error::new_simple("Expected function").with_span(pipeline_span))?;
                 pipeline.return_ty.map(|x| *x)
             }
             TransformKind::Append(bottom) => {

--- a/prqlc/prqlc/tests/integration/sql.rs
+++ b/prqlc/prqlc/tests/integration/sql.rs
@@ -4945,6 +4945,28 @@ fn test_from_text_07() {
 }
 
 #[test]
+fn test_from_text_08() {
+    assert_snapshot!(compile(r#"
+    from foo | join m=(from_text format:csv 'key,value') this.bar == that.key
+    "#).unwrap(), @r#"
+    WITH table_0 AS (
+      SELECT
+        NULL AS "key",
+        NULL AS value
+      WHERE
+        false
+    )
+    SELECT
+      foo.*,
+      table_0."key",
+      table_0.value
+    FROM
+      foo
+      INNER JOIN table_0 ON foo.bar = table_0."key"
+    "#);
+}
+
+#[test]
 fn test_header() {
     // Test both target & version at the same time
     let header = format!(


### PR DESCRIPTION
Resolves #5988 by populating the type of the Expr returned by `from_text` earlier in the resolver flow, and adds a covering test.

While I was looking at it, I attempted to improve some of the error handling of `infer_type_of_special_func` (where the initial crash was located). There are many `.unwrap()` calls in the various branches of the `match` statement; I converted some of them to the `?` try operator and/or replaced `.unwrap()` with `.ok_or(...)?`. The main challenge here is that many of these error conditions are "never supposed to happen" because the type system is supposed to catch bad user input. I don't know if there's a better/recommended strategy for handling this sort of situation -- crashing on unwrapping a None or Err is not good, but hand-writing an individual error message to replace each unwrap call seems excessive. Suggestions are welcome...