### PR TITLE
fix: repair pre-commit on main (dead stargazers link, unpinned prettier)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,9 @@ repos:
         # https://github.com/crate-ci/typos/issues/347
         pass_filenames: false
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.4
+    rev: v3.9.5
     hooks:
       - id: prettier
-        additional_dependencies:
-          # TODO: This doesn't seem to work, would be great to fix.
-          # https://github.com/PRQL/prql/issues/3078
-          - prettier-plugin-go-template
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
     hooks:
       - id: prettier
         additional_dependencies:
-          - prettier
           # TODO: This doesn't seem to work, would be great to fix.
           # https://github.com/PRQL/prql/issues/3078
           - prettier-plugin-go-template

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![GitHub CI Status](https://img.shields.io/github/actions/workflow/status/prql/prql/tests.yaml?event=push&branch=main&logo=github&style=for-the-badge)](https://github.com/PRQL/prql/actions?query=branch%3Amain+workflow%3Atests)
 [![GitHub contributors](https://img.shields.io/github/contributors/PRQL/prql?style=for-the-badge&logo=github)](https://github.com/PRQL/prql/graphs/contributors)
-[![Stars](https://img.shields.io/github/stars/PRQL/prql?style=for-the-badge&logo=github)](https://github.com/PRQL/prql/stargazers)
+[![Stars](https://img.shields.io/github/stars/PRQL/prql?style=for-the-badge&logo=github)](https://github.com/PRQL/prql)
 
 **P**ipelined **R**elational **Q**uery **L**anguage, pronounced "Prequel".
 

--- a/web/book/src/SUMMARY.md
+++ b/web/book/src/SUMMARY.md
@@ -45,7 +45,7 @@ language design decisions and formal specifications for parts of the language.
   - [Reading files](./reference/data/read-files.md)
   - [Ad-hoc data](./reference/data/relation-literals.md)
 
-- [Declarations]()
+- [Declarations](<>)
   <!-- I don't know what to call this section. -->
   - [Variables — `let` & `into`](./reference/declarations/variables.md)
   - [Functions](./reference/declarations/functions.md)
@@ -64,7 +64,7 @@ language design decisions and formal specifications for parts of the language.
     - [Take](./reference/stdlib/transforms/take.md)
     - [Window](./reference/stdlib/transforms/window.md)
 
-  - [Aggregation functions]()
+  - [Aggregation functions](<>)
   - [Date functions](./reference/stdlib/date.md)
   - [Mathematical functions](./reference/stdlib/math.md)
   - [Text functions](./reference/stdlib/text.md)


### PR DESCRIPTION
`pre-commit run --all-files` fails on a clean checkout of main, for two unrelated external reasons:

1. **lychee 404 on the README stars badge.** GitHub [restricted stargazer data](https://www.star-history.com/blog/github-stargazer-api-restriction/) in June 2026: `/stargazers` pages now return 404 for everyone but a repo's own admins/collaborators. The badge link is dead for the public, so this points it at the repo root instead of excluding it from the checker.

2. **prettier was never actually pinned.** The mirror pins prettier via `additional_dependencies: ["prettier@<rev>"]` in its hook definition, but a consumer-level `additional_dependencies` *replaces* that list — so our unpinned `prettier` entry meant every hook-env rebuild installed npm's latest. The July 6 autoupdate (#6061) triggered a rebuild that picked up the just-released prettier 3.9.5, which rewrites empty markdown link destinations `[x]()` → `[x](<>)` (and 3.9.4 rewrites them back), making differently-built environments fight over `web/book/src/SUMMARY.md`'s mdbook draft-chapter links.

   The fix drops our `additional_dependencies` block entirely so the mirror's own pin applies and the version tracks the rev (autoupdate then keeps them moving together), bumps to v3.9.5, and accepts its reformat of the two draft links — mdbook renders `[x](<>)` draft chapters identically to `[x]()` (verified by building the book). The dropped `prettier-plugin-go-template` was never active: its `.prettierrc.yaml` activation has always been commented out (#3078); anyone picking that issue up should re-add it *with* an explicit `prettier@x.y.z` pin alongside.

Verified: `pre-commit run --all-files` passes twice from a clean tree, and `mdbook build web/book` succeeds.

> _This was written by Claude Code on behalf of max_
