### PR TITLE
chore: pin typos as a local hook so autoupdate can't unpin it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,19 @@ repos:
       - id: trailing-whitespace
         # rustfmt handles rust files, and in some snapshots we expect trailing spaces.
         exclude: '.*\.(rs|snap)$'
-  - repo: https://github.com/crate-ci/typos
-    rev: v1
+  # A local hook rather than the crate-ci/typos repo hook: that repo's moving
+  # tags (`v1`, `typos-dict-*`) make autoupdate rewrite any pinned rev back to
+  # a mutable reference (#5481 and #5510 both pinned; the next autoupdate
+  # reverted each). A local hook has no rev, so the pin below sticks.
+  - repo: local
     hooks:
       - id: typos
+        name: typos
+        language: python
+        additional_dependencies: ["typos==1.48.0"]
+        entry: typos
+        args: [--write-changes, --force-exclude]
+        types: [text]
         # https://github.com/crate-ci/typos/issues/347
         pass_filenames: false
   - repo: https://github.com/rbubley/mirrors-prettier


### PR DESCRIPTION
Follow-up to #6074, fixing the last unpinned hook. The `typos` rev has been the mutable `v1` tag, which pre-commit never updates after first install — so every machine and CI environment silently freezes whatever version it first built, and versions drift apart over time.

Pinning an exact tag doesn't stick: crate-ci/typos publishes moving tags (`v1`, `typos-dict-*`) on the same repo, and `pre-commit autoupdate` re-selects among them — #5481 pinned `v1.9.0` and #5510 pinned `v1.37.2`, and the next weekly autoupdate reverted each back to `v1` (one week it even landed on `typos-dict-v0.13.13`). This converts typos to a `repo: local` hook with the version pinned via `additional_dependencies: ["typos==1.48.0"]` (PyPI binary wheels), the same pattern the config already uses for lychee. Local hooks have no `rev`, so autoupdate has nothing to rewrite. The hook definition mirrors upstream's exactly (`entry: typos`, `args: [--write-changes, --force-exclude]`, `types: [text]`) and keeps the existing `pass_filenames: false` workaround for crate-ci/typos#347.

Trade-off: typos bumps become manual (autoupdate and dependabot don't track `additional_dependencies`), which beats an unpinned version frozen per-machine. typos 1.48.0 runs clean across the repo — no new dictionary findings — and `pre-commit run --all-files` passes with the mutable-reference warning gone.

> _This was written by Claude Code on behalf of max_
