### PR TITLE
ci: publish to crates.io via trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -375,15 +375,27 @@ jobs:
     runs-on: ubuntu-24.04
     # This job runs unconditionally as a `--no-verify` dry-run smoke test when
     # `release.yaml` is reused from `nightly.yaml` on PRs; only apply the
-    # `release` environment (and its tag-restricted secret) on actual releases,
-    # otherwise the deployment-branch policy denies the dry-run on branch refs.
+    # `release` environment on actual releases, otherwise the deployment-branch
+    # policy denies the dry-run on branch refs.
     environment: ${{ github.event_name == 'release' && 'release' || '' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v7
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-release
+      # Auth is via crates.io Trusted Publishing (GitHub Actions OIDC). One
+      # exchange covers prqlc, prqlc-parser and prqlc-macros: crates.io scopes
+      # the minted token to every crate whose config matches this repo,
+      # workflow and environment. Dry runs publish nothing and have no
+      # environment to match, so they skip it.
+      - name: Authenticate with crates.io
+        id: auth
+        if: github.event_name == 'release'
+        uses: rust-lang/crates-io-auth-action@v1
       # Currently, we can only check prqlc-parser which is not dependent other local crates with --dry-run.
       # https://github.com/crate-ci/cargo-release/issues/691
       # --no-verify is required to prevent build.
@@ -391,7 +403,7 @@ jobs:
           cargo release publish --no-confirm ${{ github.event_name == 'release'
           && '--execute' || '--no-verify --package prqlc-parser'}}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   # Requires another pass: https://github.com/PRQL/prql/issues/850
   # publish-prql-java:


### PR DESCRIPTION
## What

`publish-to-cargo` now mints its crates.io credential per run through
`rust-lang/crates-io-auth-action` (GitHub Actions OIDC) instead of reading
the `CARGO_REGISTRY_TOKEN` environment secret. The token lives for about 30
minutes and the action's post step revokes it, so no long-lived publish
credential exists anywhere.

One exchange covers all three published crates. crates.io scopes the minted
token to every crate whose Trusted Publisher config matches the JWT's
repository, workflow filename and environment, so `cargo release publish`
still walks `prqlc-parser` → `prqlc-macros` → `prqlc` under a single token.

The dry-run path is untouched. It runs with no environment, so its JWT
carries no environment claim to match against, and it publishes nothing —
the auth step is gated on `github.event_name == 'release'` accordingly.

## Why

The stored token expires on a schedule, and each expiry is a silent trap:
nothing breaks until the next release, which is exactly when you don't want
to discover it.

## Prerequisite, already in place

Trusted Publishers are configured on crates.io for `prqlc`, `prqlc-parser` and `prqlc-macros`, each scoped to repository `PRQL/prql`, workflow `release.yaml`, environment `release`. They had to land before this merge: a missing config fails that crate's publish partway through the sequence, which is awkward to unwind given crates.io versions are immutable.

`CARGO_REGISTRY_TOKEN` can be removed from the `release` environment once a release has gone out this way.

## Verification

This PR's own CI exercised the changed job on its dry-run path — `nightly / nightly-release / publish-to-cargo` passed with `Authenticate with crates.io` skipped, confirming the gating leaves the nightly smoke test intact.

> _This was written by Claude Code on behalf of max_
