### PR TITLE
chore: bump version to 0.13.15 for next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # PRQL Changelog
 
+## [unreleased]
+
+**Language**:
+
+**Features**:
+
+**Fixes**:
+
+**Documentation**:
+
+**Web**:
+
+**Integrations**:
+
+**Internal changes**:
+
+**New Contributors**:
+
 ## 0.13.14 — 2026-07-24
 
 0.13.14 has 80 commits from 7 contributors. Selected changes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "compile-files"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "prqlc",
 ]
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-prql"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "ansi-to-html",
  "anstream",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "prql"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "prqlc",
  "rustler",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "prql-java"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "jni",
  "prqlc",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "anstream",
  "anyhow",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-c"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "libc",
  "prqlc",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-js"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "console_error_panic_hook",
  "prqlc",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-macros"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "prqlc",
  "syn 2.0.118",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-parser"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "chumsky",
  "enum-as-inner",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "prqlc-python"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "insta",
  "prqlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/PRQL/prql"
 # This isn't tested since `cargo-msrv` doesn't support workspaces; instead we
 # test `metadata.msrv` in `prqlc`
 rust-version = "1.81.0"
-version = "0.13.14"
+version = "0.13.15"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more on the language, more examples & comparisons with SQL, visit
 [prql-lang.org][prql website]. To experiment with PRQL in the browser, check out
 [PRQL Playground][prql playground].
 
-## Current Status - June 2026
+## Current Status - July 2026
 
 PRQL is ready to use by the intrepid, either with our supported integrations, or
 within your own tools, using one of our supported language bindings.

--- a/prqlc/bindings/elixir/native/prql/Cargo.toml
+++ b/prqlc/bindings/elixir/native/prql/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/lib.rs"
 test = false
 
 [target.'cfg(not(any(target_family="wasm")))'.dependencies]
-prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.14" }
+prqlc = { path = "../../../../prqlc", default-features = false, version = "0.13.15" }
 rustler = "0.38.0"

--- a/prqlc/bindings/js/package-lock.json
+++ b/prqlc/bindings/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prqlc",
-  "version": "0.13.14",
+  "version": "0.13.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prqlc",
-      "version": "0.13.14",
+      "version": "0.13.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/prqlc/bindings/js/package.json
+++ b/prqlc/bindings/js/package.json
@@ -35,5 +35,5 @@
     "test": "mocha tests"
   },
   "types": "dist/node/prqlc_js.d.ts",
-  "version": "0.13.14"
+  "version": "0.13.15"
 }

--- a/prqlc/packages/snap/snapcraft.yaml
+++ b/prqlc/packages/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: prqlc
 title: PRQL Compiler
 base: core22
-version: "0.13.14"
+version: "0.13.15"
 summary: CLI for PRQL, a modern language for transforming data
 description: |
   prqlc is the CLI for the PRQL compiler. It compiles PRQL to SQL, and offers various diagnostics.

--- a/prqlc/prqlc-macros/Cargo.toml
+++ b/prqlc/prqlc-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-prqlc = {path = "../prqlc", default-features = false, version = "0.13.14" }
+prqlc = {path = "../prqlc", default-features = false, version = "0.13.15" }
 syn = "2.0.117"
 
 [package.metadata.release]

--- a/prqlc/prqlc/Cargo.toml
+++ b/prqlc/prqlc/Cargo.toml
@@ -54,7 +54,7 @@ test-dbs-external = [
 ]
 
 [dependencies]
-prqlc-parser = { path = "../prqlc-parser", version = "0.13.14" }
+prqlc-parser = { path = "../prqlc-parser", version = "0.13.15" }
 
 anstream = { version = "1.0.0", features = ["auto"] }
 ariadne = "0.5.1"

--- a/prqlc/prqlc/src/cli/docs_generator.rs
+++ b/prqlc/prqlc/src/cli/docs_generator.rs
@@ -317,7 +317,7 @@ mod tests {
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta name="keywords" content="prql">
-            <meta name="generator" content="prqlc 0.13.14">
+            <meta name="generator" content="prqlc 0.13.15">
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
             <title>PRQL Docs</title>
           </head>
@@ -395,7 +395,7 @@ mod tests {
 
             </main>
             <footer class="container border-top">
-              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.14.</small>
+              <small class="text-body-secondary">Generated with <a href="https://prql-lang.org/" rel="external" target="_blank">prqlc</a> 0.13.15.</small>
             </footer>
           </body>
         </html>
@@ -477,7 +477,7 @@ mod tests {
 
 
 
-        Generated with [prqlc](https://prql-lang.org/) 0.13.14.
+        Generated with [prqlc](https://prql-lang.org/) 0.13.15.
 
         ----- stderr -----
         ");
@@ -512,7 +512,7 @@ mod tests {
 
 
 
-        Generated with [prqlc](https://prql-lang.org/) 0.13.14.
+        Generated with [prqlc](https://prql-lang.org/) 0.13.15.
 
         ----- stderr -----
         ");

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -503,10 +503,12 @@ Currently we release in a semi-automated way:
    [release workflow](https://github.com/PRQL/prql/blob/main/.github/workflows/release.yaml).
 
 5. Run
-   `cargo release patch --no-publish --no-push --execute --no-verify --no-confirm --no-tag && task prqlc:test-all`
+   `cargo release patch --no-publish --no-push --execute --no-verify --no-confirm --no-tag && task prqlc:test-all && cargo insta test --accept -p mdbook-prql`
    to bump to the next development version, then PR the resulting commit. This
-   recreates the `## [unreleased]` section for the next cycle, and
-   `task prqlc:test-all` refreshes the snapshot tests that embed the version.
+   recreates the `## [unreleased]` section for the next cycle. The version is
+   embedded in snapshots in two workspaces, so both test commands are needed:
+   `task prqlc:test-all` covers `prqlc`'s docs-generator snapshots, and
+   `cargo insta test -p mdbook-prql` covers the book's `prql.version` example.
 
 <!-- `version` and `replace` must run in one `cargo release` invocation (not separate `cargo release version` + `cargo release replace` steps) so the `prev_version` replacement for the prqlc version constraint in target.md resolves. -->
 

--- a/web/book/src/project/target.md
+++ b/web/book/src/project/target.md
@@ -83,7 +83,7 @@ echo 'prql target:sql.generic
 PRQL allows specifying a version of the language in the PRQL header, like:
 
 ```prql
-prql version:"0.13.13"
+prql version:"0.13.14"
 
 from employees
 ```

--- a/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
+++ b/web/book/tests/documentation/snapshots/documentation__book__project__target__version__1.snap
@@ -4,7 +4,7 @@ expression: "[{version = prql.version}]\n"
 ---
 WITH table_0 AS (
   SELECT
-    '0.13.14' AS version
+    '0.13.15' AS version
 )
 SELECT
   version

--- a/web/playground/package-lock.json
+++ b/web/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prql-playground",
-  "version": "0.13.14",
+  "version": "0.13.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prql-playground",
-      "version": "0.13.14",
+      "version": "0.13.15",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.32.0",
         "@monaco-editor/react": "^4.7.0",
@@ -29,7 +29,7 @@
     },
     "../../prqlc/bindings/js": {
       "name": "prqlc",
-      "version": "0.13.14",
+      "version": "0.13.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^6.0.1",

--- a/web/playground/package.json
+++ b/web/playground/package.json
@@ -46,5 +46,5 @@
     "prepare": "rsync -ai --checksum --delete ../../prqlc/prqlc/tests/integration/data/ public/data/ && node generateBook.cjs",
     "preview": "vite preview"
   },
-  "version": "0.13.14"
+  "version": "0.13.15"
 }


### PR DESCRIPTION
Step 5 of the release runbook, following the [0.13.14 release](https://github.com/PRQL/prql/releases/tag/0.13.14). `cargo release patch --no-publish --no-push --execute --no-verify --no-confirm --no-tag` bumps the workspace to 0.13.15, recreates the `## [unreleased]` changelog section for the next cycle, and moves the `prql version:` example in `target.md` to the version just released.

Two snapshot sets embed the compiler version and both are refreshed here: `prqlc`'s docs-generator snapshots, and the book's `[{version = prql.version}]` example.

That second one is why this also corrects the runbook. Step 5 prescribed `cargo release … && task prqlc:test-all`, but `task prqlc:test-all` is scoped to the `prqlc/` workspace, so it structurally cannot regenerate a snapshot living in `web/book` — every release walks into a red `book::test_prql_examples_compile` and fixes it reactively. Step 5 now runs `cargo insta test --accept -p mdbook-prql` as well, and says why.

Also refreshes the README's **Current Status** date (runbook step 7). The substance still holds — development is paced by the new-resolver question, and the priorities below it are unchanged — so only the month stamp moves.

> _This was written by Claude Code on behalf of max_
