### PR TITLE
fix: move std types into std.types module, disambiguate text and date types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Language**:
 
+- Move all standard types into a dedicated `std.types` submodule in order to
+  disambiguate between `type text` - `module text` and `type date` -
+  `module date`. (@kgutwin, #6155)
+
 **Features**:
 
 **Fixes**:

--- a/prqlc/prqlc/src/semantic/module.rs
+++ b/prqlc/prqlc/src/semantic/module.rs
@@ -35,6 +35,7 @@ impl Module {
                 Ident::from_name(NS_THIS),
                 Ident::from_name(NS_THAT),
                 Ident::from_name(NS_PARAM),
+                Ident::from_path(vec![NS_STD, "types"]),
                 Ident::from_name(NS_STD),
             ],
         }

--- a/prqlc/prqlc/src/semantic/resolver/stmt.rs
+++ b/prqlc/prqlc/src/semantic/resolver/stmt.rs
@@ -108,7 +108,7 @@ impl super::Resolver<'_> {
 
         if def.name == "main" {
             def.ty = Some(Ty::new(TyKind::Ident(Ident::from_path(vec![
-                "std", "relation",
+                "std", "types", "relation",
             ]))));
         }
 

--- a/prqlc/prqlc/src/semantic/std.prql
+++ b/prqlc/prqlc/src/semantic/std.prql
@@ -37,27 +37,29 @@ let not = expr<bool> -> <bool> internal std.not
 
 # Types
 
-## Type primitives
-type int = int
-type float = float
-type bool = bool
-type text = text
-type date = date
-type time = time
-type timestamp = timestamp
-type `func` = func
+module types {
+  ## Type primitives
+  type int = int
+  type float = float
+  type bool = bool
+  type text = text
+  type date = date
+  type time = time
+  type timestamp = timestamp
+  type `func` = func
 
-## Generic array
-type array = []
+  ## Generic array
+  type array = []
 
-## Generic relation
-type relation = [{..}]
+  ## Generic relation
+  type relation = [{..}]
 
-## Range
-type range = {start = *, end = *}
+  ## Range
+  type range = {start = *, end = *}
 
-## Transform
-type transform = func relation -> relation
+  ## Transform
+  type transform = func relation -> relation
+}
 
 # Functions
 

--- a/prqlc/prqlc/tests/integration/error_messages.rs
+++ b/prqlc/prqlc/tests/integration/error_messages.rs
@@ -195,7 +195,7 @@ fn test_ambiguous() {
        │            ──┬─
        │              ╰─── Ambiguous name
        │
-       │ Help: could be any of: std.date, this.date
+       │ Help: could be any of: std.date, std.types.date, this.date
        │
        │ Note: available columns: date
     ───╯

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
@@ -184,7 +184,7 @@ nodes:
   span: [std]
   children:
   - 57
-  - 4000000147
+  - 4000000148
   parent: 67
 - id: 65
   kind: Ident
@@ -224,14 +224,14 @@ nodes:
   children:
   - 67
   - 68
-- id: 4000000147
+- id: 4000000148
   kind: RqOperator
   span: [std]
   targets:
   - 60
-  - 4000000149
+  - 4000000150
   parent: 64
-- id: 4000000149
+- id: 4000000150
   kind: Literal
   span: [std]
 ast:


### PR DESCRIPTION
Resolves #6146.

Moves all current `type` declarations in `std.prql` into a dedicated `module types { ... }`. To preserve backwards compatibility, also adds the `std.types` ident to the list of redirects on the root module and adjusts a hard coded `std.relation` reference to be `std.types.relation`.

Note that this does change "ambiguous name" error messages when the reference is to either the `text` or `date` names. Since those names will now resolve to both `std.text` and `std.types.text`, the error includes all three potential options (plus the probably expected choice of `this.text`). To me, the proper fix here is not to stick with the old error message (giving an extra unhelpful name choice doesn't make the underlying issue any worse) but rather to line up for an improvement to the type system that could potentially filter out ambiguous names that don't have the expected type. 