### PR TITLE
test: filter std.prql spans from unrelated snapshots

### DIFF
--- a/prqlc/prqlc/src/semantic/resolver/mod.rs
+++ b/prqlc/prqlc/src/semantic/resolver/mod.rs
@@ -154,9 +154,10 @@ pub(super) mod test {
 
     #[test]
     fn test_functions_pipeline() {
-        let mut settings = insta::Settings::clone_current();
-        settings.add_filter(r"\b0:\d+-\d+", "[std]");
-        settings.bind(|| {
+        // Spans from `std.prql` carry source id 0 (`STD_LIB_SOURCE_ID`); user
+        // sources start at 1. Filtering them keeps this snapshot stable when the
+        // stdlib shifts, without hiding spans from the query under test.
+        insta::with_settings!({ filters => vec![(r"\b0:\d+-\d+", "[std]")] }, {
             assert_yaml_snapshot!(resolve_derive(
                 r#"
             from a

--- a/prqlc/prqlc/src/semantic/resolver/mod.rs
+++ b/prqlc/prqlc/src/semantic/resolver/mod.rs
@@ -154,24 +154,28 @@ pub(super) mod test {
 
     #[test]
     fn test_functions_pipeline() {
-        assert_yaml_snapshot!(resolve_derive(
-            r#"
+        let mut settings = insta::Settings::clone_current();
+        settings.add_filter(r"\b0:\d+-\d+", "[std]");
+        settings.bind(|| {
+            assert_yaml_snapshot!(resolve_derive(
+                r#"
             from a
             derive one = (foo | sum)
             "#
-        )
-        .unwrap());
+            )
+            .unwrap());
 
-        assert_yaml_snapshot!(resolve_derive(
-            r#"
+            assert_yaml_snapshot!(resolve_derive(
+                r#"
             let plus_one = x -> x + 1
             let plus = x y -> x + y
 
             from a
             derive {b = (sum foo | plus_one | plus 2)}
             "#
-        )
-        .unwrap());
+            )
+            .unwrap());
+        });
     }
     #[test]
     fn test_named_args() {

--- a/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__test__functions_pipeline-2.snap
+++ b/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__test__functions_pipeline-2.snap
@@ -27,7 +27,7 @@ expression: "resolve_derive(r#\"\n            let plus_one = x -> x + 1\n       
                     ty:
                       kind:
                         Array: ~
-                      span: "0:1699-1701"
+                      span: "[std]"
                       name: array
               span: "1:120-127"
             - Literal:

--- a/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__test__functions_pipeline.snap
+++ b/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__test__functions_pipeline.snap
@@ -13,7 +13,7 @@ expression: "resolve_derive(r#\"\n            from a\n            derive one = (
         ty:
           kind:
             Array: ~
-          span: "0:1699-1701"
+          span: "[std]"
           name: array
   span: "1:52-55"
   alias: one

--- a/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
+++ b/prqlc/prqlc/src/semantic/resolver/snapshots/prqlc__semantic__resolver__transforms__tests__aggregate_positional_arg-2.snap
@@ -14,9 +14,9 @@ TransformCall:
           kind:
             Tuple:
               - Wildcard: ~
-          span: "0:1740-1744"
+          span: "[std]"
           name: ~
-      span: "0:1739-1745"
+      span: "[std]"
       name: relation
     lineage:
       columns:
@@ -44,7 +44,7 @@ TransformCall:
                   ty:
                     kind:
                       Array: ~
-                    span: "0:1699-1701"
+                    span: "[std]"
                     name: array
             span: "1:73-87"
         span: "1:73-87"

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -1472,9 +1472,10 @@ mod tests {
         let expr = res.clone().into_relation_var().unwrap();
         let expr = super::super::test::erase_ids(*expr);
 
-        let mut settings = insta::Settings::clone_current();
-        settings.add_filter(r"\b0:\d+-\d+", "[std]");
-        settings.bind(|| {
+        // Spans from `std.prql` carry source id 0 (`STD_LIB_SOURCE_ID`); user
+        // sources start at 1. Filtering them keeps this snapshot stable when the
+        // stdlib shifts, without hiding spans from the query under test.
+        insta::with_settings!({ filters => vec![(r"\b0:\d+-\d+", "[std]")] }, {
             assert_yaml_snapshot!(expr);
         });
     }

--- a/prqlc/prqlc/src/semantic/resolver/transforms.rs
+++ b/prqlc/prqlc/src/semantic/resolver/transforms.rs
@@ -1471,7 +1471,12 @@ mod tests {
         let (res, _) = ctx.find_main_rel(&[]).unwrap().clone();
         let expr = res.clone().into_relation_var().unwrap();
         let expr = super::super::test::erase_ids(*expr);
-        assert_yaml_snapshot!(expr);
+
+        let mut settings = insta::Settings::clone_current();
+        settings.add_filter(r"\b0:\d+-\d+", "[std]");
+        settings.bind(|| {
+            assert_yaml_snapshot!(expr);
+        });
     }
 
     #[test]

--- a/prqlc/prqlc/tests/integration/queries.rs
+++ b/prqlc/prqlc/tests/integration/queries.rs
@@ -148,7 +148,10 @@ mod debug_lineage {
 
         let lineage = serde_yaml::to_string(&fc).unwrap();
 
-        with_settings!({ input_file => prql_path }, {
+        with_settings!({
+            input_file => prql_path,
+            filters => vec![(r"\b0:\d+-\d+", "[std]")],
+        }, {
             assert_snapshot!(test_name, &lineage, &prql)
         });
     }

--- a/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
+++ b/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__set_ops_remove.snap
@@ -18,7 +18,7 @@ frames:
       table:
       - default_db
       - _literal_16
-- - 0:3522-3608
+- - [std]
   - columns:
     - !Single
       name:
@@ -43,7 +43,7 @@ frames:
       table:
       - default_db
       - _literal_11
-- - 0:3611-3665
+- - [std]
   - columns:
     - !Single
       name:
@@ -157,14 +157,14 @@ nodes:
   - 11
 - id: 55
   kind: RqOperator
-  span: 0:3551-3607
+  span: [std]
   targets:
   - 48
   - 50
   parent: 57
 - id: 57
   kind: 'TransformCall: Join'
-  span: 0:3522-3608
+  span: [std]
   children:
   - 42
   - 11
@@ -172,7 +172,7 @@ nodes:
   parent: 64
 - id: 60
   kind: Ident
-  span: 0:6512-6520
+  span: [std]
   ident: !Ident
   - this
   - b
@@ -181,7 +181,7 @@ nodes:
   - 11
 - id: 64
   kind: 'TransformCall: Filter'
-  span: 0:3611-3665
+  span: [std]
   children:
   - 57
   - 4000000147
@@ -197,7 +197,7 @@ nodes:
   parent: 66
 - id: 66
   kind: Tuple
-  span: 0:3675-3678
+  span: [std]
   children:
   - 65
   parent: 67
@@ -226,14 +226,14 @@ nodes:
   - 68
 - id: 4000000147
   kind: RqOperator
-  span: 0:3619-3664
+  span: [std]
   targets:
   - 60
   - 4000000149
   parent: 64
 - id: 4000000149
   kind: Literal
-  span: 0:6524-6528
+  span: [std]
 ast:
   name: Project
   stmts:


### PR DESCRIPTION
Resolves #6152.

This is the second part; trivial, really, but applies a filter to certain insta snapshots to replace the pattern `r"\b0:\d+-\d+"` with `[std]`. This has the effect that changes to `std.prql` generate much less churn in unrelated snapshots and improves code review overall.

Note that this filtering is applied very selectively at this point, since it was determined that this issue is fairly narrowly scoped. If we find that there are additional sources of churn, it'll be worth revisiting this approach and maybe making it more generally applied.

No changelog entry as this only affects the content of test snapshots.