### PR TITLE
ci: run the OIDC publish jobs in the `release` environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -310,6 +310,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build-python-wheels]
     if: github.event_name == 'release'
+    environment: release
     permissions:
       id-token: write
     strategy:
@@ -330,6 +331,10 @@ jobs:
 
   publish-js:
     runs-on: ubuntu-24.04
+    # Off-release runs publish with `--dry-run`, on a branch ref the
+    # deployment-branch policy denies, so they take no environment — as in
+    # `publish-to-cargo` below.
+    environment: ${{ github.event_name == 'release' && 'release' || '' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
`publish-python` and `publish-js` request `id-token: write` without naming an environment, so nothing gates the ref their OIDC token is minted from. Both now join `release`, whose deployment policy admits only `*.*.*` tags. `publish-js` takes the conditional form `publish-to-cargo` already uses, because it also runs off-release as a `--dry-run` on a branch ref the policy denies.

Alongside this, the `release` and `github-pages` environments now require approval from a maintainer (@snth, @max-sixty, @aljazerzen, @eitsupi — the members of `prql-team`, named individually so the check can verify the bot isn't among them). "Prevent self-review" is off, so whoever cuts the release can approve it, and only one of the four needs to.

A reviewer is the only gate available here. A deployment branch policy can't do the job for either environment:

- Every publish job keys off `github.event_name == 'release'`, and a write-scoped account can publish a release against a tag that already exists, which takes no tag operation and lands on a ref the `*.*.*` policy admits.
- `github-pages` deploys from the `web` branch, which the release pushes with a PAT, so the bot can reach that ref by design.

At release time the run now pauses at these jobs with a "Review deployments" prompt.

One thing to watch on the first release under this: PyPI and npm trusted publishing check the environment claim only when the publisher config on their side names one. Both are currently published from no environment, so the config can't be naming one — but if a publish fails to authenticate, that's the setting to check.

This clears tend's `credential-environments`. `repo-secret-allowlist` still fails on the repo-level `TEND_BOT_TOKEN`; that one needs every consumer moved into an environment first, which is a larger change.

> _This was written by Claude Code on behalf of max-sixty_
