### PR TITLE
ci: publish the web docs once per release

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -1,13 +1,10 @@
 name: publish-web
 on:
+  # A release ends by pushing its docs to `web` with the bot's PAT, and a push
+  # made with a PAT does start workflows, so this covers releases too.
   push:
     branches:
       - web
-  # Even though releases push to `web` branch, that doesn't cause this workflow
-  # to run, because GHA can't start workflows itself. So we also run on
-  # releases.
-  release:
-    types: [released]
   # Called by pull-request when specifically requested
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
`publish-web` ran twice per release: once on the `release` event, once on the push to `web` that the release itself makes. The comment justifying the `release:` trigger says that push can't start a workflow, which holds for the default `GITHUB_TOKEN` but not here — `release.yaml`'s `push-web-branch` job checks out with `TEND_BOT_TOKEN`, and a push made with a PAT starts workflows normally.

The run history since 0.13.10 shows both firing, minutes apart:

```
2026-07-24T14:45  push     web       success
2026-07-24T14:41  release  0.13.14   success
2026-06-14T18:30  push     web       success
2026-06-14T18:29  release  0.13.13   success
```

Releases 0.13.5 through 0.13.9 show only the `release` run, so the doubling dates from when that push started using the bot's PAT.

The `web` push run lands second, so it already decides what's published; the release-triggered run is overwritten a few minutes later. Keeping the push trigger rather than the release one also preserves republishing when a docs fix is backported to `web` outside a release.

What this gives up: the release-triggered run is an accidental fallback today, so if `push-web-branch` ever fails, no deploy happens at all rather than one from the tag. That failure is visible in the release run either way.

Now that `github-pages` requires a deployment approval, the redundant run also costs an approval per release.

> _This was written by Claude Code on behalf of max-sixty_
