### PR TITLE
ci: read the bot PAT from an environment in every workflow

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -2,7 +2,9 @@ bot_name: prql-bot
 secrets:
   # Docker Hub login is needed by test-rust.yaml on internal PRs (external-DB
   # tests); it's a low-value pull token, so it's intentionally repo-level.
-  # Release secrets (cargo/snapcraft) live in the `release` environment instead.
+  # Everything else sits behind an environment, split by the ref that releases
+  # it: `tend` for the jobs that run on `main`, `release` for the ones that run
+  # on a tag.
   allowed:
     - DOCKERHUB_TOKEN
     - DOCKERHUB_USERNAME

--- a/.github/workflows/pull-request-target.yaml
+++ b/.github/workflows/pull-request-target.yaml
@@ -51,6 +51,7 @@ jobs:
     # Confirm that it's merged and has a label to ensure nothing is backported without oversight
     if: |
       github.event.pull_request.merged
+      && github.event.pull_request.base.ref == 'main'
       && (
         github.event.action == 'closed'
         || (
@@ -58,6 +59,12 @@ jobs:
           && contains(github.event.label.name, 'pr-backport-web')
         )
       )
+    # `pull_request_target` runs at the base branch's ref, and `TEND_BOT_TOKEN`
+    # lives in the `tend` environment, which admits only `main`. Hence the
+    # `base.ref` condition above.
+    environment:
+      name: tend
+      deployment: false
     steps:
       - uses: tibdex/backport@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
   brew-dispatcher:
     name: Release on homebrew-prql
     runs-on: ubuntu-24.04
+    environment: release
     if: github.event_name == 'release'
     steps:
       - uses: actions/github-script@v9
@@ -124,6 +125,7 @@ jobs:
 
   publish-winget:
     runs-on: ubuntu-24.04
+    environment: release
     needs: build-prqlc
     if: github.event_name == 'release'
     steps:
@@ -426,6 +428,7 @@ jobs:
 
   push-web-branch:
     runs-on: ubuntu-24.04
+    environment: release
     if: github.event_name == 'release'
     steps:
       - name: 📂 Checkout code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -783,6 +783,12 @@ jobs:
     # default toolchain to run on. The minimum is defined by Cargo.toml's
     # metadata.msrv and is updated manually based on when build environments
     # such as debian & winget are updated.
+    #
+    # `TEND_BOT_TOKEN` lives in the `tend` environment, which admits only
+    # `main`; `nightly-upstream` is schedule-only, so the ref is always `main`.
+    environment:
+      name: tend
+      deployment: false
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
`tend check` fails `repo-secret-allowlist`: `TEND_BOT_TOKEN` is a repo-level secret, so every workflow the repo runs can read the bot's PAT, including workflows a same-repo PR branch adds. The allowlist escape hatch isn't available for this one — tend refuses `TEND_BOT_TOKEN` in `secrets.allowed` at config load, on the grounds that a repo-level copy is exactly what the environment gate exists to prevent.

So every consumer moves behind an environment. The generated `tend-*.yaml` jobs already do this. The five hand-written ones split by the ref they run at, which is what decides the environment: a deployment branch policy is evaluated against the run's ref, and a job naming an environment that doesn't admit its ref is refused before its first step.

| Job | Ref | Environment |
|---|---|---|
| `tests.yaml:update-rust-toolchain` | `main` (schedule-only) | `tend` |
| `pull-request-target.yaml:backport` | base branch | `tend` |
| `release.yaml:brew-dispatcher` | tag | `release` |
| `release.yaml:publish-winget` | tag | `release` |
| `release.yaml:push-web-branch` | tag | `release` |

`backport` also gains a `base.ref == 'main'` condition. `pull_request_target` runs at the base branch's ref, and `tend` admits only `main`, so without it the backport PRs that merge into `web` would hit a refused environment rather than skipping. Backports flow out of `main`, so this doesn't lose anything.

The three release jobs pick up the required reviewers already on the `release` environment. GitHub approves per job rather than per environment, so a release will ask for approval in a couple more rounds than it does today.

### Secret operations

`release` now holds its own `TEND_BOT_TOKEN`, copied from the bot's `gh` credential per the install skill's step 8c, so the three release jobs have a token the moment this lands.

That leaves the deletion, which is what makes the check pass. It goes after this merges, not before: a job naming an environment can still read a repo-level secret of the same name, so the workflows keep working across the merge, and deleting early would leave the ungated jobs on `main` with an empty token.

```
gh secret delete TEND_BOT_TOKEN --repo PRQL/prql
```

<details>
<summary>Why the release jobs can't use the <code>tend</code> environment</summary>

`tend` holds the token already, but its policy admits only `main`, and tend's own `environment` check asserts that. A release job runs at `refs/tags/X.Y.Z`. `release` is the environment whose policy covers that ref, and tend's `credential-environments` check requires required reviewers on any environment a workflow reaches on a `release:` trigger, which `release` has.

</details>

> _This was written by Claude Code on behalf of max-sixty_
