### PR TITLE
ci: keep the publish credential inside the `release` environment

### DIFF
--- a/.github/actions/build-js/action.yaml
+++ b/.github/actions/build-js/action.yaml
@@ -1,0 +1,37 @@
+name: build-js
+description: "Build the prqlc npm package, ready for `npm publish`."
+
+runs:
+  using: composite
+  steps:
+    - uses: baptiste0928/cargo-install@v3
+      with:
+        crate: wasm-pack
+
+    - name: Setup Node
+      uses: actions/setup-node@v7
+      with:
+        # Node 24+ includes npm 11.5.1+ required for OIDC trusted publishing
+        node-version: "24.x"
+        registry-url: "https://registry.npmjs.org"
+
+    - run: ./.github/workflows/scripts/set_version.sh
+      shell: bash
+
+    - name: 💰 Cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: ${{ env.version }}-${{ hashFiles('./Cargo.lock') }}
+        # Share key with the `build-web` job
+        shared-key: web
+        save-if: false
+        # Caching `~/.cargo/bin/` breaks the rustup `cargo`/`rustc` symlinks
+        # on the new macos-15 runner image — see
+        # https://github.com/Swatinem/rust-cache/issues/341.
+        cache-bin: "false"
+
+    # This is only required in order to have `cross-env` installed, since `npx
+    # cross-env` doesn't seem to work in CI (https://github.com/PRQL/prql/pull/3728)
+    - run: npm install
+      working-directory: prqlc/bindings/js/
+      shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -329,60 +329,62 @@ jobs:
           command: upload
           args: --skip-existing *
 
+  # `release.yaml` is reused from `nightly.yaml` on PRs, where it only
+  # smoke-tests the publish path. Those runs are on branch refs, which the
+  # `release` environment's deployment policy denies, so each smoke test is its
+  # own job holding no `id-token: write`. A registry accepts an OIDC token from
+  # any run of this workflow unless its publisher config pins the environment,
+  # so a run outside `release` must not be able to mint one.
+  test-publish-js:
+    runs-on: ubuntu-24.04
+    if: github.event_name != 'release'
+    permissions:
+      contents: read
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v7
+      - uses: ./.github/actions/build-js
+      # `--provenance` needs an OIDC token, so it belongs to `publish-js` alone.
+      - name: Check the npm package
+        run: npm publish --dry-run --access public
+        working-directory: prqlc/bindings/js/
+
   publish-js:
     runs-on: ubuntu-24.04
-    # Off-release runs publish with `--dry-run`, on a branch ref the
-    # deployment-branch policy denies, so they take no environment — as in
-    # `publish-to-cargo` below.
-    environment: ${{ github.event_name == 'release' && 'release' || '' }}
+    if: github.event_name == 'release'
+    environment: release
     permissions:
       contents: read
       id-token: write
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v7
+      - uses: ./.github/actions/build-js
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        working-directory: prqlc/bindings/js/
+
+  test-publish-to-cargo:
+    runs-on: ubuntu-24.04
+    if: github.event_name != 'release'
+    permissions:
+      contents: read
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v7
       - uses: baptiste0928/cargo-install@v3
         with:
-          crate: wasm-pack
-
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          # Node 24+ includes npm 11.5.1+ required for OIDC trusted publishing
-          node-version: "24.x"
-          registry-url: "https://registry.npmjs.org"
-
-      - run: ./.github/workflows/scripts/set_version.sh
-      - name: 💰 Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: ${{ env.version }}-${{ hashFiles('./Cargo.lock') }}
-          # Share key with the `build-web` job
-          shared-key: web
-          save-if: false
-          # Caching `~/.cargo/bin/` breaks the rustup `cargo`/`rustc` symlinks
-          # on the new macos-15 runner image — see
-          # https://github.com/Swatinem/rust-cache/issues/341.
-          cache-bin: "false"
-
-      # This is only required in order to have `cross-env` installed, since `npx
-      # cross-env` doesn't seem to work in CI (https://github.com/PRQL/prql/pull/3728)
-      - run: npm install
-        working-directory: prqlc/bindings/js/
-
-      - name: Publish to npm
-        run:
-          npm publish --provenance --access public ${{ (github.event_name !=
-          'release') && '--dry-run' || '' }}
-        working-directory: prqlc/bindings/js/
+          crate: cargo-release
+      # Currently, we can only check prqlc-parser which is not dependent other local crates with --dry-run.
+      # https://github.com/crate-ci/cargo-release/issues/691
+      # --no-verify is required to prevent build.
+      - run:
+          cargo release publish --no-confirm --no-verify --package prqlc-parser
 
   publish-to-cargo:
     runs-on: ubuntu-24.04
-    # This job runs unconditionally as a `--no-verify` dry-run smoke test when
-    # `release.yaml` is reused from `nightly.yaml` on PRs; only apply the
-    # `release` environment on actual releases, otherwise the deployment-branch
-    # policy denies the dry-run on branch refs.
-    environment: ${{ github.event_name == 'release' && 'release' || '' }}
+    if: github.event_name == 'release'
+    environment: release
     permissions:
       contents: read
       id-token: write
@@ -395,18 +397,11 @@ jobs:
       # Auth is via crates.io Trusted Publishing (GitHub Actions OIDC). One
       # exchange covers prqlc, prqlc-parser and prqlc-macros: crates.io scopes
       # the minted token to every crate whose config matches this repo,
-      # workflow and environment. Dry runs publish nothing and have no
-      # environment to match, so they skip it.
+      # workflow and environment.
       - name: Authenticate with crates.io
         id: auth
-        if: github.event_name == 'release'
         uses: rust-lang/crates-io-auth-action@v1
-      # Currently, we can only check prqlc-parser which is not dependent other local crates with --dry-run.
-      # https://github.com/crate-ci/cargo-release/issues/691
-      # --no-verify is required to prevent build.
-      - run:
-          cargo release publish --no-confirm ${{ github.event_name == 'release'
-          && '--execute' || '--no-verify --package prqlc-parser'}}
+      - run: cargo release publish --no-confirm --execute
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,6 +111,9 @@ jobs:
             nightly:
               - .github/workflows/nightly.yaml
               - .github/workflows/release.yaml
+              # The build steps `release.yaml` runs, so a change to one is
+              # smoke-tested by the same nightly run.
+              - .github/actions/build-*/**
               - "**/Cargo.toml"
               - Cargo.lock
               - rust-toolchain.toml


### PR DESCRIPTION
`publish-js` and `publish-to-cargo` each ran on every event, holding `id-token: write` throughout, and named the `release` environment only when `github.event_name == 'release'`. On every other event they minted an OIDC token from a run nothing gates.

That token is accepted by a registry whose trusted-publisher config doesn't pin an environment — the claims it checks are the repository and the workflow filename, both of which an ungated run satisfies. `release.yaml` accepts `workflow_dispatch`, so an account with write access can dispatch a branch carrying its own copy of this file and publish with it. The environment is the only part of the run it can't fake, which is why the credential has to live inside one.

So each pair is now two jobs:

- `publish-js` / `publish-to-cargo` — `if: github.event_name == 'release'`, `environment: release`, and the OIDC permission.
- `test-publish-js` / `test-publish-to-cargo` — the smoke tests `nightly.yaml` runs on PRs, with no `id-token: write` at all.

The js build steps move into `.github/actions/build-js` rather than being duplicated across the two jobs, following `build-prqlc` and `build-python`. The `nightly` path filter in `tests.yaml` gains `.github/actions/build-*/**` to go with that: it watched `release.yaml` but nothing under `.github/actions/`, so a change to the extracted steps would no longer have triggered the smoke test that runs them. `build-prqlc` and `build-python` had the same gap.

Two consequences worth naming:

- The npm smoke test drops `--provenance`, which needs an OIDC token. It still checks that the package builds and that `npm publish` accepts it.
- A static `environment:` is also readable by tend, whose `credential-environments` check declines to judge a job whose environment is an expression. This takes prql from SKIP to PASS on it.

This only closes the hole if the registries pin the environment too, which is configured on their side: npm, crates.io and PyPI each have an optional environment field in the trusted publisher config, and a blank one accepts any run of this workflow.

> _This was written by Claude Code on behalf of max-sixty_
