### PR TITLE
ci: publish the release docs from the release run

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -46,11 +46,9 @@ jobs:
         with:
           prefix-key: ${{ env.version }}-${{ hashFiles('./Cargo.lock') }}
           shared-key: web
-          # A release builds on its tag, and a later `web` build starts from
-          # that cache.
           save-if:
             ${{ github.ref == 'refs/heads/web' || github.ref ==
-            'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+            'refs/heads/main' }}
           # Caching `~/.cargo/bin/` breaks the rustup `cargo`/`rustc` symlinks
           # on the new macos-15 runner image — see
           # https://github.com/Swatinem/rust-cache/issues/341.

--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -46,9 +46,11 @@ jobs:
         with:
           prefix-key: ${{ env.version }}-${{ hashFiles('./Cargo.lock') }}
           shared-key: web
+          # A release builds on its tag, and a later `web` build starts from
+          # that cache.
           save-if:
             ${{ github.ref == 'refs/heads/web' || github.ref ==
-            'refs/heads/main' }}
+            'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           # Caching `~/.cargo/bin/` breaks the rustup `cargo`/`rustc` symlinks
           # on the new macos-15 runner image — see
           # https://github.com/Swatinem/rust-cache/issues/341.

--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -1,11 +1,9 @@
 name: publish-web
 on:
-  # A release ends by pushing its docs to `web` with the bot's PAT, and a push
-  # made with a PAT does start workflows, so this covers releases too.
   push:
     branches:
       - web
-  # Called by pull-request when specifically requested
+  # Called by `release` on a release, and by `tests` on a `pr-publish-web` label
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -426,15 +426,25 @@ jobs:
   #         nexus_password: ${{ secrets.nexus_password }}
   #         directory: prql-java/java/
 
+  publish-web:
+    if: github.event_name == 'release'
+    uses: ./.github/workflows/publish-web.yaml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+  # `web` tracks the latest release, so doc-only fixes backport onto it. A push
+  # with the default token starts no workflow, so `publish-web` is the release's
+  # only publish.
   push-web-branch:
     runs-on: ubuntu-24.04
-    environment: release
     if: github.event_name == 'release'
+    permissions:
+      contents: write
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v7
-        with:
-          token: ${{ secrets.TEND_BOT_TOKEN }}
       - run: git push origin HEAD:web --force
 
   push-devcontainer:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -347,6 +347,10 @@ jobs:
   publish-web:
     uses: ./.github/workflows/publish-web.yaml
     if: contains(github.event.pull_request.labels.*.name, 'pr-publish-web')
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
   nightly:
     needs: rules

--- a/web/book/src/project/contributing/development.md
+++ b/web/book/src/project/contributing/development.md
@@ -410,8 +410,8 @@ the confidence to make changes faster, please raise an issue.
 
 ## Website
 
-The website is published together with the book and the playground, and is
-automatically built and released on any push to the `web` branch.
+The website is published together with the book and the playground, from a
+release's tag and from any later push to the `web` branch.
 
 The `web` branch points to the latest release plus any website-specific fixes.
 That way, the compiler behavior in the playground matches the latest release
@@ -498,9 +498,11 @@ Currently we release in a semi-automated way:
    )"
    ```
 
-4. From there, both the tag and release is created and all packages are
-   published automatically based on our
-   [release workflow](https://github.com/PRQL/prql/blob/main/.github/workflows/release.yaml).
+4. From there the tag and release are created, and the
+   [release workflow](https://github.com/PRQL/prql/blob/main/.github/workflows/release.yaml)
+   publishes the packages and the website. Its publishing jobs sit behind the
+   `release` and `github-pages` environments, so approve the pending deployments
+   on the run's page.
 
 5. Run
    `cargo release patch --no-publish --no-push --execute --no-verify --no-confirm --no-tag && task prqlc:test-all && cargo insta test --accept -p mdbook-prql`


### PR DESCRIPTION
`release.yaml` reached the docs publish indirectly: `push-web-branch` force-pushed the release commit to `web` with the bot's PAT, purely so that push would start `publish-web.yaml`. Both hops sit behind a required reviewer, so the docs took two approvals in two separate runs to go out.

`release.yaml` now calls `publish-web.yaml` directly and builds from the release tag, which holds the same tree `web` was carrying. `push-web-branch` still moves `web`, since that's the base doc-only fixes backport onto, but with the default token: it needs no environment, and its push starts no second publish. So the docs path goes from two gated jobs across two runs to one gated job in the release run.

The remaining gate on `github-pages` can't be removed while the release event is the trigger: `tend` treats `on: release` as bot-steerable, so a deployment-branch policy can never gate an environment the release reaches, and `actions/deploy-pages` requires both `id-token: write` and the `github-pages` environment.

One smaller piece rides along: a callee can't request a scope its caller lacks, so both call sites of `publish-web.yaml` now grant the `pages` and `id-token` scopes `actions/deploy-pages` needs — `tests.yaml`'s `pr-publish-web` path was missing them too.

One consequence worth naming. The release's web build now runs on a tag rather than on `web`, and cache scoping lets a `web` run restore only `web`'s own caches and `main`'s. `main`'s version has bumped by the time a backport lands, so its key no longer matches, which makes the first `web` build after a release a cold one. Backports are rare enough — the last was October 2024 — that this looked cheaper than the alternatives.

Nothing on the release path can be exercised without cutting a release. If `publish-web` ever fails in a release run, re-running that job or dispatching `publish-web` on the tag recovers it.

> _This was written by Claude Code on behalf of max-sixty_
