### PR TITLE
chore: add frontmatter to the running-tend skill

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: running-tend
+description:
+  PRQL-specific guidance for tend CI workflows. Adds PR title conventions, CI
+  structure, Dependabot-batch polling, weekly maintenance tasks, and
+  issue-closing policy on top of the generic tend-* skills. Use when operating
+  in CI.
+---
+
 # Running Tend in PRQL
 
 Tend-specific guidance for this repo. Project build commands, test strategy,

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: running-tend
 description:
-  PRQL-specific guidance for tend CI workflows. Adds PR title conventions, CI
-  structure, Dependabot-batch polling, weekly maintenance tasks, and
-  issue-closing policy on top of the generic tend-* skills. Use when operating
-  in CI.
+  PRQL-specific guidance for tend CI workflows. Adds a standing exception for
+  filing issues in other repos, PR title conventions, CI structure,
+  Dependabot-batch polling, weekly maintenance tasks, and issue-closing policy
+  on top of the generic tend-* skills. Use when operating in CI.
 ---
 
 # Running Tend in PRQL


### PR DESCRIPTION
`.claude/skills/running-tend/SKILL.md` had no YAML frontmatter. Claude Code discovers the file anyway, but falls back to the directory name and the file's first heading, so a CI session saw it listed as `running-tend: Running Tend in PRQL`. The overlay still got loaded — the bundled `running-in-ci` skill tells the bot to load `running-tend` whenever it appears in the skill list — but an agent judges relevance from that line, and an H1 says nothing about what the file contains.

The frontmatter names the skill and describes what this overlay carries: the standing exception for filing issues in other repos, PR title conventions, CI structure, the Dependabot-batch polling rule, weekly maintenance, and the issue-closing policy. The guidance itself is unchanged, and the frontmatter matches what tend's installer now stamps for new overlays.

Checked on Claude Code 2.1.235 (tend's action pins 2.1.233) by listing the available skills in a checkout with and without the change.

> _This was written by Claude Code on behalf of max-sixty_
